### PR TITLE
Fix: Map swallowed SDK string errors to user friendly UI messages in Vite demo (`MnemonicManager`)

### DIFF
--- a/js/examples/vite-core/src/App.tsx
+++ b/js/examples/vite-core/src/App.tsx
@@ -107,41 +107,21 @@ const MnemonicManager = () => {
 
   const clearMessage = () => setMessage(undefined)
 
-  const mapTechnicalErrorToFriendly = (rawError: string): string => {
-    const lowerError = rawError.toLowerCase()
-    
-    if (lowerError.includes('mnemonic already exists')) {
-      return 'You already have a wallet set up.'
-    }
-    if (lowerError.includes('invalid checksum')) {
-      return 'The recovery phrase you entered is invalid. Please double-check your spelling.'
-    }
-    if (lowerError.includes('invalid word count')) {
-      return 'Recovery phrases must be exactly 12 or 24 words long.'
-    }
-    if (lowerError.includes('contains an unknown word')) {
-      return 'The recovery phrase contains an unknown word. Please check your spelling.'
-    }
-    
-    // Fallback for unknown strings
-    return 'Operation failed'
-  }
-
-  // Helper function to extract user-friendly error messages
+  // Helper function to extract error messages directly
   const extractErrorMessage = (error: any): string => {
     let errorMsg = 'Operation failed'
 
     if (typeof error === 'string') {
-      errorMsg = mapTechnicalErrorToFriendly(error)
+      errorMsg = error
     } else if (error instanceof Error) {
-      errorMsg = mapTechnicalErrorToFriendly(error.message)
+      errorMsg = error.message
     } else if (typeof error === 'object' && error !== null) {
       // Handle RPC error objects
       const rpcError = error as any
       if (rpcError.error) {
-        errorMsg = mapTechnicalErrorToFriendly(rpcError.error)
+        errorMsg = rpcError.error
       } else if (rpcError.message) {
-        errorMsg = mapTechnicalErrorToFriendly(rpcError.message)
+        errorMsg = rpcError.message
       }
     }
 
@@ -449,7 +429,7 @@ const JoinFederation = ({
               <summary>Guardian Endpoints</summary>
               <div className="guardian-list">
                 {Object.entries(previewData.config.global.api_endpoints).map(
-                  ([id, peer]) => (
+                  ([id, peer]: [string, any]) => (
                     <div key={id} className="guardian-item">
                       <div>
                         <strong>{peer.name}</strong>
@@ -465,7 +445,7 @@ const JoinFederation = ({
               <summary>Module Configuration</summary>
               <div className="module-list">
                 {Object.entries(previewData.config.modules).map(
-                  ([id, module]) => (
+                  ([id, module]: [string, any]) => (
                     <div key={id} className="module-item">
                       <strong>{module.kind}</strong>
                     </div>

--- a/js/examples/vite-core/src/App.tsx
+++ b/js/examples/vite-core/src/App.tsx
@@ -119,9 +119,15 @@ const MnemonicManager = () => {
       // Handle RPC error objects
       const rpcError = error as any
       if (rpcError.error) {
-        errorMsg = rpcError.error
+        errorMsg =
+          typeof rpcError.error === 'string'
+            ? rpcError.error
+            : JSON.stringify(rpcError.error)
       } else if (rpcError.message) {
-        errorMsg = rpcError.message
+        errorMsg =
+          typeof rpcError.message === 'string'
+            ? rpcError.message
+            : JSON.stringify(rpcError.message)
       }
     }
 
@@ -428,29 +434,35 @@ const JoinFederation = ({
             <details className="preview-details">
               <summary>Guardian Endpoints</summary>
               <div className="guardian-list">
-                {Object.entries(previewData.config.global.api_endpoints).map(
-                  ([id, peer]: [string, any]) => (
-                    <div key={id} className="guardian-item">
-                      <div>
-                        <strong>{peer.name}</strong>
-                      </div>
-                      <div className="url">{peer.url}</div>
+                {(
+                  Object.entries(previewData.config.global.api_endpoints) as [
+                    string,
+                    { name: string; url: string },
+                  ][]
+                ).map(([id, peer]) => (
+                  <div key={id} className="guardian-item">
+                    <div>
+                      <strong>{peer.name}</strong>
                     </div>
-                  ),
-                )}
+                    <div className="url">{peer.url}</div>
+                  </div>
+                ))}
               </div>
             </details>
 
             <details className="preview-details">
               <summary>Module Configuration</summary>
               <div className="module-list">
-                {Object.entries(previewData.config.modules).map(
-                  ([id, module]: [string, any]) => (
-                    <div key={id} className="module-item">
-                      <strong>{module.kind}</strong>
-                    </div>
-                  ),
-                )}
+                {(
+                  Object.entries(previewData.config.modules) as [
+                    string,
+                    { kind: string },
+                  ][]
+                ).map(([id, module]) => (
+                  <div key={id} className="module-item">
+                    <strong>{module.kind}</strong>
+                  </div>
+                ))}
               </div>
             </details>
 

--- a/js/examples/vite-core/src/App.tsx
+++ b/js/examples/vite-core/src/App.tsx
@@ -107,19 +107,41 @@ const MnemonicManager = () => {
 
   const clearMessage = () => setMessage(undefined)
 
+  const mapTechnicalErrorToFriendly = (rawError: string): string => {
+    const lowerError = rawError.toLowerCase()
+    
+    if (lowerError.includes('mnemonic already exists')) {
+      return 'You already have a wallet set up.'
+    }
+    if (lowerError.includes('invalid checksum')) {
+      return 'The recovery phrase you entered is invalid. Please double-check your spelling.'
+    }
+    if (lowerError.includes('invalid word count')) {
+      return 'Recovery phrases must be exactly 12 or 24 words long.'
+    }
+    if (lowerError.includes('contains an unknown word')) {
+      return 'The recovery phrase contains an unknown word. Please check your spelling.'
+    }
+    
+    // Fallback for unknown strings
+    return 'Operation failed'
+  }
+
   // Helper function to extract user-friendly error messages
   const extractErrorMessage = (error: any): string => {
     let errorMsg = 'Operation failed'
 
-    if (error instanceof Error) {
-      errorMsg = error.message
+    if (typeof error === 'string') {
+      errorMsg = mapTechnicalErrorToFriendly(error)
+    } else if (error instanceof Error) {
+      errorMsg = mapTechnicalErrorToFriendly(error.message)
     } else if (typeof error === 'object' && error !== null) {
       // Handle RPC error objects
       const rpcError = error as any
       if (rpcError.error) {
-        errorMsg = rpcError.error
+        errorMsg = mapTechnicalErrorToFriendly(rpcError.error)
       } else if (rpcError.message) {
-        errorMsg = rpcError.message
+        errorMsg = mapTechnicalErrorToFriendly(rpcError.message)
       }
     }
 


### PR DESCRIPTION
### **Summary**
Fixes an issue in the `vite-core` example app where raw SDK string errors were being swallowed and surfaced to the user as generic `"Operation failed"` messages. 

**Closes #326**

### Implementation details
- Updated the `extractErrorMessage` helper inside the `MnemonicManager` component to properly intercept primitive string errors thrown by the WASM modules.
- Added a `mapTechnicalErrorToFriendly` dictionary to translate highly technical backend strings into clean, user friendly UI messages.