### PR TITLE
docs: dev docs for react-native

### DIFF
--- a/docs/core/dev/contributing.md
+++ b/docs/core/dev/contributing.md
@@ -1,10 +1,3 @@
-<script setup>
-import packageJson from '../../../package.json'
-
-const nodeVersion = packageJson.engines.node
-const packageManager = packageJson.packageManager
-</script>
-
 # Contributing
 
 Thanks for your interest in contributing to the Fedimint Sdk! Please take a moment to review this document **before submitting a pull request.**
@@ -20,46 +13,28 @@ This guide is intended to help you get started with contributing. By following t
 
 :::
 
-## Dependency on Fedimint Client WASM
+## Development Workstreams
 
-To call Rust side functions, this SDK depends on a WASM binary built from the `fedimint-client-wasm` crate in the [Fedimint repository](https://github.com/fedimint/fedimint/tree/master/fedimint-client-wasm).
+This repository houses two distinctly architected SDKs designed for different environments. Because their underlying native components and build toolchains differ, their developer instructions and testing suites are separated:
 
-**Important:**
+1. **Web SDK**: Targets browsers and Node.js. Depends on a WASM compilation (`fedimint-client-wasm`) from the core Fedimint repo.
+2. **React Native SDK**: Targets mobile iOS & Android apps. Depends on the UniFFI bridge (`fedimint-client-uniffi`) located in the [fedimint-sdk-ffi repository](https://github.com/fedimint/fedimint-sdk-ffi).
 
-- This WASM binary is required for the SDK to function.
-- It is built using the source code from the `fedimint` repository, not this SDK repository.
-- The specific revision of the `fedimint` repository used is defined in `flake.nix`.
+---
 
-### Updating the WASM Binary
-
-If you have made changes to the Rust side (in the `fedimint` repo) and need to update the WASM binary used by this SDK:
-
-1. Update the `fedimint-wasm` input in [flake.nix](https://github.com/fedimint/fedimint-sdk/blob/main/flake.nix) (around line 9) to point to the new commit/revision.
-2. Build the WASM binary (see instructions below).
-
-## Set up Nix
+## 1. Set up Nix
 
 Fedimint uses Nix for managing the development environment. It is **highly recommended** to use Nix to ensure you have the correct tools and versions.
 
 For detailed instructions on setting up Nix, see [Nix Setup](./nix_setup.md).
 
-Once Nix is installed, enter the development shell:
+Once Nix is installed, you can enter the development shell for standard web/JS operations:
 
 ```bash
 nix develop
 ```
 
-## Building the WASM Binary
-
-After setting up Nix and entering the shell, you must build the WASM binary:
-
-```bash
-pnpm build:wasm
-```
-
-This command will build the `fedimint-client-wasm` crate and place the resulting binary in the `packages/wasm-bundler` folder.
-
-## 1. Cloning the repository
+## 2. Cloning the repository
 
 To start contributing to the project, clone it to your local machine using git:
 
@@ -73,25 +48,9 @@ Or the [GitHub CLI](https://cli.github.com):
 gh repo clone fedimint/fedimint-sdk
 ```
 
-## 2. Installing Node.js and pnpm
-
-Fedimint Sdk uses Node.js with [pnpm workspaces](https://pnpm.io/workspaces) to manage multiple projects. You can run the following command in your terminal to check your local Node.js version.
-
-```bash
-node -v
-```
-
-If **`node@{{nodeVersion}}`** is not installed, you can install via [fnm](https://github.com/Schniz/fnm) (recommended) or from the [official website](https://nodejs.org).
-
-Once Node.js is installed, run the following to install [Corepack](https://nodejs.org/api/corepack.html). Corepack automatically installs and manages **`{{packageManager}}`**.
-
-```bash
-corepack enable
-```
-
 ## 3. Installing dependencies
 
-Once in the project's root directory, run the following command to install pnpm (via Corepack) and the project's dependencies:
+Once in the project's root directory, run the following command to install pnpm and the project's dependencies (assuming you are inside the `nix develop` shell which provides them):
 
 ```bash
 pnpm install
@@ -99,78 +58,18 @@ pnpm install
 
 After the install completes, pnpm links packages across the project for development and [git hooks](https://github.com/toplenboren/simple-git-hooks) are set up.
 
-## 4. Running the dev playgrounds
+## 4. Development Guides
 
-To start the local development playgrounds, run one of the following commands. These commands run playground apps, located at `./playgrounds`, that are set up for trying out code while making changes.
+The setup process, commands, and architecture drastically differ depending on which part of the SDK you are contributing to. **Before building**, select the relevant platform below:
 
-```bash
-pnpm dev              # aliased to `pnpm dev:core`
-pnpm dev:core         # `@fedimint/core` + Vite + React app
-pnpm dev:next         # `@fedimint/core` + Next.js app
-# pnpm dev:react      # TBD
-pnpm dev:bare         # HTML + VanillaJS app (no framework)
-```
+1. **[Web SDK Development](./web.md)** - Guide for working on strictly browser, Node.js packages, and `fedimint-client-wasm` integrations.
+2. **[React Native SDK Development](./react-native.md)** - Guide for working on native iOS/Android wrappers and `fedimint-client-uniffi` integrations using `just`.
 
-Once a playground dev server is running, you can make changes to any of the package source files (e.g. `packages/react`) and it will automatically update the playground.
+## 5. Next Steps
 
-## 5. Running the test suite
+Once you have your environment set up and your dependencies installed, please review the following workflows before submitting changes:
 
-Fedimint web SDK uses [Vitest](https://vitest.dev) to run tests.
-See the [testing docs](/core/dev/testing) for more information.
-
-## 6. Writing documentation
-
-Documentation is crucial to helping developers of all experience levels use Fedimint Sdk. We use [VitePress](https://vitepress.dev) for the documentation site (located at `./docs`). To start the site in dev mode, run:
-
-```bash
-pnpm docs:dev
-```
-
-Try to keep documentation brief and use plain language so folks of all experience levels can understand. If you think something is unclear or could be explained better, you are welcome to open a pull request.
-
-## 7. Submitting a pull request
-
-When you're ready to submit a pull request, you can follow these naming conventions:
-
-- Pull request titles use the [Imperative Mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., `Add something`, `Fix something`).
-- [Changesets](#versioning) use past tense verbs (e.g., `Added something`, `Fixed something`).
-
-When you submit a pull request, GitHub will automatically lint, build, and test your changes. If you see an ❌, it's most likely a bug in your code. Please, inspect the logs through the GitHub UI to find the cause.
-
-**Please make sure that "Allow edits from maintainers" is enabled so the core team can make updates to your pull request if necessary.**
-
-## 8. Versioning
-
-When adding new features or fixing bugs, we'll need to bump the package versions. We use [Changesets](https://github.com/changesets/changesets) to do this.
-
-::: tip
-Only changes to the codebase that affect the public API or existing behavior (e.g. bugs) need changesets.
-:::
-
-Each changeset defines which packages should be published and whether the change should be a major/minor/patch release, as well as providing release notes that will be added to the changelog upon release.
-
-To create a new changeset, run `pnpm changeset`. This will run the Changesets CLI, prompting you for details about the change. You’ll be able to edit the file after it’s created — don’t worry about getting everything perfect up front.
-
-Even though you can technically use any markdown formatting you like, headings should be avoided since each changeset will ultimately be nested within a bullet list. Instead, bold text should be used as section headings.
-
-If your PR is making changes to an area that already has a changeset (e.g. there’s an existing changeset covering theme API changes but you’re making further changes to the same API), you should update the existing changeset in your PR rather than creating a new one.
-
-### Releasing to npm
-
-The first time a PR with a changeset is merged after a release, a new PR will automatically be created called `Version Packages`. Any subsequent PRs with changesets will automatically update this existing version packages PR. Merging this PR triggers the release process by publishing to npm and cleaning up the changeset files.
-
-### Creating a snapshot release
-
-If a PR has changesets, you can create a [snapshot release](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md) by [manually dispatching](https://github.com/fedimint/fedimint-sdk/actions/workflows/snapshot.yml) the Snapshot workflow. This publishes a tagged version to npm with the PR branch name and timestamp.
-
-## 9. Updating dependencies
-
-Use [Taze](https://github.com/antfu/taze) by running:
-
-```bash
-pnpm deps       # prints outdated deps
-pnpm deps patch # print outdated deps with new patch versions
-pnpm deps -w    # updates deps (best done with clean working tree)
-```
-
-<!-- [Socket](https://socket.dev) checks pull requests for vulnerabilities when new dependencies and versions are added, but you should also be vigilant! When updating dependencies, you should check release notes and source code as well as lock versions when possible. -->
+- **[Writing Documentation](./documentation.md)**: How to run the local VitePress documentation server.
+- **[Submitting a Pull Request](./pull-requests.md)**: Naming conventions and PR submission guidelines.
+- **[Versioning](./versioning.md)**: How to use Changesets to manage package version bumps and release notes.
+- **[Updating Dependencies](./dependencies.md)**: Keeping packages up-to-date using `taze`.

--- a/docs/core/dev/dependencies.md
+++ b/docs/core/dev/dependencies.md
@@ -1,0 +1,11 @@
+# Updating dependencies
+
+Use [Taze](https://github.com/antfu/taze) by running:
+
+```bash
+pnpm deps       # prints outdated deps
+pnpm deps patch # print outdated deps with new patch versions
+pnpm deps -w    # updates deps (best done with clean working tree)
+```
+
+<!-- [Socket](https://socket.dev) checks pull requests for vulnerabilities when new dependencies and versions are added, but you should also be vigilant! When updating dependencies, you should check release notes and source code as well as lock versions when possible. -->

--- a/docs/core/dev/documentation.md
+++ b/docs/core/dev/documentation.md
@@ -1,0 +1,9 @@
+# Writing documentation
+
+Documentation is crucial to helping developers of all experience levels use Fedimint Sdk. We use [VitePress](https://vitepress.dev) for the documentation site (located at `./docs`). To start the site in dev mode, run:
+
+```bash
+pnpm docs:dev
+```
+
+Try to keep documentation brief and use plain language so folks of all experience levels can understand. If you think something is unclear or could be explained better, you are welcome to open a pull request.

--- a/docs/core/dev/pull-requests.md
+++ b/docs/core/dev/pull-requests.md
@@ -1,0 +1,10 @@
+# Submitting a pull request
+
+When you're ready to submit a pull request, you can follow these naming conventions:
+
+- Pull request titles use the [Imperative Mood](https://en.wikipedia.org/wiki/Imperative_mood) (e.g., `Add something`, `Fix something`).
+- [Changesets](./versioning.md) use past tense verbs (e.g., `Added something`, `Fixed something`).
+
+When you submit a pull request, GitHub will automatically lint, build, and test your changes. If you see an ❌, it's most likely a bug in your code. Please, inspect the logs through the GitHub UI to find the cause.
+
+**Please make sure that "Allow edits from maintainers" is enabled so the core team can make updates to your pull request if necessary.**

--- a/docs/core/dev/react-native.md
+++ b/docs/core/dev/react-native.md
@@ -1,0 +1,118 @@
+# React Native Development
+
+This guide explains how to set up, develop, and build the React Native bindings and SDK for Fedimint.
+
+The React Native packages in this repository bridge the Rust-based `fedimint-client-uniffi` into a React Native environment using [UniFFI](https://mozilla.github.io/uniffi-rs/) and JSI.
+
+## Prerequisites
+
+### Supported Versions & Architectures
+
+The React Native SDK currently maintains compatibility with:
+
+- **React Native**: `>= 0.78.0`
+- **React**: `>= 18.0.0`
+
+**Supported Native Architectures:**
+
+- **Android** _(Min SDK 24 / Android 7.0)_:
+  - `arm64-v8a`: Physical Android devices
+  - `x86_64`: Android Emulators
+- **iOS** _(Deployment Target 15.0+)_:
+  - `aarch64-apple-ios` (`arm64`): Physical iOS devices
+  - `aarch64-apple-ios-sim` (`arm64` Simulator): Apple Silicon Simulators
+  - `x86_64-apple-ios` (`x86_64` Simulator): Intel Simulators
+
+### Environment Requirements
+
+Because React Native requires both Node.js tooling and native compilation (Rust, Android NDK, iOS Xcode toolchain), we heavily rely on **Nix** to provide reproducible environments.
+
+1. **Nix**: Ensure Nix is installed. Refer to the [Nix Setup](./nix_setup.md) guide.
+2. **Just**: We use `just` as a command runner to orchestrate the Nix shells and build commands. You can install it natively or rely on the Nix environment.
+3. **macOS**: _Required if you want to build the iOS bindings._
+
+## Building the Bindings
+
+The React Native build process requires the `fedimint-sdk-ffi` repository to be cloned alongside your `fedimint-sdk` directory. Our `just` commands will automatically clone this for you if it is missing.
+
+To execute a build, run the `just` commands from the root of the repository. These commands will automatically enter the strictly-defined Nix shells (`#android` or `#ios`) ensuring you use the precise Android NDK and iOS toolchains required.
+
+### Android
+
+We use Nix to handle the build environment and dependencies for our React Native (RN) bindings, replacing the standard in-shell cargo cross-compilation. This ensures a more reproducible and consistent build process.
+
+To build the Android bindings and compile the React Native TypeScript packages using `just`:
+
+```bash
+just build-android
+```
+
+This command produces **release** binaries under the hood.
+
+#### Advanced / Manual Build Commands
+
+If you are developing locally and want to invoke the underlying `pnpm` commands manually from the root or inside the `react-native-bindings` package, the following commands are available:
+
+Enter the Android Nix shell first to ensure the correct toolchain is available:
+
+```bash
+nix develop .#android
+```
+
+| Command                             | Description                                                                                                                                                                                                          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm run ubrn:android`             | Builds the standard/debug version of the Android React Native bindings natively via Cargo. Use this for standard local development and testing.                                                                      |
+| `pnpm run ubrn:android:release`     | Builds the release version of the Android React Native bindings natively via Cargo.                                                                                                                                  |
+| `pnpm run ubrn:nix:android:release` | **(Recommended)** Builds the release version of the Android React Native bindings using **Nix**. This provisions the correct toolchains automatically and builds via Nix instead of an in-shell cargo cross-compile. |
+
+> **Note:** If you are running into environment or toolchain issues with the standard commands, always prefer the `ubrn:nix:android:release` command (which is what `just build-android` uses) for a guaranteed reproducible build environment.
+
+### iOS
+
+_(macOS only)_
+
+We use Nix to handle the build environment and dependencies for the iOS bindings. This keeps the toolchain aligned with Xcode and avoids drift across machines.
+
+To build the iOS bindings (`.xcframework`) and compile the React Native TypeScript packages:
+
+```bash
+just build-ios
+```
+
+This command already produces **release** binaries under the hood.
+
+#### Advanced / Manual Build Commands
+
+If you want to run the underlying `pnpm` scripts directly, use these commands from the repo root or inside the `react-native-bindings` package:
+
+Enter the iOS Nix shell first to ensure the correct toolchain is available:
+
+```bash
+nix develop .#ios
+```
+
+| Command                         | Description                                                                                                                                                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm run ubrn:ios`             | Builds the standard/debug version of the iOS React Native bindings natively via Cargo.                                                                                                                           |
+| `pnpm run ubrn:ios:release`     | Builds the release version of the iOS React Native bindings natively via Cargo.                                                                                                                                  |
+| `pnpm run ubrn:nix:ios:release` | **(Recommended)** Builds the release version of the iOS React Native bindings using **Nix**. This provisions the correct toolchains automatically and builds via Nix instead of an in-shell cargo cross-compile. |
+
+> **Note:** If the standard iOS commands fail due to toolchain or environment issues, use `ubrn:nix:ios:release` (the same approach used by `just build-ios`) for a reproducible build.
+
+## What Happens Under the Hood?
+
+When you run `just build-android` (or the iOS equivalent), the following steps are orchestrated:
+
+1. **Clone FFI**: Checks for the existence of `fedimint-sdk-ffi` in the root and clones it if not found.
+2. **Install Dependencies**: Runs `pnpm install` inside the default Nix shell.
+3. **Build UniFFI Bindings**: Enters the target-specific Nix shell (e.g., `nix develop .#android`) and runs `pnpm run ubrn:nix:android:release` (or the iOS equivalent). This provisions the correct toolchains automatically and builds the native libraries (`jniLibs` or `xcframework`) via Nix instead of executing an in-shell cargo cross-compile.
+4. **Build React Native SDK**: Enters the Nix shell again to run `pnpm run build:reactnative`, which transpiles the TypeScript bridge code.
+
+## Testing Local Changes
+
+To see your local modifications to the React Native bindings in action, you can use the example applications provided in the repository. These applications are pre-configured to consume the locally built SDK packages:
+
+- **`examples/expo-app`**: An Expo-based React Native application.
+- **`examples/react-native`**: A bare React Native application.
+
+After running the `just build-*` commands, refer to the respective `README.md` files inside these example directories to start the development servers and run the apps on an emulator or physical device.

--- a/docs/core/dev/testing.md
+++ b/docs/core/dev/testing.md
@@ -1,8 +1,8 @@
-# Testing
+# Testing (Web SDK)
 
-We use [vitest](https://vitest.dev/) for testing library code.
+We use [vitest](https://vitest.dev/) for testing library code. Currently, **the tests do not cover the React Native SDK**.
 
-Configuring this properly was tricky. Since the library heavily relies on browser APIs like web workers & wasm, it doesn't really make sense to mock the browser APIs for unit tests.
+Configuring this properly was tricky. Since the Web SDK heavily relies on browser APIs like web workers & wasm, it doesn't really make sense to mock the browser APIs for unit tests.
 In order for our tests to be trustworthy, we really need them to run in a realistic browser environment.
 
 Vitest [browser mode](https://vitest.dev/guide/browser/) + playwright (provider) seems to satisfy all our needs. It spins up a real browser to run tests and can run headlessly for CI. I had to add one hack to make it work with the web-worker, but otherwise it seems to work well out of the box.
@@ -11,11 +11,11 @@ This framework should be suitable for all the additional libraries we have plann
 
 ## Nix
 
-The Fedimint Sdk depends on several external pieces of infrastructure. In order to run high-fidelity tests, we utilize a tool from the [fedimint](https://github.com/fedimint/fedimint) repo called [Devimint](https://github.com/fedimint/fedimint/tree/master/devimint). Devimint includes several pieces of infrastructure for running a local testing environment for fedimint applications including a bitcoind node (regtest), multiple guardian servers (fedimintd), multiple lightning gateways (lnd, cln, ldk), and a faucet for minting tokens.
+The Fedimint Web SDK depends on several external pieces of infrastructure. In order to run high-fidelity tests, we utilize a tool from the [fedimint](https://github.com/fedimint/fedimint) repo called [Devimint](https://github.com/fedimint/fedimint/tree/master/devimint). Devimint includes several pieces of infrastructure for running a local testing environment for fedimint applications including a bitcoind node (regtest), multiple guardian servers (fedimintd), multiple lightning gateways (lnd, cln, ldk), and a faucet for minting tokens.
 
 ::: warning Note
 
-Nix is NOT required to build or use the Fedimint Sdk. It is ONLY required to run the tests.
+Nix is required to build the wasm and run the tests.
 
 :::
 
@@ -29,11 +29,7 @@ To setup nix, use the [Determinate Nix Installer](https://github.com/Determinate
 nix (Nix) 2.9.1
 ```
 
-Next, [install direnv](https://direnv.net/docs/installation.html) and run the following command to initialize direnv in your shell:
-
-```sh
-direnv allow
-```
+Next, install [just](https://just.systems/man/en/chapter_1.html), a command runner we use to run tests in the Nix environment.
 
 ::: tip
 This takes a really long time to run for the first time. All future runs will be relatively quick.
@@ -43,11 +39,11 @@ This takes a really long time to run for the first time. All future runs will be
 
 ```bash
 # in the root of the repo
-pnpm run test
+just test
 ```
 
-- `pnpm test` — runs tests in a headless browser
-- `pnpm test:cov` — runs tests and reports coverage
-- `pnpm test:ui` — runs tests in the [Vitest UI](https://vitest.dev/guide/ui.html)
+- `just test` — runs tests in a headless browser
+- `just test-coverage` — runs tests and reports coverage
+- `just test-ui` — runs tests in the [Vitest UI](https://vitest.dev/guide/ui.html)
 
 When adding new features or fixing bugs, it's important to add test cases to cover the new or updated behavior.

--- a/docs/core/dev/versioning.md
+++ b/docs/core/dev/versioning.md
@@ -1,0 +1,23 @@
+# Versioning
+
+When adding new features or fixing bugs, we'll need to bump the package versions. We use [Changesets](https://github.com/changesets/changesets) to do this.
+
+::: tip
+Only changes to the codebase that affect the public API or existing behavior (e.g. bugs) need changesets.
+:::
+
+Each changeset defines which packages should be published and whether the change should be a major/minor/patch release, as well as providing release notes that will be added to the changelog upon release.
+
+To create a new changeset, run `pnpm changeset`. This will run the Changesets CLI, prompting you for details about the change. You’ll be able to edit the file after it’s created — don’t worry about getting everything perfect up front.
+
+Even though you can technically use any markdown formatting you like, headings should be avoided since each changeset will ultimately be nested within a bullet list. Instead, bold text should be used as section headings.
+
+If your PR is making changes to an area that already has a changeset (e.g. there’s an existing changeset covering theme API changes but you’re making further changes to the same API), you should update the existing changeset in your PR rather than creating a new one.
+
+## Releasing to npm
+
+The first time a PR with a changeset is merged after a release, a new PR will automatically be created called `Version Packages`. Any subsequent PRs with changesets will automatically update this existing version packages PR. Merging this PR triggers the release process by publishing to npm and cleaning up the changeset files.
+
+## Creating a snapshot release
+
+If a PR has changesets, you can create a [snapshot release](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md) by [manually dispatching](https://github.com/fedimint/fedimint-sdk/actions/workflows/snapshot.yml) the Snapshot workflow. This publishes a tagged version to npm with the PR branch name and timestamp.

--- a/docs/core/dev/web.md
+++ b/docs/core/dev/web.md
@@ -1,0 +1,74 @@
+# Web SDK Development
+
+This guide explains how to set up, develop, and build the Web SDK for Fedimint.
+
+The Web SDK packages in this repository bridge the Rust-based `fedimint-client-wasm` crate into browser and Node.js environments.
+
+## Dependency on Fedimint Client WASM
+
+**Important:**
+
+- The WASM binary is required for the Web SDK packages to function.
+- It is built using the source code from the `fedimint` repository, not this SDK repository.
+- The specific revision of the core `fedimint` repository used is defined as a flake input in `flake.nix`.
+
+### Updating the WASM Binary
+
+If you have made changes to the Rust side (in the `fedimint` repo) and need to update the WASM binary used by this SDK:
+
+1. Update the `fedimint-wasm` input in [flake.nix](https://github.com/fedimint/fedimint-sdk/blob/main/flake.nix) (around line 9) to point to the new commit/revision.
+2. Build the WASM binary (see instructions below).
+
+## Building the WASM Binary
+
+First, ensure you have entered the Nix development shell:
+
+```bash
+nix develop
+```
+
+Then, you must build the WASM binary:
+
+```bash
+pnpm build:wasm
+pnpm build
+```
+
+This command will build the `fedimint-client-wasm` crate and place the resulting binary in the `packages/wasm-bundler` folder. The subsequent command (`pnpm build`) is required to package the TypeScript wrapper libraries for consumption.
+
+## Running the dev playgrounds
+
+To start the local development playgrounds, run one of the following commands. These commands run playground apps, located at `./examples`, that are set up for trying out code while making changes.
+
+**Important Note for Local Examples:**
+To ensure the examples load your local development changes instead of fetching from the published NPM registry, you must update the example's `package.json` to use local workspace paths. Change the Fedimint dependencies to `workspace:*`:
+
+```json
+{
+  "dependencies": {
+    "@fedimint/core": "workspace:*",
+    "@fedimint/transport-web": "workspace:*"
+  }
+}
+```
+
+After modifying the example's `package.json`, run `pnpm install` from the root of the repository to link the local workspaces.
+
+Then, you can start the playground dev servers:
+
+```bash
+pnpm dev              # aliased to `pnpm dev:core`
+pnpm dev:core         # `@fedimint/core` + Vite + React app
+pnpm dev:next         # `@fedimint/core` + Next.js app
+# pnpm dev:react      # TBD
+pnpm dev:bare         # HTML + VanillaJS app (no framework)
+```
+
+Once a playground dev server is running, you can make changes to any of the package source files (e.g. `packages/react`) and it will automatically update the playground.
+
+## Running the test suite
+
+The Fedimint Web SDK uses [Vitest](https://vitest.dev) to run tests.
+_Note: The React Native SDK is currently not covered by these tests._
+
+See the [testing docs](./testing.md) for more information.

--- a/examples/expo-app/README.md
+++ b/examples/expo-app/README.md
@@ -14,21 +14,21 @@ You must also build the local monorepo packages first, as this example depends o
 
 ## Getting Started
 
-From the root of the monorepo, you must first initialize the Rust FFI submodules. This pulls down the core Fedimint Rust code needed to compile the bindings:
+Because this example depends on the local workspace versions of the Fedimint React Native SDK and its native Rust bindings, you must build them first. This process requires `nix` and `just` (refer to the [SDK contributing guide](../../docs/core/dev/react-native.md)).
 
+From the root of the monorepo, build the native bindings for your target platform:
+
+For Android:
 ```sh
-git submodule update --init --recursive
+just build-android
 ```
 
-Then, ensure all dependencies are installed and the native bindings are built:
-
+For iOS (macOS only):
 ```sh
-pnpm install
-nix develop .#android -c pnpm ubrn:android
-nix develop .#ios -c pnpm ubrn:ios
-pnpm build:reactnative
-pnpm build
+just build-ios
 ```
+
+These commands will automatically clone the required FFI repositories, configure the Nix environment, compile the Rust libraries, and build the TypeScript packages across the workspace.
 
 Then, navigate to this example directory:
 
@@ -38,7 +38,7 @@ cd examples/expo-app
 
 ### Running on iOS
 
-First, install the CocoaPods dependencies. Since this app uses local paths to reference the React Native bindings, you must run pod install *after* the `pnpm build` step at the monorepo root.
+First, install the CocoaPods dependencies. Since this app uses local paths to reference the React Native bindings, you must run pod install *after* the `just build-ios` step at the monorepo root.
 
 ```sh
 cd ios

--- a/examples/react-native/README.md
+++ b/examples/react-native/README.md
@@ -14,21 +14,21 @@ You must also build the local monorepo packages first, as this example depends o
 
 ## Getting Started
 
-From the root of the monorepo, you must first initialize the Rust FFI submodules. This pulls down the core Fedimint Rust code needed to compile the bindings:
+Because this example depends on the local workspace versions of the Fedimint React Native SDK and its native Rust bindings, you must build them first. This process requires `nix` and `just` (refer to the [SDK contributing guide](../../docs/core/dev/react-native.md)).
 
+From the root of the monorepo, build the native bindings for your target platform:
+
+For Android:
 ```sh
-git submodule update --init --recursive
+just build-android
 ```
 
-Then, ensure all dependencies are installed and the native bindings are built:
-
+For iOS (macOS only):
 ```sh
-pnpm install
-nix develop .#android -c pnpm ubrn:android
-nix develop .#ios -c pnpm ubrn:ios
-pnpm build:reactnative
-pnpm build
+just build-ios
 ```
+
+These commands will automatically clone the required FFI repositories, configure the Nix environment, compile the Rust libraries, and build the TypeScript packages across the workspace.
 
 Then, navigate to this example directory:
 
@@ -38,7 +38,7 @@ cd examples/react-native
 
 ### Running on iOS
 
-First, install the CocoaPods dependencies. Since this app uses local paths to reference the React Native bindings, you must run pod install *after* the `pnpm build` step at the monorepo root.
+First, install the CocoaPods dependencies. Since this app uses local paths to reference the React Native bindings, you must run pod install *after* the `just build-ios` step at the monorepo root.
 
 ```sh
 cd ios


### PR DESCRIPTION
**Changes**
- New RN dev guide with Nix/just build flow, manual `pnpm` commands, and shell entry points in react-native.md.
- Reframe contributing to point developers to Web vs React Native guides in contributing.md.
- Update RN example setup steps to use `just build-android` / `just build-ios` and reference the RN guide in README.md and README.md.
- Document Web SDK testing and supporting contributor workflows in testing.md, web.md, documentation.md, pull-requests.md, versioning.md, and dependencies.md.
