### PR TITLE
Capture wasm worker crash stacks and add a native repro for the peg_in crash

### DIFF
--- a/.changeset/worker-error-stacks.md
+++ b/.changeset/worker-error-stacks.md
@@ -1,0 +1,8 @@
+---
+'@fedimint/transport-web': patch
+---
+
+Include the error's stack when reporting uncaught wasm worker errors.
+
+`event.message` alone drops the stack, and for a wasm trap the stack (with its wasm frame
+references) is the only clue to what crashed.

--- a/fedimint-client-uniffi/src/lib.rs
+++ b/fedimint-client-uniffi/src/lib.rs
@@ -237,6 +237,54 @@ mod tests {
         assert_eq!(responses[0]["data"], json!(true));
     }
 
+    /// Repro for the wasm peg_in-right-after-join crash (issue #330 /
+    /// fedimint#9046): same flow as the TS integration test, natively, so a
+    /// panic yields a symbolized backtrace.
+    #[test]
+    #[ignore = "needs a running devimint federation: set REPRO_INVITE_CODE and run with --ignored"]
+    fn peg_in_right_after_join() {
+        let invite = std::env::var("REPRO_INVITE_CODE")
+            .expect("REPRO_INVITE_CODE must hold a devimint federation invite code");
+
+        for round in 1..=3 {
+            eprintln!("=== round {round}");
+            let dir = tempfile::tempdir().unwrap();
+            let handler = new_handler(&dir);
+            let client_name = format!("{round:0>36}");
+
+            rpc_collect(
+                &handler,
+                json!({ "request_id": 1, "type": "set_mnemonic", "words": TEST_MNEMONIC }),
+            );
+            let responses = rpc_collect(
+                &handler,
+                json!({
+                    "request_id": 2,
+                    "type": "join_federation",
+                    "invite_code": invite,
+                    "force_recover": false,
+                    "client_name": client_name,
+                }),
+            );
+            assert_eq!(responses[0]["type"], "data", "join failed: {responses:?}");
+
+            // Deliberately no delay: this is the race under investigation.
+            let responses = rpc_collect(
+                &handler,
+                json!({
+                    "request_id": 3,
+                    "type": "client_rpc",
+                    "client_name": client_name,
+                    "module": "wallet",
+                    "method": "peg_in",
+                    "payload": { "extra_meta": {} },
+                }),
+            );
+            eprintln!("peg_in responses: {responses:?}");
+            assert_eq!(responses[0]["type"], "data", "peg_in failed: {responses:?}");
+        }
+    }
+
     #[test]
     fn reports_errors_as_responses() {
         let dir = tempfile::tempdir().unwrap();

--- a/packages/integration-tests/src/services/WalletService.test.ts
+++ b/packages/integration-tests/src/services/WalletService.test.ts
@@ -28,7 +28,11 @@ walletTest(
   async ({ wallet }) => {
     expect(wallet).toBeDefined()
     expect(wallet.isOpen()).toBe(true)
-    // TODO: @maan2003 Plz help me investigate why we crash without this delay
+    // Works around an upstream crash: peg_in right after joining races the
+    // wallet module's background DB writes and panics on the resulting
+    // WriteConflict (https://github.com/fedimint/fedimint/issues/9046). The
+    // delay shrinks the window but cannot close it; remove once the fix lands
+    // in the pinned wasm.
     await new Promise((resolve) => setTimeout(resolve, 100))
     const response = await wallet.wallet.generateAddress()
 

--- a/packages/react-native/src/__tests__/ReactNativeTransport.test.ts
+++ b/packages/react-native/src/__tests__/ReactNativeTransport.test.ts
@@ -18,7 +18,7 @@ function newTransport() {
   const errors: unknown[] = []
   transport.setMessageHandler((message) => messages.push(message))
   transport.setErrorHandler((error) => errors.push(error))
-  const handler = RpcHandler.instances.at(-1)!
+  const handler = RpcHandler.instances[RpcHandler.instances.length - 1]!
   return { transport, handler, messages, errors }
 }
 

--- a/packages/transport-web/src/worker.js
+++ b/packages/transport-web/src/worker.js
@@ -111,9 +111,17 @@ self.onmessage = async (event) => {
 /** @param {unknown} value */
 function describeError(value) {
   if (value instanceof Error) {
-    // Prefer the stack: for a wasm panic it names the wasm frames, which is
-    // the only clue to what actually crashed.
-    return value.stack || value.message || String(value)
+    const header = value.message
+      ? `${value.name}: ${value.message}`
+      : value.name
+    // Include the stack: for a wasm panic it names the wasm frames, which is
+    // the only clue to what actually crashed. Chrome-style stacks already
+    // start with the header line; Firefox stacks hold only the frames, so
+    // prepend the header there — never repeat it.
+    const stack = value.stack || ''
+    return stack.startsWith(header)
+      ? stack
+      : [header, stack].filter(Boolean).join('\n')
   }
   return String(value) || 'unknown error'
 }
@@ -131,7 +139,13 @@ function describeError(value) {
 // time); console.error keeps the full text visible in browser/CI logs.
 self.addEventListener('error', (event) => {
   event.preventDefault()
-  const error = `Uncaught error in wasm worker: ${event.message || describeError(event.error)}`
+  // event.error carries the whole picture (message + stack) when the browser
+  // exposes it; event.message is only the fallback, as on its own it drops
+  // the stack — for a wasm trap the only clue to what crashed.
+  const details = event.error
+    ? describeError(event.error)
+    : event.message || 'unknown'
+  const error = `Uncaught error in wasm worker: ${details}`
   console.error(error)
   self.postMessage({ type: 'error', error })
 })


### PR DESCRIPTION
Follow-ups from tracking down the `generateAddress` flake (#330) to its actual root cause: **`WalletClientModule::supports_safe_deposit()` panics on a recoverable db `WriteConflict`** when `peg_in` races the wallet module's post-join background writes — filed upstream with a full backtrace as fedimint/fedimint#9046 (and the unwind-turned-abort in `ClientHandle::drop` as fedimint/fedimint#9053).

- **transport-web**: include the error's stack when reporting uncaught worker errors. `event.message` alone is how CI ended up with a bare `Uncaught RuntimeError: unreachable`; with the stack, the trap carries its wasm frames (this is what made the diagnosis possible). Patch changeset included.
- **fedimint-client-uniffi**: opt-in native reproduction test for the crash (set `REPRO_INVITE_CODE` and run under devimint; self-skips otherwise — CI unaffected). It reproduces the panic deterministically with a symbolized backtrace today, and becomes the verification that the upstream fix works once the pins are bumped.
- **integration-tests**: the 100ms-sleep workaround now documents the real root cause instead of the old investigate-me TODO.

Verified: all 12 unit/RN vitest tests and the 5 crate tests pass; prettier and cargo fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013riT6ZjqJa1fjSiLiKDnFT