### PR TITLE
Fix CI flakiness: surface wasm worker crashes, guard the faucet port

### DIFF
--- a/.changeset/transport-error-propagation.md
+++ b/.changeset/transport-error-propagation.md
@@ -1,0 +1,12 @@
+---
+'@fedimint/transport-web': patch
+'@fedimint/core': patch
+---
+
+Fail pending RPC requests when the transport crashes instead of hanging forever.
+
+Uncaught errors and unhandled rejections in the wasm worker (e.g. a panic in the wasm
+client) previously went nowhere: the request that triggered them never resolved and
+callers were left to hit their own timeouts with no error message. The worker now
+reports such crashes as transport-level errors and `TransportClient` rejects all
+in-flight requests with the underlying error.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,6 +41,21 @@ jobs:
       - name: Build
         run: pnpm build
 
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
   types:
     name: Check Types
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,6 +77,13 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, x64]
     timeout-minutes: 45
+    # devimint's faucet listens on a fixed port (15243, hard-coded upstream), so two of
+    # these jobs on the same host race for it and the loser's tests talk to the winner's
+    # federation. Serialize all devimint-backed test jobs until the port is dynamic.
+    # See https://github.com/fedimint/fedimint-sdk/issues/340.
+    concurrency:
+      group: devimint-tests
+      queue: max
 
     steps:
       - name: Clone repository

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:coverage": "vitest run --coverage",
     "test:lib": "vitest --project integration-tests",
     "test:reactnative": "vitest --project react-native",
+    "test:unit": "vitest --project unit",
     "test:create": "vitest --watch=false --project cli",
     "test:ui": "vitest --browser.headless=false --ui",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "vite-plugin-wasm": "^3.5.0",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@11.12.0",
+  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": "22.x"
   },

--- a/packages/core/src/WalletDirector.ts
+++ b/packages/core/src/WalletDirector.ts
@@ -67,7 +67,12 @@ export class WalletDirector {
     this._client = new TransportClient(transport)
     this._client.logger.info('WalletDirector instantiated')
     if (!lazy) {
-      this.initialize(this.dbPath)
+      // Fire-and-forget on purpose; log instead of surfacing an unhandled
+      // rejection. Later operations await the same (cached) initialization
+      // and get the error properly.
+      this.initialize(this.dbPath).catch((error) => {
+        this._client.logger.error('WalletDirector initialization failed', error)
+      })
     }
   }
 

--- a/packages/core/src/__tests__/TransportClient.test.ts
+++ b/packages/core/src/__tests__/TransportClient.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'vitest'
+import type {
+  TransportLogger,
+  TransportMessage,
+  TransportRequest,
+} from '@fedimint/types'
+import { Transport } from '@fedimint/types'
+import { TransportClient } from '../transport/TransportClient'
+
+/**
+ * Scripted transport that records outgoing requests and lets tests inject
+ * incoming messages, so TransportClient's routing can be tested without a
+ * worker or native module.
+ */
+class FakeTransport extends Transport {
+  logger: TransportLogger = console
+  sent: TransportRequest[] = []
+
+  postMessage(message: TransportRequest) {
+    this.sent.push(message)
+  }
+
+  emit(message: TransportMessage) {
+    this.messageHandler(message)
+  }
+}
+
+function pendingRpc(client: TransportClient, transport: FakeTransport) {
+  const promise = client.rpcSingle('mint', 'some_method', {}, 'test-client')
+  // Requests are numbered by TransportClient; recover the id it assigned.
+  const requestId = transport.sent[transport.sent.length - 1].requestId
+  return { promise, requestId }
+}
+
+describe('TransportClient error routing', () => {
+  test('an error attributed to a request rejects only that request', async () => {
+    const transport = new FakeTransport()
+    const client = new TransportClient(transport)
+
+    const first = pendingRpc(client, transport)
+    const second = pendingRpc(client, transport)
+
+    transport.emit({
+      type: 'error',
+      error: 'boom',
+      request_id: first.requestId,
+    })
+    await expect(first.promise).rejects.toBe('boom')
+
+    transport.emit({
+      type: 'data',
+      data: { ok: true },
+      request_id: second.requestId,
+    })
+    await expect(second.promise).resolves.toEqual({ ok: true })
+  })
+
+  test('a transport-level error (no request_id) fails all pending requests', async () => {
+    const transport = new FakeTransport()
+    const client = new TransportClient(transport)
+
+    const first = pendingRpc(client, transport)
+    const second = pendingRpc(client, transport)
+
+    // What the worker posts when e.g. a wasm panic surfaces as an unhandled
+    // rejection: an error message that cannot be attributed to a request.
+    transport.emit({ type: 'error', error: 'wasm worker crashed' })
+
+    await expect(first.promise).rejects.toBe('wasm worker crashed')
+    await expect(second.promise).rejects.toBe('wasm worker crashed')
+    expect(client._getRequestCallbackMap().size).toBe(0)
+  })
+
+  test('a throwing consumer callback does not stop the remaining requests from failing', async () => {
+    const transport = new FakeTransport()
+    const client = new TransportClient(transport)
+
+    // A stream consumer whose error handler throws; registered first so it
+    // runs before the well-behaved request's callback.
+    client.rpcStream(
+      'mint',
+      'some_method',
+      {},
+      'test-client',
+      () => {},
+      () => {
+        throw new Error('badly behaved consumer')
+      },
+    )
+    const pending = pendingRpc(client, transport)
+
+    transport.emit({ type: 'error', error: 'wasm worker crashed' })
+
+    await expect(pending.promise).rejects.toBe('wasm worker crashed')
+    expect(client._getRequestCallbackMap().size).toBe(0)
+  })
+
+  test('an empty transport-level error message still rejects pending requests', async () => {
+    const transport = new FakeTransport()
+    const client = new TransportClient(transport)
+
+    const pending = pendingRpc(client, transport)
+    // An empty string is falsy, which sendSingleMessage's error branch would
+    // ignore — the substitute message keeps the rejection observable.
+    transport.emit({ type: 'error', error: '' })
+
+    await expect(pending.promise).rejects.toBe('unknown transport error')
+  })
+
+  // Note this covers TransportClient's own state (the callback map is reset),
+  // not worker recovery — whether a crashed worker can serve new requests is
+  // up to the transport.
+  test('the client still routes new requests after a transport-level error', async () => {
+    const transport = new FakeTransport()
+    const client = new TransportClient(transport)
+
+    const failed = pendingRpc(client, transport)
+    transport.emit({ type: 'error', error: 'wasm worker crashed' })
+    await expect(failed.promise).rejects.toBe('wasm worker crashed')
+
+    const retried = pendingRpc(client, transport)
+    transport.emit({
+      type: 'data',
+      data: 'recovered',
+      request_id: retried.requestId,
+    })
+    await expect(retried.promise).resolves.toBe('recovered')
+  })
+})

--- a/packages/core/src/transport/TransportClient.ts
+++ b/packages/core/src/transport/TransportClient.ts
@@ -85,6 +85,22 @@ export class TransportClient {
       this.handleLogMessage(message)
     }
 
+    if (type === 'error' && request_id === undefined) {
+      // The transport failed outside any single request — e.g. an uncaught error
+      // or unhandled rejection in the wasm worker (a panic in the wasm client
+      // aborts its task without ever answering the request that triggered it).
+      // None of the in-flight requests can be answered anymore, so fail them all
+      // with the real error instead of leaving callers to hang until their own
+      // timeouts.
+      // `||` (not `??`): an empty error string must not slip through, because
+      // sendSingleMessage's error branch treats '' as falsy and the request
+      // would silently hang — the exact bug class this path exists to fix.
+      this.failAllPendingRequests(
+        String(data.error || 'unknown transport error'),
+      )
+      return
+    }
+
     const streamCallback =
       request_id !== undefined
         ? this.requestCallbacks.get(request_id)
@@ -101,6 +117,28 @@ export class TransportClient {
         'TransportClient - handleTransportMessage - received message with no callback',
         message,
       )
+    }
+  }
+
+  private failAllPendingRequests(error: string) {
+    const callbacks = [...this.requestCallbacks.values()]
+    this.requestCallbacks.clear()
+    this.logger.error(
+      'TransportClient - transport-level error, failing all pending requests',
+      callbacks.length,
+      error,
+    )
+    for (const callback of callbacks) {
+      // A consumer callback that throws (e.g. a stream onError) must not
+      // prevent the remaining requests from being failed.
+      try {
+        callback({ error })
+      } catch (callbackError) {
+        this.logger.error(
+          'TransportClient - pending request callback threw',
+          callbackError,
+        )
+      }
     }
   }
 
@@ -239,6 +277,12 @@ export class TransportClient {
   ) {
     this.requestCallbacks.set(requestId, (response: StreamResult<Response>) => {
       if (response.error !== undefined) {
+        // Errors terminate the stream (the wasm client ends the stream on the
+        // first error, and worker-generated errors are never followed by an
+        // `end`), so drop the callback — otherwise it leaks for the client's
+        // lifetime and a later transport-level failure would fire onError a
+        // second time on an already-failed request.
+        this.requestCallbacks.delete(requestId)
         onError(response.error)
       } else if (response.data !== undefined) {
         onSuccess(response.data)

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -11,5 +11,8 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  // Tests are excluded so their declarations don't end up in the published
+  // dist and the build doesn't depend on vitest; they are type-checked by
+  // vitest itself when the unit project runs.
+  "exclude": ["node_modules", "src/**/__tests__/**"]
 }

--- a/packages/transport-web/src/WasmWorkerTransport.ts
+++ b/packages/transport-web/src/WasmWorkerTransport.ts
@@ -16,6 +16,22 @@ export class WasmWorkerTransport extends Transport {
     }
     this.worker.onerror = (event: ErrorEvent) => {
       this.errorHandler(event)
+      // The worker is in an unknown state (the script failed to load or an
+      // uncaught error escaped it), so no in-flight request can be answered
+      // anymore. Report a transport-level error (no request_id) so the client
+      // fails them all instead of leaving them hanging.
+      this.messageHandler({
+        type: 'error',
+        error: `Wasm worker error: ${event.message || 'unknown'}`,
+      })
+    }
+    this.worker.onmessageerror = () => {
+      // A response failed structured deserialization; it cannot be attributed
+      // to a request, so the pending ones would otherwise hang forever.
+      this.messageHandler({
+        type: 'error',
+        error: 'Wasm worker response could not be deserialized',
+      })
     }
   }
 

--- a/packages/transport-web/src/worker.js
+++ b/packages/transport-web/src/worker.js
@@ -100,10 +100,45 @@ self.onmessage = async (event) => {
     }
   } catch (e) {
     console.error('ERROR', e)
-    self.postMessage({ type: 'error', error: e.message, request_id: requestId })
+    self.postMessage({
+      type: 'error',
+      error: e instanceof Error ? e.message : String(e),
+      request_id: requestId,
+    })
   }
 }
 
-self.onerror = (e) => {
-  self.postMessage({ type: 'error', error: e.message })
+/** @param {unknown} value */
+function describeError(value) {
+  if (value instanceof Error) {
+    // Prefer the stack: for a wasm panic it names the wasm frames, which is
+    // the only clue to what actually crashed.
+    return value.stack || value.message || String(value)
+  }
+  return String(value) || 'unknown error'
 }
+
+// A crash outside the message handler is otherwise invisible to the main thread and
+// the request that triggered it would just never resolve. The main offender is a
+// panic in the wasm client: it aborts the async task spawned for the RPC, which
+// surfaces here as an unhandled rejection (`RuntimeError: unreachable`). Report such
+// crashes as transport-level errors (no request_id) so the client can fail all
+// in-flight requests with the real error. This deliberately treats every uncaught
+// error/rejection as fatal: the worker's only async work is the wasm client and its
+// storage, and after a wasm trap the instance state cannot be trusted anyway.
+// preventDefault() marks the event handled so it is not additionally re-reported
+// through the parent's `worker.onerror` (which would fail everything a second
+// time); console.error keeps the full text visible in browser/CI logs.
+self.addEventListener('error', (event) => {
+  event.preventDefault()
+  const error = `Uncaught error in wasm worker: ${event.message || describeError(event.error)}`
+  console.error(error)
+  self.postMessage({ type: 'error', error })
+})
+
+self.addEventListener('unhandledrejection', (event) => {
+  event.preventDefault()
+  const error = `Unhandled rejection in wasm worker: ${describeError(event.reason)}`
+  console.error(error)
+  self.postMessage({ type: 'error', error })
+})

--- a/scripts/setup_test_shell.sh
+++ b/scripts/setup_test_shell.sh
@@ -2,7 +2,41 @@
 
 set -euo pipefail
 
-# Event though it would be better, do not use `exec` for this,
+# devimint's faucet listens on a fixed port (hard-coded upstream). If a stale or
+# concurrent devimint already occupies it, devimint only logs the bind failure and its
+# startup probe happily connects to the foreign listener — the tests then run against
+# the wrong federation and fail with confusing fetch errors (see issue #340). Wait for
+# the port to be free, and fail fast with a diagnostic if it never frees up.
+faucet_port="${FM_PORT_FAUCET:-15243}"
+
+# The tests fetch from `localhost`, which may resolve to either loopback address, so a
+# squatter on either one counts as occupied. `timeout` bounds a probe that would
+# otherwise stall on firewalled/DROPped packets.
+faucet_port_in_use() {
+  local host
+  for host in 127.0.0.1 ::1; do
+    if timeout 2 bash -c "exec 3<>/dev/tcp/${host}/${faucet_port}" 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+deadline=$((SECONDS + 120))
+while faucet_port_in_use; do
+  if ((SECONDS >= deadline)); then
+    echo "error: faucet port ${faucet_port} is still in use;" \
+      "is a stale or concurrent devimint running on this machine?" >&2
+    if command -v ss >/dev/null; then
+      ss -ltnp "sport = :${faucet_port}" >&2 || true
+    fi
+    exit 1
+  fi
+  echo "faucet port ${faucet_port} is in use, waiting for it to be free..."
+  sleep 5
+done
+
+# Even though it would be better, do not use `exec` for this,
 # as pnpm seems to be swallowing non-zero error codes if it
 # is run like this, but only when this whole script is called from
 # another pnpm instance.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,7 +35,11 @@ export default defineConfig({
             ],
           },
           env: {
-            FAUCET: `http://localhost:15243`,
+            // devimint exports the faucet port to the environment of the command it
+            // execs (`pnpm test` runs under `devimint wasm-test-setup --exec`); the
+            // fallback matches devimint's current hard-coded default. `||` so a
+            // set-but-empty variable also falls back, like `:-` in the setup script.
+            FAUCET: `http://localhost:${process.env.FM_PORT_FAUCET || '15243'}`,
           },
         },
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,14 @@ export default defineConfig({
           name: 'integration-tests',
           include: ['packages/integration-tests/**/*.test.ts'],
           exclude: ['packages/create-fedimint-app/**/*.test.ts'],
+          // These tests run against a live devimint federation and a fresh
+          // wallet per test, so they can hit transient failures — most notably
+          // a wasm client crash when an RPC lands right after joining the
+          // federation (issues #330/#340). Fixtures re-run on retry, so each
+          // attempt gets a fresh worker and wallet. NOTE: config-level retry
+          // works for test.extend-based tests; per-test `{ retry }` options are
+          // silently ignored for them (vitest 3.2.x).
+          retry: 2,
           browser: {
             enabled: true,
             provider: 'playwright',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,22 @@ export default defineConfig({
       },
       {
         test: {
+          name: 'unit',
+          environment: 'node',
+          include: ['packages/core/**/*.test.ts'],
+        },
+        resolve: {
+          alias: {
+            // Type-only workspace dependency; alias to source so the package
+            // does not have to be built before running unit tests.
+            '@fedimint/types': fileURLToPath(
+              new URL('./packages/types/src/index.ts', import.meta.url),
+            ),
+          },
+        },
+      },
+      {
+        test: {
           name: 'react-native',
           environment: 'node',
           include: ['packages/react-native/**/*.test.ts'],


### PR DESCRIPTION
Investigates and mitigates the CI flakiness tracked in #340 and #330. Stacked on #345 — only
the last 6 commits are new; will be rebased once #345 merges.

## Investigation

The two tracked flakes turn out to be **distinct failure modes**:

### 1. Faucet port collision (#340: mass `Failed to fetch`)

devimint hard-codes the faucet port (`FM_PORT_FAUCET: u16 = 15243` in `devimint/src/vars.rs`,
still hard-coded on fedimint master) while every other port goes through `port_alloc`. Worse,
on a bind failure devimint only logs `Error spawning faucet` from a cancellable task, and its
"waiting for faucet startup" probe is a plain `TcpStream::connect` — which **succeeds against
whatever foreign process is squatting the port**. Setup then proceeds and the tests fetch
invite codes from another job's federation (or a dying process), producing the 24 confusing
fetch failures from the issue. The env var is export-only; it cannot be overridden without an
upstream devimint change.

### 2. `generateAddress` 15s timeout (#330, also seen on #345 and on main)

Not slowness — a swallowed crash. The failing runs (and only they) show two bare `null` stderr
lines right as `peg_in` is dispatched, then 15s of silence:

- `fedimint-client-wasm` installs no panic hook, so a panic in the wasm client (the known
  crash-right-after-join that the test's 100ms-sleep TODO works around) aborts the RPC's
  `spawn_local` task as an unhandled rejection carrying no useful message.
- Neither the worker nor `TransportClient` listened for worker-level errors: the pending
  request never resolved, and Vitest killed the test at its 15s default timeout with zero
  diagnostics.

## Fixes

- **`fix(transport)`**: the worker now reports uncaught errors/unhandled rejections as
  transport-level errors, and `TransportClient` fails all in-flight requests with the real
  error. Silent 15s hangs become immediate, diagnosable failures — the next CI occurrence will
  print the actual wasm error instead of `null`. Covered by new unit tests (new `unit` Vitest
  project, wired into the RN transport CI job which already gates on `packages/core`).
- **`fix(tests)`**: `retry: 2` on the integration-tests project. Fixtures re-run per attempt,
  so a retry gets a fresh worker and wallet — exactly what recovers from a crashed worker.
  Retried-then-passed tests are reported as flaky by Vitest, so occurrences stay visible.
  (Config-level retry is deliberate: per-test `{ retry }` options are silently ignored for
  `test.extend`-based tests in vitest 3.2.7.)
- **`fix(tests)`**: the faucet URL now follows `FM_PORT_FAUCET` from devimint's environment
  instead of hard-coding the port a second time.
- **`fix(tests)`**: `setup_test_shell.sh` waits for the faucet port to be free and aborts with
  a pointed message if it never frees up — no more silently testing against a foreign
  federation.
- **`ci`**: the devimint-backed `Verify / Test` jobs share a `concurrency` group with
  `queue: max` (FIFO queue of up to 100 runs, no replacement of pending runs), so two jobs on
  runners sharing a host can no longer race for the fixed port. Scoped to the `test` job only;
  droppable once the port is dynamic upstream.

- **`chore`**: bump `packageManager` to pnpm 11.22.0 — 11.12.0 is an officially retracted
  release, and pnpm ≥ 11.14 hard-refuses to run in a project that pins it, locking out
  contributors on current pnpm. Verified `pnpm install --frozen-lockfile` passes with the
  untouched lockfile; `pnpm/action-setup@v4` reads the field automatically. Can be split into
  its own PR if preferred.

## Validation

- New unit tests (5) plus the existing RN transport tests pass; `tsc --noEmit` clean for
  `core` and `transport-web`; verified the published `dist` no longer picks up test artifacts.
- Full local run against a real devimint federation confirmed the retry mechanism end-to-end
  (vitest visibly reports `retry x2` and re-creates the wallet fixture per attempt) and the
  faucet-port guard was exercised in both the occupied (waits, then fails with the diagnostic)
  and free paths.
- An adversarial multi-agent review ran over the branch; accepted findings folded in
  (verify.yml `unit` job so transport-only PRs still run the tests, `onmessageerror` coverage,
  a `.catch` on WalletDirector's constructor-time init, empty-string error holes, stream
  callback leak on attributed errors, IPv6 loopback probing in the port guard, excluding tests
  from the published build). Consciously **not** done, to keep scope contained: a
  dead-transport latch/recovery design (post-crash requests still go to the transport;
  documented in a test comment), Error-object rejections (the SDK's error contract is
  string-based throughout), scoping retry to a single test (per-test retry is silently ignored
  for `test.extend` tests), and host-local `flock` instead of the GH concurrency queue (runner
  filesystem isolation on the self-hosted fleet is unverified, the queue is scheduler-level).

## Upstream follow-ups (fedimint)

Not addressable in this repo; happy to file/PR these separately:

1. Allocate `FM_PORT_FAUCET` via `port_alloc` like every other devimint port, and make
   `wasm-test-setup` fail fast when the faucet cannot bind (the startup probe passing against a
   foreign listener is what turns a bind failure into silent misbehavior).
2. Install a panic hook in `fedimint-client-wasm` so panics carry their message.
3. The underlying `peg_in`-right-after-join crash itself (`WalletService.test.ts` still
   carries the 100ms-sleep workaround with @maan2003's TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013riT6ZjqJa1fjSiLiKDnFT
