### PR TITLE
chore: add dependabot configuration for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/docs'
+      - '/packages/*'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      npm:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Adding a dependabot.yml is recommended because some of our GitHub Actions are currently out of date and not being updated automatically. This PR sets that up so future dependency and Action updates are raised automatically.