### PR TITLE
fix(tests): disable file parallelism in Playwright configuration

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
           browser: {
             enabled: true,
             provider: 'playwright',
+            fileParallelism: false,
             ui: false, // no ui for the core library
             api: {
               port: 63315,


### PR DESCRIPTION
Run browser integration test files sequentially to prevent resource contention between WASM workers, wallets, and the shared devimint federation. This should stabilize the flaky `generateAddress` test without masking it behind a longer timeout.

fixes https://github.com/fedimint/fedimint-sdk/issues/330