### PR TITLE
feat(tests): add parseOobNotes test for locally spent notes

### DIFF
--- a/.changeset/clean-notes-parse.md
+++ b/.changeset/clean-notes-parse.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core': patch
+---
+
+Normalize parsed OOB note federation ID prefixes to the documented hexadecimal string format.

--- a/packages/core/src/WalletDirector.ts
+++ b/packages/core/src/WalletDirector.ts
@@ -6,8 +6,38 @@ import {
   ParsedBolt11Invoice,
   PreviewFederation,
   ParsedNoteDetails,
+  JSONValue,
 } from '@fedimint/types'
 import { FedimintWallet } from './FedimintWallet'
+
+type RpcParsedNoteDetails = Omit<ParsedNoteDetails, 'federation_id_prefix'> & {
+  federation_id_prefix: JSONValue
+}
+
+function isByte(value: JSONValue): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= 255
+  )
+}
+
+function isFourByteArray(
+  value: JSONValue,
+): value is [number, number, number, number] {
+  return Array.isArray(value) && value.length === 4 && value.every(isByte)
+}
+
+function federationIdPrefixToHex(prefix: JSONValue): string {
+  if (!isFourByteArray(prefix)) {
+    throw new Error(
+      'Invalid parse_oob_notes response: federation_id_prefix must contain four bytes',
+    )
+  }
+
+  return prefix.map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
 
 export class WalletDirector {
   // Protected to allow for TestWalletDirector to access the client
@@ -209,11 +239,16 @@ export class WalletDirector {
    */
   async parseOobNotes(notes: string): Promise<ParsedNoteDetails> {
     await this._client.initialize()
-    const response = await this._client.sendSingleMessage<ParsedNoteDetails>(
+    const response = await this._client.sendSingleMessage<RpcParsedNoteDetails>(
       'parse_oob_notes',
       { oob_notes: notes },
     )
-    return response
+    return {
+      ...response,
+      federation_id_prefix: federationIdPrefixToHex(
+        response.federation_id_prefix,
+      ),
+    }
   }
 
   /**

--- a/packages/integration-tests/src/FedimintWallet.test.ts
+++ b/packages/integration-tests/src/FedimintWallet.test.ts
@@ -3,6 +3,21 @@ import { FedimintWallet } from '@fedimint/core/testing'
 import { expect, vi } from 'vitest'
 import { walletTest } from './test/fixtures'
 
+function sumNoteCounts(noteCounts: Record<string, number>) {
+  return Object.entries(noteCounts).reduce((sum, [denomination, count]) => {
+    return sum + Number(denomination) * count
+  }, 0)
+}
+
+function federationIdPrefixBytes(federationId: string) {
+  return (
+    federationId
+      .slice(0, 8)
+      .match(/.{1,2}/g)
+      ?.map((byte) => Number.parseInt(byte, 16)) ?? []
+  )
+}
+
 walletTest('get invite code from devimint', async ({ wallet }) => {
   expect(wallet).toBeDefined()
   const inviteCode = await wallet.testing.getInviteCode()
@@ -116,3 +131,33 @@ walletTest('previewFederation', async ({ walletDirector, unopenedWallet }) => {
     federation_id: expect.any(String),
   })
 })
+
+walletTest(
+  'parseOobNotes should parse locally spent notes via wasm',
+  async ({ walletDirector, fundedWallet }) => {
+    expect(fundedWallet).toBeDefined()
+    expect(fundedWallet.isOpen()).toBe(true)
+
+    const spendAmount = 4096
+    const federationId = await fundedWallet.federation.getFederationId()
+    const inviteCode = await fundedWallet.federation.getInviteCode(0)
+
+    if (!inviteCode) {
+      throw new Error('Expected federation invite code to be available')
+    }
+
+    const { operation_id: spendOperationId, notes } =
+      await fundedWallet.mint.spendNotes(spendAmount, 3600, true)
+    expect(spendOperationId).toBeTypeOf('string')
+
+    const parsed = await walletDirector.parseOobNotes(notes)
+    expect(parsed).toMatchObject({
+      total_amount: spendAmount,
+      federation_id_prefix: federationIdPrefixBytes(federationId),
+      federation_id: federationId,
+      invite_code: inviteCode,
+    })
+    expect(sumNoteCounts(parsed.note_counts)).toEqual(spendAmount)
+  },
+  30000,
+)

--- a/packages/integration-tests/src/FedimintWallet.test.ts
+++ b/packages/integration-tests/src/FedimintWallet.test.ts
@@ -1,4 +1,4 @@
-import { TransportClient } from '@fedimint/core'
+import { TransportClient, WalletDirector, type Transport } from '@fedimint/core'
 import { FedimintWallet } from '@fedimint/core/testing'
 import { expect, vi } from 'vitest'
 import { walletTest } from './test/fixtures'
@@ -9,13 +9,32 @@ function sumNoteCounts(noteCounts: Record<string, number>) {
   }, 0)
 }
 
-function federationIdPrefixBytes(federationId: string) {
-  return (
-    federationId
-      .slice(0, 8)
-      .match(/.{1,2}/g)
-      ?.map((byte) => Number.parseInt(byte, 16)) ?? []
-  )
+class StaticResponseTransport {
+  logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+
+  private messageHandler: Parameters<Transport['setMessageHandler']>[0] =
+    () => {}
+
+  constructor(private readonly response: unknown) {}
+
+  setMessageHandler(handler: Parameters<Transport['setMessageHandler']>[0]) {
+    this.messageHandler = handler
+  }
+
+  setErrorHandler() {}
+
+  postMessage(message: Parameters<Transport['postMessage']>[0]) {
+    this.messageHandler({
+      type: 'data',
+      request_id: message.requestId,
+      data: message.type === 'init' ? true : this.response,
+    })
+  }
 }
 
 walletTest('get invite code from devimint', async ({ wallet }) => {
@@ -153,11 +172,39 @@ walletTest(
     const parsed = await walletDirector.parseOobNotes(notes)
     expect(parsed).toMatchObject({
       total_amount: spendAmount,
-      federation_id_prefix: federationIdPrefixBytes(federationId),
+      federation_id_prefix: federationId.slice(0, 8),
       federation_id: federationId,
       invite_code: inviteCode,
     })
     expect(sumNoteCounts(parsed.note_counts)).toEqual(spendAmount)
   },
   30000,
+)
+
+walletTest.each([
+  { name: 'non-array values', prefix: '00010203' },
+  { name: 'too few bytes', prefix: [0, 1, 2] },
+  { name: 'too many bytes', prefix: [0, 1, 2, 3, 4] },
+  { name: 'negative bytes', prefix: [0, 1, 2, -1] },
+  { name: 'bytes above 255', prefix: [0, 1, 2, 256] },
+  { name: 'non-integer bytes', prefix: [0, 1, 2, 3.5] },
+])(
+  'parseOobNotes rejects malformed federation ID prefixes: $name',
+  async ({ prefix }) => {
+    const director = new WalletDirector(
+      new StaticResponseTransport({
+        total_amount: 1000,
+        federation_id_prefix: prefix,
+        federation_id: null,
+        invite_code: null,
+        note_counts: { '1000': 1 },
+      }) as unknown as Transport,
+      undefined,
+      true,
+    )
+
+    await expect(director.parseOobNotes('notes')).rejects.toThrow(
+      'Invalid parse_oob_notes response: federation_id_prefix must contain four bytes',
+    )
+  },
 )


### PR DESCRIPTION
This is a follow-up to add an integration test around parseOobNotes using real OOB notes from devimint.

It helps prevent future WASM updates from silently breaking the parse_oob_notes path.