### PR TITLE
Reduce build downloads and keep the FFI cache warm

### DIFF
--- a/.changeset/quiet-transport-logs.md
+++ b/.changeset/quiet-transport-logs.md
@@ -1,0 +1,7 @@
+---
+'@fedimint/react-native': patch
+---
+
+Stop logging request and response payloads in `ReactNativeTransport`: they can carry secrets
+(mnemonic words, invite codes), which ended up in device logs. Only the message type and request
+id are logged now, at debug level, always through the injectable logger.

--- a/.github/actions/build-rn-android/action.yml
+++ b/.github/actions/build-rn-android/action.yml
@@ -15,6 +15,19 @@ runs:
       shell: bash
       run: nix develop --accept-flake-config -c just build-android
 
+    - name: Push FFI libs to Cachix
+      # The self-hosted runner keeps a persistent /nix/store, so cachix-action's
+      # post-run hook (which only pushes newly *built* paths) stops pushing once
+      # the store is warm and the cache entries can expire. Push the lib outputs
+      # explicitly so `just build-android` elsewhere substitutes them instead of
+      # cross-compiling the whole dependency tree from source.
+      shell: bash
+      continue-on-error: true
+      run: |
+        nix build --accept-flake-config --no-link --print-out-paths \
+          .#android-aarch64-linux-android .#android-x86_64-linux-android \
+          | cachix push fedimint
+
     - name: Compress Android binaries
       id: compress
       shell: bash

--- a/.github/actions/build-rn-android/action.yml
+++ b/.github/actions/build-rn-android/action.yml
@@ -20,12 +20,15 @@ runs:
       # post-run hook (which only pushes newly *built* paths) stops pushing once
       # the store is warm and the cache entries can expire. Push the lib outputs
       # explicitly so `just build-android` elsewhere substitutes them instead of
-      # cross-compiling the whole dependency tree from source.
+      # cross-compiling the whole dependency tree from source. The -deps
+      # derivations cover the other case: a source edit misses the lib cache
+      # but still substitutes the dependency build.
       shell: bash
       continue-on-error: true
       run: |
         nix build --accept-flake-config --no-link --print-out-paths \
           .#android-aarch64-linux-android .#android-x86_64-linux-android \
+          .#android-aarch64-linux-android-deps .#android-x86_64-linux-android-deps \
           | cachix push fedimint
 
     - name: Compress Android binaries

--- a/.github/actions/build-rn-ios/action.yml
+++ b/.github/actions/build-rn-ios/action.yml
@@ -39,7 +39,7 @@ runs:
       run: |
         installables=()
         for target in ${IOS_TARGETS:-aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios}; do
-          installables+=(".#ios-$target")
+          installables+=(".#ios-$target" ".#ios-$target-deps")
         done
         nix build --accept-flake-config --no-link --print-out-paths "${installables[@]}" \
           | cachix push fedimint

--- a/.github/actions/build-rn-ios/action.yml
+++ b/.github/actions/build-rn-ios/action.yml
@@ -27,6 +27,23 @@ runs:
         IOS_TARGETS: ${{ inputs.device-only == 'true' && 'aarch64-apple-ios' || '' }}
       run: nix develop --accept-flake-config -c just build-ios
 
+    - name: Push FFI libs to Cachix
+      # Same rationale as the Android action: cachix-action's post-run hook
+      # only pushes newly *built* paths, so already-realized libs never reach
+      # the cache. Push explicitly so local builds can substitute them. The
+      # fallback target list mirrors nix-prebuild.sh's default.
+      shell: bash
+      continue-on-error: true
+      env:
+        IOS_TARGETS: ${{ inputs.device-only == 'true' && 'aarch64-apple-ios' || '' }}
+      run: |
+        installables=()
+        for target in ${IOS_TARGETS:-aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios}; do
+          installables+=(".#ios-$target")
+        done
+        nix build --accept-flake-config --no-link --print-out-paths "${installables[@]}" \
+          | cachix push fedimint
+
     - name: Compress iOS binaries
       id: compress
       shell: bash

--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -26,6 +26,16 @@ runs:
       shell: bash
       run: nix build -L .#wasmBundle
 
+    - name: Push WASM bundle to Cachix
+      # cachix-action's post-run hook only pushes newly *built* paths, so on
+      # runners with a persistent /nix/store an already-realized wasmBundle is
+      # never (re-)pushed and its cache entry can expire. Push it explicitly.
+      shell: bash
+      continue-on-error: true
+      # `result` is the previous step's out-link; reusing it avoids paying a
+      # second evaluation of the fedimint-wasm flake just to push.
+      run: readlink -f result | cachix push fedimint
+
     - name: Copy WASM files
       shell: bash
       run: |

--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -1,6 +1,12 @@
 name: Build WASM
 description: Builds the WASM bundle using Nix
 
+inputs:
+  cachix_auth_token:
+    description: 'Cachix authentication token'
+    required: false
+    default: ''
+
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -14,6 +14,7 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
+    secrets: inherit
 
   build-rn-android:
     name: Build Android Bindings

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -2,6 +2,7 @@ name: Nix Native Builds
 
 on:
   push:
+    branches: [main]
     paths:
       - 'fedimint-client-uniffi/**'
       - 'nix/**'
@@ -16,10 +17,17 @@ on:
       - 'flake.lock'
       - '.github/workflows/nix-build.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   build-ios:
     name: Build iOS Artifacts
     runs-on: macos-latest
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -27,8 +35,13 @@ jobs:
         uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          # max-jobs/cores mirror the Justfile's build-ios: heavy native deps
+          # (rocksdb, aws-lc-sys) otherwise OOM macos-latest's small runners
+          # on cache-cold builds. Warm runs only substitute, so unaffected.
           extra_nix_config: |
             sandbox = relaxed
+            max-jobs = 1
+            cores = 1
 
       - name: Setup Cachix
         uses: cachix/cachix-action@18cf96c7c98e048e10a83abd92116114cd8504be # v14
@@ -51,6 +64,7 @@ jobs:
   build-android:
     name: Build Android Artifacts
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -10,6 +10,8 @@ on:
       - 'flake.lock'
       - '.github/workflows/nix-build.yml'
   pull_request:
+    # `labeled` so adding the `ci-ios` label starts the gated iOS build.
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'fedimint-client-uniffi/**'
       - 'nix/**'
@@ -28,6 +30,11 @@ jobs:
     name: Build iOS Artifacts
     runs-on: macos-latest
     timeout-minutes: 240
+    # macOS runners are the scarce and expensive lane, so PRs only build iOS
+    # when explicitly asked to via the `ci-ios` label (adding the label
+    # triggers a run through the `labeled` event). Pushes to main always
+    # build, so breakage is still caught before release.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ios')
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -63,7 +70,7 @@ jobs:
 
   build-android:
     name: Build Android Artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,3 +17,4 @@ jobs:
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml
+    secrets: inherit

--- a/.github/workflows/react-native-pr.yml
+++ b/.github/workflows/react-native-pr.yml
@@ -1,7 +1,24 @@
 name: React Native Verify
 
 on:
+  # On pushes to main everything builds, including iOS — the safety net for
+  # the label-gated PR builds below.
+  push:
+    branches: [main]
+    paths:
+      - 'packages/react-native/**'
+      - 'packages/react-native-bindings/**'
+      - 'packages/core/**'
+      - 'packages/types/**'
+      - 'fedimint-client-uniffi/**'
+      - 'nix/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'Justfile'
+      - '.github/**'
   pull_request:
+    # `labeled` so adding the `ci-ios` label starts the gated iOS build.
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'packages/react-native/**'
       - 'packages/react-native-bindings/**'
@@ -50,6 +67,10 @@ jobs:
     name: Build iOS
     runs-on: macos-latest
     timeout-minutes: 120
+    # macOS runners are the scarce and expensive lane, so PRs only build iOS
+    # when explicitly asked to via the `ci-ios` label. workflow_dispatch and
+    # other events still always build.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci-ios')
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-nix

--- a/.github/workflows/react-native-pr.yml
+++ b/.github/workflows/react-native-pr.yml
@@ -29,6 +29,11 @@ jobs:
       - uses: ./.github/actions/install-deps
       - name: Run transport unit tests
         run: pnpm test:reactnative
+      - name: Type-check transport against the stubbed bindings
+        # The package is excluded from the root typecheck because its real
+        # bindings types are ubrn-generated; this config maps them to the
+        # test stub so the type-level contract still gets checked.
+        run: pnpm --filter @fedimint/react-native typecheck:test
 
   build-android:
     name: Build Android

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -7,11 +7,18 @@ name: Rust Continuous Integration
 
 on:
   push:
+    branches: [main]
     paths:
       - 'fedimint-client-uniffi/**'
+      - '.github/workflows/rust-ci.yaml'
   pull_request:
     paths:
       - 'fedimint-client-uniffi/**'
+      - '.github/workflows/rust-ci.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 permissions: {}
 
@@ -19,6 +26,7 @@ jobs:
   test:
     name: 'Run tests'
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: fedimint-client-uniffi
@@ -32,16 +40,13 @@ jobs:
       - name: 'Set up Rust'
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: 'Build'
-        run: cargo build
-
       - name: 'Test'
-        run: CLASSPATH=./tests/jna/jna-5.14.0.jar cargo test --features uniffi/bindgen-tests
+        run: cargo test --locked
 
   check:
     name: 'Run clippy and fmt'
-    needs: test
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: fedimint-client-uniffi
@@ -56,7 +61,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: 'Check fmt'
-        run: cargo fmt --all -- --config format_code_in_doc_comments=true --check
+        run: cargo fmt --all -- --check
 
       - name: 'Check clippy'
-        run: cargo clippy --all-targets --features "uniffi/bindgen-tests"
+        run: cargo clippy --locked --all-targets

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,9 @@
 name: Verify
 on:
   workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
   workflow_dispatch:
 
 jobs:
@@ -71,6 +74,8 @@ jobs:
 
       - name: Build WASM
         uses: ./.github/actions/build-wasm
+        with:
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Run pnpm tests
         shell: bash

--- a/fedimint-client-uniffi/Cargo.toml
+++ b/fedimint-client-uniffi/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 authors = ["The Fedimint Developers"]
 description = "fedimint client for uniffi"
 readme = "README.md"
-repository = "https://github.com/fedimint/fedimint"
+repository = "https://github.com/fedimint/fedimint-sdk"
 
 [lib]
 crate-type = ["staticlib", "cdylib", "lib"]

--- a/fedimint-client-uniffi/Cargo.toml
+++ b/fedimint-client-uniffi/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.141"
 socket2 = { version = "0.5.7", features = ["all"] }
 thiserror = "2.0.12"
-tokio = "1.48.0"
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "fs"] }
 uniffi = { version = "0.29", features = ["cli"] }
 
 [build-dependencies]

--- a/fedimint-client-uniffi/build.rs
+++ b/fedimint-client-uniffi/build.rs
@@ -1,6 +1,11 @@
 fn main() {
     fedimint_build::set_code_version();
 
+    // set_code_version() emits a `cargo:rerun-if-env-changed` directive, which
+    // disables cargo's rerun-on-any-change default, so the stub needs its own
+    // rerun directive or edits to it are silently ignored by stale builds.
+    println!("cargo:rerun-if-changed=sdallocx_stub.c");
+
     // On Android, aws-lc declares `sdallocx` as a weak symbol and checks
     // `if (sdallocx)` before calling it. Android's linker resolves the GLOB_DAT
     // entry for weak undefined symbols to the PLT stub (non-NULL) while the

--- a/fedimint-client-uniffi/src/lib.rs
+++ b/fedimint-client-uniffi/src/lib.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use fedimint_client_rpc::{RpcGlobalState, RpcRequest, RpcResponse, RpcResponseHandler};
+use fedimint_client_rpc::{
+    RpcGlobalState, RpcRequest, RpcResponse, RpcResponseHandler, RpcResponseKind,
+};
 use fedimint_connectors::ConnectorRegistry;
 use fedimint_core::db::Database;
 
@@ -98,7 +100,23 @@ struct CallbackWrapper(Box<dyn RpcCallback>);
 
 impl RpcResponseHandler for CallbackWrapper {
     fn handle_response(&self, response: RpcResponse) {
-        let json = serde_json::to_string(&response).expect("Failed to serialize RPC response");
+        // With panic = "abort" in the release profile, panicking here would
+        // take down the whole host app, so degrade to an error response on
+        // the (currently impossible) serialization failure instead.
+        let json = serde_json::to_string(&response).unwrap_or_else(|e| {
+            let fallback = RpcResponse {
+                request_id: response.request_id,
+                kind: RpcResponseKind::Error {
+                    error: format!("Failed to serialize RPC response: {e}"),
+                },
+            };
+            serde_json::to_string(&fallback).unwrap_or_else(|_| {
+                format!(
+                    r#"{{"request_id":{},"type":"error","error":"unserializable RPC response"}}"#,
+                    response.request_id
+                )
+            })
+        });
         self.0.on_response(json);
     }
 }

--- a/fedimint-client-uniffi/uniffi-android.toml
+++ b/fedimint-client-uniffi/uniffi-android.toml
@@ -1,3 +1,11 @@
+# Android-specific overrides for Kotlin bindings generation. uniffi-bindgen
+# only auto-loads uniffi.toml, so this file has no effect unless a bindgen
+# invocation merges it in explicitly — nothing in this repo does (the
+# react-native bindings generate C++/TypeScript via ubrn, and the Kotlin
+# bindgen flow that concatenated this file with uniffi.toml — the
+# fedimint-sdk-ffi repo's scripts/generate-android-so.sh — has not been
+# ported here). Kept so that flow can be restored without re-deriving these
+# settings.
 [bindings.kotlin]
 android = true
 android_cleaner = true

--- a/flake.lock
+++ b/flake.lock
@@ -35,7 +35,30 @@
     "android-nixpkgs": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777582825,
+        "narHash": "sha256-EWfss3XWBfuvr5icPZJgkp9m7fOF1P1KhFCsECZ7IDU=",
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "a2b56f05390f7ad84c158eefd1877fbd9e4d2825",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "a2b56f05390f7ad84c158eefd1877fbd9e4d2825",
+        "type": "github"
+      }
+    },
+    "android-nixpkgs_2": {
+      "inputs": {
+        "devshell": "devshell_2",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "fedimint",
           "cargo-deluxe",
@@ -58,10 +81,10 @@
         "type": "github"
       }
     },
-    "android-nixpkgs_2": {
+    "android-nixpkgs_3": {
       "inputs": {
-        "devshell": "devshell_2",
-        "flake-utils": "flake-utils_6",
+        "devshell": "devshell_3",
+        "flake-utils": "flake-utils_7",
         "nixpkgs": [
           "fedimint",
           "flakebox",
@@ -83,60 +106,10 @@
         "type": "github"
       }
     },
-    "android-nixpkgs_3": {
-      "inputs": {
-        "devshell": "devshell_3",
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777582825,
-        "narHash": "sha256-EWfss3XWBfuvr5icPZJgkp9m7fOF1P1KhFCsECZ7IDU=",
-        "owner": "tadfisher",
-        "repo": "android-nixpkgs",
-        "rev": "a2b56f05390f7ad84c158eefd1877fbd9e4d2825",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tadfisher",
-        "repo": "android-nixpkgs",
-        "rev": "a2b56f05390f7ad84c158eefd1877fbd9e4d2825",
-        "type": "github"
-      }
-    },
     "android-nixpkgs_4": {
       "inputs": {
         "devshell": "devshell_4",
-        "flake-utils": [
-          "flakebox",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "flakebox",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762287806,
-        "narHash": "sha256-tmF7Fm2VNukLV32w60QiFLDJB4cO26lhKdDLR8k1BX0=",
-        "owner": "tadfisher",
-        "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tadfisher",
-        "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
-        "type": "github"
-      }
-    },
-    "android-nixpkgs_5": {
-      "inputs": {
-        "devshell": "devshell_5",
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_11",
         "nixpkgs": [
           "fedimint-wasm",
           "cargo-deluxe",
@@ -159,12 +132,39 @@
         "type": "github"
       }
     },
+    "android-nixpkgs_5": {
+      "inputs": {
+        "devshell": "devshell_5",
+        "flake-utils": "flake-utils_14",
+        "nixpkgs": [
+          "fedimint-wasm",
+          "flakebox",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762287806,
+        "narHash": "sha256-tmF7Fm2VNukLV32w60QiFLDJB4cO26lhKdDLR8k1BX0=",
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tadfisher",
+        "repo": "android-nixpkgs",
+        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "type": "github"
+      }
+    },
     "android-nixpkgs_6": {
       "inputs": {
         "devshell": "devshell_6",
-        "flake-utils": "flake-utils_16",
+        "flake-utils": [
+          "flakebox",
+          "flake-utils"
+        ],
         "nixpkgs": [
-          "fedimint-wasm",
           "flakebox",
           "nixpkgs"
         ]
@@ -209,7 +209,7 @@
       "inputs": {
         "nix-bundle": "nix-bundle_2",
         "nix-utils": "nix-utils_2",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1753802540,
@@ -228,7 +228,7 @@
     },
     "cargo-deluxe": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "flakebox": "flakebox",
         "nixpkgs": [
           "fedimint",
@@ -252,8 +252,8 @@
     },
     "cargo-deluxe_2": {
       "inputs": {
-        "flake-utils": "flake-utils_12",
-        "flakebox": "flakebox_4",
+        "flake-utils": "flake-utils_10",
+        "flakebox": "flakebox_3",
         "nixpkgs": [
           "fedimint-wasm",
           "nixpkgs"
@@ -345,22 +345,6 @@
       }
     },
     "crane_5": {
-      "locked": {
-        "lastModified": 1776394852,
-        "narHash": "sha256-K0i9GoNk2To1RQkW348EY4c7RYf3mD74hWlGSc/9sk0=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "db220b8709cea4bd43c9adcd4192f212fb6768d1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "ref": "v0.23.3",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_6": {
       "inputs": {
         "nixpkgs": [
           "fedimint-wasm",
@@ -384,7 +368,7 @@
         "type": "github"
       }
     },
-    "crane_7": {
+    "crane_6": {
       "locked": {
         "lastModified": 1771121070,
         "narHash": "sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI=",
@@ -396,6 +380,21 @@
       "original": {
         "owner": "ipetkov",
         "ref": "v0.23.1",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_7": {
+      "locked": {
+        "lastModified": 1755993354,
+        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
         "repo": "crane",
         "type": "github"
       }
@@ -417,68 +416,21 @@
     },
     "crane_9": {
       "locked": {
-        "lastModified": 1755993354,
-        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
+        "lastModified": 1776394852,
+        "narHash": "sha256-K0i9GoNk2To1RQkW348EY4c7RYf3mD74hWlGSc/9sk0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
+        "rev": "db220b8709cea4bd43c9adcd4192f212fb6768d1",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
+        "ref": "v0.23.3",
         "repo": "crane",
         "type": "github"
       }
     },
     "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "android-nixpkgs",
-          "nixpkgs"
-        ],
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1695195896,
-        "narHash": "sha256-pq9q7YsGXnQzJFkR5284TmxrLNFc0wo4NQ/a5E93CQU=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "05d40d17bf3459606316e3e9ec683b784ff28f16",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "devshell_2": {
-      "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "flakebox",
-          "android-nixpkgs",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "devshell_3": {
       "inputs": {
         "nixpkgs": [
           "android-nixpkgs",
@@ -499,9 +451,35 @@
         "type": "github"
       }
     },
-    "devshell_4": {
+    "devshell_2": {
       "inputs": {
         "nixpkgs": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "android-nixpkgs",
+          "nixpkgs"
+        ],
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1695195896,
+        "narHash": "sha256-pq9q7YsGXnQzJFkR5284TmxrLNFc0wo4NQ/a5E93CQU=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "05d40d17bf3459606316e3e9ec683b784ff28f16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_3": {
+      "inputs": {
+        "nixpkgs": [
+          "fedimint",
           "flakebox",
           "android-nixpkgs",
           "nixpkgs"
@@ -521,7 +499,7 @@
         "type": "github"
       }
     },
-    "devshell_5": {
+    "devshell_4": {
       "inputs": {
         "nixpkgs": [
           "fedimint-wasm",
@@ -530,7 +508,7 @@
           "android-nixpkgs",
           "nixpkgs"
         ],
-        "systems": "systems_14"
+        "systems": "systems_12"
       },
       "locked": {
         "lastModified": 1695195896,
@@ -546,10 +524,32 @@
         "type": "github"
       }
     },
-    "devshell_6": {
+    "devshell_5": {
       "inputs": {
         "nixpkgs": [
           "fedimint-wasm",
+          "flakebox",
+          "android-nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741473158,
+        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_6": {
+      "inputs": {
+        "nixpkgs": [
           "flakebox",
           "android-nixpkgs",
           "nixpkgs"
@@ -575,7 +575,7 @@
         "bundlers": "bundlers",
         "cargo-deluxe": "cargo-deluxe",
         "fenix": "fenix_2",
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_6",
         "flakebox": "flakebox_2",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -602,9 +602,9 @@
         "bundlers": "bundlers_2",
         "cargo-deluxe": "cargo-deluxe_2",
         "fenix": "fenix_4",
-        "flake-utils": "flake-utils_15",
-        "flakebox": "flakebox_5",
-        "nixpkgs": "nixpkgs_9",
+        "flake-utils": "flake-utils_13",
+        "flakebox": "flakebox_4",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "wild": "wild_4"
       },
@@ -734,30 +734,13 @@
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
+        "rev": "298b12d701ef0d12c0f2e4858d4208bee24d14e5",
         "type": "github"
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_10": {
       "inputs": {
-        "systems": [
-          "flakebox",
-          "systems"
-        ]
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -773,13 +756,16 @@
         "type": "github"
       }
     },
-    "flake-utils_11": {
+    "flake-utils_10": {
+      "inputs": {
+        "systems": "systems_11"
+      },
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -788,7 +774,7 @@
         "type": "github"
       }
     },
-    "flake-utils_12": {
+    "flake-utils_11": {
       "inputs": {
         "systems": "systems_13"
       },
@@ -806,25 +792,7 @@
         "type": "github"
       }
     },
-    "flake-utils_13": {
-      "inputs": {
-        "systems": "systems_15"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_14": {
+    "flake-utils_12": {
       "inputs": {
         "systems": [
           "fedimint-wasm",
@@ -847,9 +815,49 @@
         "type": "github"
       }
     },
+    "flake-utils_13": {
+      "inputs": {
+        "systems": "systems_15"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_14": {
+      "inputs": {
+        "systems": "systems_16"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_15": {
       "inputs": {
-        "systems": "systems_17"
+        "systems": [
+          "fedimint-wasm",
+          "flakebox",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -886,7 +894,6 @@
     "flake-utils_17": {
       "inputs": {
         "systems": [
-          "fedimint-wasm",
           "flakebox",
           "systems"
         ]
@@ -905,34 +912,13 @@
         "type": "github"
       }
     },
-    "flake-utils_18": {
-      "inputs": {
-        "systems": "systems_20"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -943,7 +929,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -961,12 +947,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "systems"
-        ]
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -984,14 +965,19 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": [
+          "fedimint",
+          "cargo-deluxe",
+          "flakebox",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -1020,6 +1006,24 @@
     },
     "flake-utils_7": {
       "inputs": {
+        "systems": "systems_8"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_8": {
+      "inputs": {
         "systems": [
           "fedimint",
           "flakebox",
@@ -1040,16 +1044,13 @@
         "type": "github"
       }
     },
-    "flake-utils_8": {
-      "inputs": {
-        "systems": "systems_9"
-      },
+    "flake-utils_9": {
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -1060,12 +1061,12 @@
     },
     "flakebox": {
       "inputs": {
-        "android-nixpkgs": "android-nixpkgs",
+        "android-nixpkgs": "android-nixpkgs_2",
         "crane": "crane",
         "fenix": "fenix",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": "nixpkgs_3",
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1728662483,
@@ -1083,18 +1084,18 @@
     },
     "flakebox_2": {
       "inputs": {
-        "android-nixpkgs": "android-nixpkgs_2",
+        "android-nixpkgs": "android-nixpkgs_3",
         "crane": "crane_2",
         "fenix": [
           "fedimint",
           "fenix"
         ],
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": [
           "fedimint",
           "nixpkgs"
         ],
-        "systems": "systems_8",
+        "systems": "systems_9",
         "wild": "wild"
       },
       "locked": {
@@ -1116,38 +1117,10 @@
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_4",
         "crane": "crane_5",
-        "fenix": [
-          "fenix"
-        ],
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": "systems_11"
-      },
-      "locked": {
-        "lastModified": 1776404855,
-        "narHash": "sha256-D4OAj55i8YwPbzbRltpWEHbwsgGfJaOLRtaM7BqtB2w=",
-        "owner": "rustshop",
-        "repo": "flakebox",
-        "rev": "fa493d2de9db942e4d03934e6599d756a70388d4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rustshop",
-        "repo": "flakebox",
-        "rev": "fa493d2de9db942e4d03934e6599d756a70388d4",
-        "type": "github"
-      }
-    },
-    "flakebox_4": {
-      "inputs": {
-        "android-nixpkgs": "android-nixpkgs_5",
-        "crane": "crane_6",
         "fenix": "fenix_3",
-        "flake-utils": "flake-utils_14",
-        "nixpkgs": "nixpkgs_8",
-        "systems": "systems_16"
+        "flake-utils": "flake-utils_12",
+        "nixpkgs": "nixpkgs_7",
+        "systems": "systems_14"
       },
       "locked": {
         "lastModified": 1755720430,
@@ -1164,20 +1137,20 @@
         "type": "github"
       }
     },
-    "flakebox_5": {
+    "flakebox_4": {
       "inputs": {
-        "android-nixpkgs": "android-nixpkgs_6",
-        "crane": "crane_7",
+        "android-nixpkgs": "android-nixpkgs_5",
+        "crane": "crane_6",
         "fenix": [
           "fedimint-wasm",
           "fenix"
         ],
-        "flake-utils": "flake-utils_17",
+        "flake-utils": "flake-utils_15",
         "nixpkgs": [
           "fedimint-wasm",
           "nixpkgs"
         ],
-        "systems": "systems_19",
+        "systems": "systems_17",
         "wild": "wild_3"
       },
       "locked": {
@@ -1192,6 +1165,34 @@
         "owner": "dpc",
         "repo": "flakebox",
         "rev": "d4f37f5d9508b85cd020e3f7d3aa966725457a61",
+        "type": "github"
+      }
+    },
+    "flakebox_5": {
+      "inputs": {
+        "android-nixpkgs": "android-nixpkgs_6",
+        "crane": "crane_9",
+        "fenix": [
+          "fenix"
+        ],
+        "flake-utils": "flake-utils_17",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_19"
+      },
+      "locked": {
+        "lastModified": 1776404855,
+        "narHash": "sha256-D4OAj55i8YwPbzbRltpWEHbwsgGfJaOLRtaM7BqtB2w=",
+        "owner": "rustshop",
+        "repo": "flakebox",
+        "rev": "fa493d2de9db942e4d03934e6599d756a70388d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustshop",
+        "repo": "flakebox",
+        "rev": "fa493d2de9db942e4d03934e6599d756a70388d4",
         "type": "github"
       }
     },
@@ -1243,7 +1244,7 @@
     },
     "nix-utils": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -1262,8 +1263,8 @@
     },
     "nix-utils_2": {
       "inputs": {
-        "flake-utils": "flake-utils_11",
-        "nixpkgs": "nixpkgs_6"
+        "flake-utils": "flake-utils_9",
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1744222205,
@@ -1376,22 +1377,6 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
-        "type": "github"
-      }
-    },
-    "nixpkgs_6": {
-      "locked": {
         "lastModified": 1629252929,
         "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
         "owner": "nixos",
@@ -1405,7 +1390,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1728492678,
         "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
@@ -1421,7 +1406,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1758216857,
         "narHash": "sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY=",
@@ -1437,7 +1422,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1775002709,
         "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
@@ -1453,15 +1438,31 @@
         "type": "github"
       }
     },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "android-nixpkgs": "android-nixpkgs",
         "fedimint": "fedimint",
         "fedimint-wasm": "fedimint-wasm",
         "fenix": "fenix_5",
-        "flake-utils": "flake-utils_18",
-        "nixpkgs": "nixpkgs_5",
-        "flakebox": "flakebox_3",
-        "android-nixpkgs": "android-nixpkgs_3"
+        "flake-utils": "flake-utils_16",
+        "flakebox": "flakebox_5",
+        "nixpkgs": "nixpkgs_9"
       }
     },
     "rust-analyzer-src": {
@@ -1550,6 +1551,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_10": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1714,21 +1730,6 @@
         "type": "github"
       }
     },
-    "systems_20": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "systems_3": {
       "locked": {
         "lastModified": 1681028828,
@@ -1836,7 +1837,7 @@
     },
     "utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -1854,7 +1855,7 @@
     },
     "utils_2": {
       "inputs": {
-        "systems": "systems_12"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -1918,7 +1919,7 @@
     },
     "wild_3": {
       "inputs": {
-        "crane": "crane_8",
+        "crane": "crane_7",
         "nixpkgs": [
           "fedimint-wasm",
           "nixpkgs"
@@ -1940,7 +1941,7 @@
     },
     "wild_4": {
       "inputs": {
-        "crane": "crane_9",
+        "crane": "crane_8",
         "nixpkgs": [
           "fedimint-wasm",
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,9 @@
       url = "github:NixOS/nixpkgs/ac62194c3917d5f474c1a844b6fd6da2db95077d";
     };
     fenix = {
-      url = "github:nix-community/fenix";
+      # Pinned like the inputs below: fenix moves nightly, and every bump
+      # invalidates all toolchain and cross-compile derivations.
+      url = "github:nix-community/fenix/298b12d701ef0d12c0f2e4858d4208bee24d14e5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flakebox = {

--- a/flake.nix
+++ b/flake.nix
@@ -94,10 +94,9 @@
           ++ (map (t: fenixPkgs.targets.${t}.stable.rust-std) targets)
         );
 
+        # Only the ABIs we ship (see ubrn.config.yaml's android targets).
         androidToolchain = mkToolchain [
           "aarch64-linux-android"
-          "armv7-linux-androideabi"
-          "i686-linux-android"
           "x86_64-linux-android"
         ];
         
@@ -177,8 +176,6 @@
             
             export BINDGEN_EXTRA_CLANG_ARGS_aarch64_linux_android="--sysroot=$TOOLCHAIN/sysroot -I$TOOLCHAIN/lib/clang/$CLANG_VER/include -I$TOOLCHAIN/lib64/clang/$CLANG_VER/include"
             export BINDGEN_EXTRA_CLANG_ARGS_x86_64_linux_android="--sysroot=$TOOLCHAIN/sysroot -I$TOOLCHAIN/lib/clang/$CLANG_VER/include -I$TOOLCHAIN/lib64/clang/$CLANG_VER/include"
-            export BINDGEN_EXTRA_CLANG_ARGS_armv7_linux_androideabi="--sysroot=$TOOLCHAIN/sysroot -I$TOOLCHAIN/lib/clang/$CLANG_VER/include -I$TOOLCHAIN/lib64/clang/$CLANG_VER/include"
-            export BINDGEN_EXTRA_CLANG_ARGS_i686_linux_android="--sysroot=$TOOLCHAIN/sysroot -I$TOOLCHAIN/lib/clang/$CLANG_VER/include -I$TOOLCHAIN/lib64/clang/$CLANG_VER/include"
 
             # Force bindgen to use NDK clang instead of any Homebrew/system LLVM
             # This prevents aws-lc-sys build failures when Homebrew LLVM is installed

--- a/flake.nix
+++ b/flake.nix
@@ -56,14 +56,14 @@
             android_sdk.accept_license = true;
           };
         };
+        # No emulator system images: nothing in this repo runs an emulator, and
+        # each ABI's image adds gigabytes to the dev shell closure.
         androidSdk = pkgs.androidenv.composeAndroidPackages {
           includeNDK = true;
           toolsVersion = "26.1.1";
           ndkVersions = ["27.1.12297006"];
-          includeSystemImages = true;
           buildToolsVersions = ["36.0.0"];
           platformVersions = ["36"];
-          abiVersions = ["arm64-v8a" "x86_64"];
           cmdLineToolsVersion = "13.0";
         };
         
@@ -127,9 +127,10 @@
             pkgs.just
           ];
 
+          # Used by the android/ios shells; referencing playwright-driver here
+          # would pull the browser bundles (>1 GiB) into their closures, so
+          # only the wasm shells (via wasmShellHook) set up Playwright.
           commonShellHook = ''
-            export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
-            export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
             export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
           '';
 

--- a/nix/ffi.nix
+++ b/nix/ffi.nix
@@ -117,7 +117,11 @@ let
     ln -s /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild $out/bin/xcodebuild
   '';
 
-  # Build the crate for a single (rustTarget, targetKey) pair.
+  # Build the crate for a single (rustTarget, targetKey) pair, returning
+  # `{ deps, lib }`: the crane dependency-only derivation and the final
+  # library build on top of it. Exposing deps as its own package lets CI
+  # push it to Cachix, so a source edit only recompiles the crate itself
+  # instead of the whole cross-compiled dependency tree.
   # `targetKey` is the flakebox-stdTargets key (e.g. `aarch64-ios`),
   # `rustTarget` is the Cargo triple (e.g. `aarch64-apple-ios`).
   buildOne =
@@ -128,81 +132,85 @@ let
     }:
     let
       target = stdTargets.${targetKey} { };
+      commonArgs =
+        target.args
+        // (lib.optionalAttrs isDarwin {
+          # nixpkgs' stdenv walks `buildInputs` and adds each `/lib` to
+          # the cc-wrapper's NIX_LDFLAGS. Putting libiconv here is what
+          # makes `cc -liconv` resolve in the host build-script link
+          # step on macOS 14+ (where iconv lives only in the Apple SDK).
+          # iOS cross-compile linker invocations also see this path but
+          # harmlessly skip the wrong-arch Mach-O lib (with a warning)
+          # and resolve via the SDK paths supplied by mkIOSTarget.
+          buildInputs = [ pkgs.libiconv ];
+        })
+        // (lib.optionalAttrs isIos {
+          # iOS cross-compile reads /Applications/Xcode.app and /usr/bin
+          # via the xcode-wrapper symlinks; this requires relaxed
+          # sandboxing.
+          __noChroot = true;
+          IPHONEOS_DEPLOYMENT_TARGET = "15.0";
+          MACOSX_DEPLOYMENT_TARGET = "14.0";
+
+          # nixpkgs' darwin stdenv sets SDKROOT to its bundled
+          # apple-sdk-11 (a macOS SDK) and points DEVELOPER_DIR into
+          # the Nix store. When cc-rs's build script runs
+          # `xcrun --sdk iphoneos --show-sdk-path` to find the
+          # iPhoneOS SDK, those Nix-store paths confuse xcrun and it
+          # exits 255. Reset to the real /Applications/Xcode.app so
+          # xcrun resolves SDKs via xcode-select.
+          #
+          # Mirrors the iosShellHook in flake.nix + fedi's xcode dev shell.
+          preBuild = ''
+            unset SDKROOT
+            unset NIX_CFLAGS_COMPILE
+            unset NIX_LDFLAGS
+            # APPEND (not prepend) /usr/bin so xcrun resolves but
+            # bare `tar` still picks up Nix's GNU tar — crane's deps
+            # archive uses GNU-only `--sort=name` and would fail
+            # against macOS's BSD tar.
+            export PATH=$PATH:/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin
+            export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+
+            # Nix's cc-wrapper hardcodes --sysroot to a Nix-store
+            # SDK that lacks libSystem on modern macOS runners.
+            # Bypass it for host builds by pointing Cargo's host
+            # linker to the system clang, which resolves libSystem
+            # natively via xcrun.
+            export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/usr/bin/cc
+            export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/bin/cc
+          '';
+        })
+        // {
+          inherit src;
+          pname = "fedimint-client-uniffi-${rustTarget}";
+          version = "0.1.0";
+          cargoExtraArgs = "--locked --target ${rustTarget} --lib";
+          CARGO_BUILD_TARGET = rustTarget;
+          doCheck = false;
+          strictDeps = true;
+          # rocksdb needs cmake; aws-lc-sys needs cmake + perl + go.
+          # python3 is needed by some ring/aws-lc generation scripts.
+          # gnutar overrides macOS's BSD tar so crane's depsArchive
+          # (`tar --sort=name`) works.
+          nativeBuildInputs =
+            (target.args.nativeBuildInputs or [ ])
+            ++ [
+              pkgs.gnutar
+              pkgs.cmake
+              pkgs.pkg-config
+              pkgs.perl
+              pkgs.python3
+              pkgs.go
+            ]
+            ++ lib.optionals isIos [ xcode-wrapper ];
+      };
+      deps = craneLib.buildDepsOnly commonArgs;
     in
-    craneLib.buildPackage (
-      target.args
-      // (lib.optionalAttrs isDarwin {
-        # nixpkgs' stdenv walks `buildInputs` and adds each `/lib` to
-        # the cc-wrapper's NIX_LDFLAGS. Putting libiconv here is what
-        # makes `cc -liconv` resolve in the host build-script link
-        # step on macOS 14+ (where iconv lives only in the Apple SDK).
-        # iOS cross-compile linker invocations also see this path but
-        # harmlessly skip the wrong-arch Mach-O lib (with a warning)
-        # and resolve via the SDK paths supplied by mkIOSTarget.
-        buildInputs = [ pkgs.libiconv ];
-      })
-      // (lib.optionalAttrs isIos {
-        # iOS cross-compile reads /Applications/Xcode.app and /usr/bin
-        # via the xcode-wrapper symlinks; this requires relaxed
-        # sandboxing.
-        __noChroot = true;
-        IPHONEOS_DEPLOYMENT_TARGET = "15.0";
-        MACOSX_DEPLOYMENT_TARGET = "14.0";
-
-        # nixpkgs' darwin stdenv sets SDKROOT to its bundled
-        # apple-sdk-11 (a macOS SDK) and points DEVELOPER_DIR into
-        # the Nix store. When cc-rs's build script runs
-        # `xcrun --sdk iphoneos --show-sdk-path` to find the
-        # iPhoneOS SDK, those Nix-store paths confuse xcrun and it
-        # exits 255. Reset to the real /Applications/Xcode.app so
-        # xcrun resolves SDKs via xcode-select.
-        #
-        # Mirrors the iosShellHook in flake.nix + fedi's xcode dev shell.
-        preBuild = ''
-          unset SDKROOT
-          unset NIX_CFLAGS_COMPILE
-          unset NIX_LDFLAGS
-          # APPEND (not prepend) /usr/bin so xcrun resolves but
-          # bare `tar` still picks up Nix's GNU tar — crane's deps
-          # archive uses GNU-only `--sort=name` and would fail
-          # against macOS's BSD tar.
-          export PATH=$PATH:/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin
-          export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
-
-          # Nix's cc-wrapper hardcodes --sysroot to a Nix-store
-          # SDK that lacks libSystem on modern macOS runners.
-          # Bypass it for host builds by pointing Cargo's host
-          # linker to the system clang, which resolves libSystem
-          # natively via xcrun.
-          export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=/usr/bin/cc
-          export CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=/usr/bin/cc
-        '';
-      })
-      // {
-        inherit src;
-        pname = "fedimint-client-uniffi-${rustTarget}";
-        version = "0.1.0";
-        cargoExtraArgs = "--locked --target ${rustTarget} --lib";
-        CARGO_BUILD_TARGET = rustTarget;
-        doCheck = false;
-        strictDeps = true;
-        # rocksdb needs cmake; aws-lc-sys needs cmake + perl + go.
-        # python3 is needed by some ring/aws-lc generation scripts.
-        # gnutar overrides macOS's BSD tar so crane's depsArchive
-        # (`tar --sort=name`) works.
-        nativeBuildInputs =
-          (target.args.nativeBuildInputs or [ ])
-          ++ [
-            pkgs.gnutar
-            pkgs.cmake
-            pkgs.pkg-config
-            pkgs.perl
-            pkgs.python3
-            pkgs.go
-          ]
-          ++ lib.optionals isIos [ xcode-wrapper ];
-      }
-    );
+    {
+      inherit deps;
+      lib = craneLib.buildPackage (commonArgs // { cargoArtifacts = deps; });
+    };
 
   ##############
   # Android
@@ -237,7 +245,7 @@ let
     mkdir -p $out/jniLibs
     ${lib.concatMapStringsSep "\n" (t: ''
       mkdir -p $out/jniLibs/${t.abi}
-      cp ${androidPerTargetBuilds.${t.rustTarget}}/lib/libfedimint_client_uniffi.so \
+      cp ${androidPerTargetBuilds.${t.rustTarget}.lib}/lib/libfedimint_client_uniffi.so \
          $out/jniLibs/${t.abi}/
     '') androidShipped}
   '';
@@ -284,23 +292,25 @@ let
       ''
         export PATH=/usr/bin:$PATH
         mkdir -p $out/ios-arm64
-        cp ${iosPerTargetBuilds."aarch64-apple-ios"}/lib/libfedimint_client_uniffi.a \
+        cp ${iosPerTargetBuilds."aarch64-apple-ios".lib}/lib/libfedimint_client_uniffi.a \
            $out/ios-arm64/
 
         mkdir -p $out/ios-arm64_x86_64-simulator
         /usr/bin/lipo -create \
-          ${iosPerTargetBuilds."aarch64-apple-ios-sim"}/lib/libfedimint_client_uniffi.a \
-          ${iosPerTargetBuilds."x86_64-apple-ios"}/lib/libfedimint_client_uniffi.a \
+          ${iosPerTargetBuilds."aarch64-apple-ios-sim".lib}/lib/libfedimint_client_uniffi.a \
+          ${iosPerTargetBuilds."x86_64-apple-ios".lib}/lib/libfedimint_client_uniffi.a \
           -output $out/ios-arm64_x86_64-simulator/libfedimint_client_uniffi.a
       '';
 in
 {
   androidBundle = androidJniLibs;
 }
-// lib.mapAttrs' (t: drv: lib.nameValuePair "android-${t}" drv) androidPerTargetBuilds
+// lib.mapAttrs' (t: b: lib.nameValuePair "android-${t}" b.lib) androidPerTargetBuilds
+// lib.mapAttrs' (t: b: lib.nameValuePair "android-${t}-deps" b.deps) androidPerTargetBuilds
 // lib.optionalAttrs isDarwin (
   {
     iosBundle = iosBundle;
   }
-  // lib.mapAttrs' (t: drv: lib.nameValuePair "ios-${t}" drv) iosPerTargetBuilds
+  // lib.mapAttrs' (t: b: lib.nameValuePair "ios-${t}" b.lib) iosPerTargetBuilds
+  // lib.mapAttrs' (t: b: lib.nameValuePair "ios-${t}-deps" b.deps) iosPerTargetBuilds
 )

--- a/nix/ffi.nix
+++ b/nix/ffi.nix
@@ -18,8 +18,11 @@ let
       android_sdk.accept_license = true;
     };
   };
-  lib = pkgs.lib;
-  stdenv = pkgs.stdenv;
+  # lib from the flake output and isDarwin from the system string, so that
+  # computing the returned attr *names* (which every `nix build .#wasmBundle`
+  # does through the merge in flake.nix) never forces the pkgs import above.
+  lib = nixpkgs.lib;
+  isDarwin = lib.hasSuffix "-darwin" system;
 
   # NOTE: at the pinned flakebox rev, mkStdTargets only uses this argument's
   # presence to gate the android-* target attrs — the cross-compile env it
@@ -68,7 +71,7 @@ let
         "aarch64-android"
         "x86_64-android"
       ]
-      ++ lib.optionals stdenv.isDarwin [
+      ++ lib.optionals isDarwin [
         "aarch64-ios"
         "aarch64-ios-sim"
         "x86_64-ios"
@@ -78,21 +81,16 @@ let
 
   craneLib = toolchain.craneLib;
 
-  # Keep .c, .toml (uniffi.toml, uniffi-android.toml), and .udl alongside
-  # Rust sources. craneLib.cleanCargoSource on its own would strip these.
+  # Keep sdallocx_stub.c (compiled by build.rs) alongside the Rust sources
+  # craneLib.filterCargoSources keeps. The uniffi*.toml configs are
+  # deliberately NOT included: these builds only run `cargo build --lib`
+  # (bindgen runs later via ubrn, outside Nix), so including bindgen-only
+  # config would needlessly invalidate every cross-compile on edits to it.
   src =
     let
       crateDir = ../fedimint-client-uniffi;
-      keepExtras =
-        path: _type:
-        let
-          base = baseNameOf path;
-        in
-        base == "sdallocx_stub.c"
-        || base == "uniffi.toml"
-        || base == "uniffi-android.toml"
-        || lib.hasSuffix ".udl" path;
-      filter = path: type: (keepExtras path type) || (craneLib.filterCargoSources path type);
+      filter =
+        path: type: baseNameOf path == "sdallocx_stub.c" || craneLib.filterCargoSources path type;
     in
     lib.cleanSourceWith {
       src = crateDir;
@@ -133,7 +131,7 @@ let
     in
     craneLib.buildPackage (
       target.args
-      // (lib.optionalAttrs stdenv.isDarwin {
+      // (lib.optionalAttrs isDarwin {
         # nixpkgs' stdenv walks `buildInputs` and adds each `/lib` to
         # the cc-wrapper's NIX_LDFLAGS. Putting libiconv here is what
         # makes `cc -liconv` resolve in the host build-script link
@@ -300,7 +298,7 @@ in
   androidBundle = androidJniLibs;
 }
 // lib.mapAttrs' (t: drv: lib.nameValuePair "android-${t}" drv) androidPerTargetBuilds
-// lib.optionalAttrs stdenv.isDarwin (
+// lib.optionalAttrs isDarwin (
   {
     iosBundle = iosBundle;
   }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -30,7 +30,8 @@
     "build": "bob build",
     "clean": "rm -rf lib tsconfig.tsbuildinfo",
     "clean:deep": "pnpm run clean && rm -rf node_modules",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
     "@fedimint/core": "workspace:*",

--- a/packages/react-native/src/ReactNativeTransport.ts
+++ b/packages/react-native/src/ReactNativeTransport.ts
@@ -19,11 +19,10 @@ export class ReactNativeTransport extends Transport {
   }
 
   async postMessage(message: TransportRequest): Promise<void> {
-    this.logger.info(
-      'ReactNativeTransport postMessage received:',
-      JSON.stringify(message),
-    )
     const { type, payload, requestId } = message
+    // Payloads can carry secrets (mnemonic words, invite codes), so only the
+    // message type and id are ever logged.
+    this.logger.debug('ReactNativeTransport postMessage:', type, requestId)
     try {
       // Handle init - just respond with success since we initialized in constructor
       if (type === 'init') {
@@ -56,15 +55,16 @@ export class ReactNativeTransport extends Transport {
           ...(typeof payload === 'object' && payload !== null ? payload : {}),
         }
         const json = JSON.stringify(rustRequest)
-        console.info('ReactNativeTransport sending RPC:', json)
+        this.logger.debug('ReactNativeTransport sending RPC:', type, requestId)
 
         const callback = {
           onResponse: (responseStr: string) => {
             try {
               const response = JSON.parse(responseStr)
-              console.info(
-                'ReactNativeTransport RPC parsed response:',
-                JSON.stringify(response),
+              this.logger.debug(
+                'ReactNativeTransport RPC response:',
+                response.type,
+                response.request_id,
               )
 
               if (response.type === 'error') {

--- a/packages/react-native/tsconfig.test.json
+++ b/packages/react-native/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "../..",
+    "paths": {
+      "@fedimint/react-native-bindings": [
+        "./src/__tests__/rpc-handler-stub.ts"
+      ],
+      "@fedimint/types": ["../types/src/index.ts"]
+    }
+  },
+  "include": ["src/ReactNativeTransport.ts", "src/__tests__"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 import wasm from 'vite-plugin-wasm'
 import { defineConfig } from 'vitest/config'
 
@@ -58,14 +60,15 @@ export default defineConfig({
             // The real bindings module is ubrn-generated and needs a compiled
             // native library; unit tests run against a stub instead. Types are
             // aliased to source so no workspace build is needed beforehand.
-            '@fedimint/react-native-bindings': new URL(
-              './packages/react-native/src/__tests__/rpc-handler-stub.ts',
-              import.meta.url,
-            ).pathname,
-            '@fedimint/types': new URL(
-              './packages/types/src/index.ts',
-              import.meta.url,
-            ).pathname,
+            '@fedimint/react-native-bindings': fileURLToPath(
+              new URL(
+                './packages/react-native/src/__tests__/rpc-handler-stub.ts',
+                import.meta.url,
+              ),
+            ),
+            '@fedimint/types': fileURLToPath(
+              new URL('./packages/types/src/index.ts', import.meta.url),
+            ),
           },
         },
       },


### PR DESCRIPTION
Follow-up to #339, rebased on main now that it landed.

Building the RN bindings locally used to mean multi-GB downloads and a from-source cross-compile
of ~760 derivations, because nothing kept the Cachix cache warm and the dev shells carried weight
the builds never use. This PR attacks both:

Smaller closures:
- Drop Android emulator system images (multi-GB per ABI; nothing here runs an emulator) and the
  Playwright browser bundles from the android/iOS dev shells — the wasm shells keep their own.
- Drop the armv7/i686 Android targets nothing ships from both toolchains (verified the trim only
  removes those targets' env vars from the build derivations).
- Scope the Nix build source to files the build actually reads, and keep FFI evaluation lazy so
  wasm-only builds don't pay for it.

Warm cache:
- Explicitly `cachix push` the FFI lib outputs **and their crane deps derivations** (~95% of the
  build cost) after CI builds — cachix-action's post-run hook never re-pushes paths already
  realized on the warm self-hosted runner, which is how the cache went cold. Same treatment for
  `wasmBundle`, whose auth token was never actually reaching the reusable verify workflow.
- Pin fenix like the other FFI inputs so a routine lock refresh can't silently invalidate every
  toolchain and cross-compile derivation.

Review hardening (from an adversarial review pass over the branch):
- rust-ci: `--locked` so CI validates the resolution the Nix builds ship, dead CLASSPATH/feature
  config dropped, no redundant build step, lint job unserialized; both imported workflows get
  main-only push triggers, concurrency groups, timeouts, and the iOS job the same parallelism cap
  the Justfile uses against macos-latest OOM.
- The RN transport no longer logs request/response payloads (set_mnemonic/get_mnemonic carried
  wallet words into device logs), and its tests are now also type-checked in CI against the
  stubbed bindings.
- The FFI crate declares the tokio features it actually uses, reruns build.rs when the sdallocx
  stub changes, and degrades to an error response instead of aborting the host app if RPC
  response serialization ever fails.

Known deliberate skips: the in-flight-RPC cancellation on `cleanup` (inherited design, needs its
own discussion), the possibly-forcer aws-lc-rs/socket2 direct deps (removing them needs
cross-target build verification), and deduplicating the shipped-target lists across nix/yaml/sh
(fits the planned repo restructuring).

Generated by Claude Fable 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013riT6ZjqJa1fjSiLiKDnFT
