### PR TITLE
Bump the fedimint pins to pick up the CI flakiness fixes

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,6 @@
+---
+'@fedimint/fedimint-client-wasm-bundler': patch
+'@fedimint/fedimint-client-wasm-web': patch
+---
+
+Rebuild the wasm client from a fedimint revision that installs a panic hook and fixes the wallet write conflict behind it, so a peg-in issued right after joining a federation no longer crashes the worker

--- a/flake.lock
+++ b/flake.lock
@@ -1221,6 +1221,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-playwright": {
+      "locked": {
+        "lastModified": 1766473571,
+        "narHash": "sha256-5G1NDO2PulBx1RoaA6U1YoUDX0qZslpPxv+n5GX6Qto=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "76701a179d3a98b07653e2b0409847499b2a07d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "76701a179d3a98b07653e2b0409847499b2a07d3",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1779508470,
@@ -1388,7 +1404,8 @@
         "fenix": "fenix_5",
         "flake-utils": "flake-utils_14",
         "flakebox": "flakebox_5",
-        "nixpkgs": "nixpkgs_9"
+        "nixpkgs": "nixpkgs_9",
+        "nixpkgs-playwright": "nixpkgs-playwright"
       }
     },
     "rust-analyzer-src": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1766435619,
-        "narHash": "sha256-3A5Z5K28YB45REOHMWtyQ24cEUXW76MOtbT6abPrARE=",
+        "lastModified": 1777660670,
+        "narHash": "sha256-C8hgon8MOPJWA67TH1PHEziDwpsSdJN2CpFdKTwb6ZI=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "a98dbc80b16730a64c612c6ab5d5fecb4ebb79ba",
+        "rev": "20377f44edabca7c4a765ccdcd05935331b6191f",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     "advisory-db_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1774906818,
-        "narHash": "sha256-COucnjXdgN4H1Ze1EIAxmdrv2CtGKIAMv9Fp9GCMMf0=",
+        "lastModified": 1777660670,
+        "narHash": "sha256-C8hgon8MOPJWA67TH1PHEziDwpsSdJN2CpFdKTwb6ZI=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "4d2c416daab78050bd9bf5d84e3d91c43d7b04c9",
+        "rev": "20377f44edabca7c4a765ccdcd05935331b6191f",
         "type": "github"
       },
       "original": {
@@ -67,24 +67,28 @@
         ]
       },
       "locked": {
-        "lastModified": 1727381935,
-        "narHash": "sha256-G2fOYRZM7bXK5eBb+GK3k/WmO+q5JA/GtFwSPc3kdc8=",
+        "lastModified": 1749500520,
+        "narHash": "sha256-4OEhpqY3kQ4DklONf0O1+OWsfpWGQAXmnvqdTeJYd54=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "522d86121cbd413aff922c54f38106ecf8740107",
+        "rev": "7dc07be20c7a516cc7490969c4072ff692fb1b27",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "522d86121cbd413aff922c54f38106ecf8740107",
+        "rev": "7dc07be20c7a516cc7490969c4072ff692fb1b27",
         "type": "github"
       }
     },
     "android-nixpkgs_3": {
       "inputs": {
         "devshell": "devshell_3",
-        "flake-utils": "flake-utils_7",
+        "flake-utils": [
+          "fedimint",
+          "flakebox",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "fedimint",
           "flakebox",
@@ -92,24 +96,24 @@
         ]
       },
       "locked": {
-        "lastModified": 1762287806,
-        "narHash": "sha256-tmF7Fm2VNukLV32w60QiFLDJB4cO26lhKdDLR8k1BX0=",
+        "lastModified": 1774654405,
+        "narHash": "sha256-71jT3XLRInSfbXiBgucWwEufe79N3i5FgAAJ1jCiQWg=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "rev": "0afc63ee6baf0914918169427744cc09ee651ebc",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "rev": "0afc63ee6baf0914918169427744cc09ee651ebc",
         "type": "github"
       }
     },
     "android-nixpkgs_4": {
       "inputs": {
         "devshell": "devshell_4",
-        "flake-utils": "flake-utils_11",
+        "flake-utils": "flake-utils_10",
         "nixpkgs": [
           "fedimint-wasm",
           "cargo-deluxe",
@@ -135,7 +139,11 @@
     "android-nixpkgs_5": {
       "inputs": {
         "devshell": "devshell_5",
-        "flake-utils": "flake-utils_14",
+        "flake-utils": [
+          "fedimint-wasm",
+          "flakebox",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "fedimint-wasm",
           "flakebox",
@@ -143,17 +151,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1762287806,
-        "narHash": "sha256-tmF7Fm2VNukLV32w60QiFLDJB4cO26lhKdDLR8k1BX0=",
+        "lastModified": 1774654405,
+        "narHash": "sha256-71jT3XLRInSfbXiBgucWwEufe79N3i5FgAAJ1jCiQWg=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "rev": "0afc63ee6baf0914918169427744cc09ee651ebc",
         "type": "github"
       },
       "original": {
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "d3cbdd2a82b3d054b4e283d28ba27548186a88e7",
+        "rev": "0afc63ee6baf0914918169427744cc09ee651ebc",
         "type": "github"
       }
     },
@@ -236,23 +244,23 @@
         ]
       },
       "locked": {
-        "lastModified": 1729202329,
-        "narHash": "sha256-lltxyfay1Vg1CmcAU/r3kOCQs7/WdK22YKORAgzmXkg=",
+        "lastModified": 1771736449,
+        "narHash": "sha256-lTd7RKO/QFGZyfzgtJmBhda+Nj3YBBCbPED6MEruq40=",
         "owner": "rustshop",
         "repo": "cargo-deluxe",
-        "rev": "4acc6488d02f032434a5a1341f21f20d328bba40",
+        "rev": "3e9bb6051a6461dd841d5e415de9c3f315c3be81",
         "type": "github"
       },
       "original": {
         "owner": "rustshop",
         "repo": "cargo-deluxe",
-        "rev": "4acc6488d02f032434a5a1341f21f20d328bba40",
+        "rev": "3e9bb6051a6461dd841d5e415de9c3f315c3be81",
         "type": "github"
       }
     },
     "cargo-deluxe_2": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
+        "flake-utils": "flake-utils_9",
         "flakebox": "flakebox_3",
         "nixpkgs": [
           "fedimint-wasm",
@@ -275,84 +283,6 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "fedimint",
-          "cargo-deluxe",
-          "flakebox",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717383740,
-        "narHash": "sha256-559HbY4uhNeoYvK3H6AMZAtVfmR3y8plXZ1x6ON/cWU=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "b65673fce97d277934488a451724be94cc62499a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "b65673fce97d277934488a451724be94cc62499a",
-        "type": "github"
-      }
-    },
-    "crane_2": {
-      "locked": {
-        "lastModified": 1758758545,
-        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "ref": "v0.21.1",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_3": {
-      "locked": {
-        "lastModified": 1755993354,
-        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_4": {
-      "locked": {
-        "lastModified": 1755993354,
-        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_5": {
-      "inputs": {
-        "nixpkgs": [
-          "fedimint-wasm",
-          "cargo-deluxe",
-          "flakebox",
-          "nixpkgs"
-        ]
-      },
       "locked": {
         "lastModified": 1745454774,
         "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
@@ -368,53 +298,85 @@
         "type": "github"
       }
     },
-    "crane_6": {
+    "crane_2": {
       "locked": {
-        "lastModified": 1771121070,
-        "narHash": "sha256-aIlv7FRXF9q70DNJPI237dEDAznSKaXmL5lfK/Id/bI=",
+        "lastModified": 1776394852,
+        "narHash": "sha256-K0i9GoNk2To1RQkW348EY4c7RYf3mD74hWlGSc/9sk0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a2812c19f1ed2e5ed5ce2ef7109798b575c180e1",
+        "rev": "db220b8709cea4bd43c9adcd4192f212fb6768d1",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
-        "ref": "v0.23.1",
+        "ref": "v0.23.3",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_3": {
+      "locked": {
+        "lastModified": 1774313767,
+        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_4": {
+      "locked": {
+        "lastModified": 1745454774,
+        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "type": "github"
+      }
+    },
+    "crane_5": {
+      "locked": {
+        "lastModified": 1776394852,
+        "narHash": "sha256-K0i9GoNk2To1RQkW348EY4c7RYf3mD74hWlGSc/9sk0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "db220b8709cea4bd43c9adcd4192f212fb6768d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.23.3",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_6": {
+      "locked": {
+        "lastModified": 1774313767,
+        "narHash": "sha256-hy0XTQND6avzGEUFrJtYBBpFa/POiiaGBr2vpU6Y9tY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "3d9df76e29656c679c744968b17fbaf28f0e923d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
         "repo": "crane",
         "type": "github"
       }
     },
     "crane_7": {
-      "locked": {
-        "lastModified": 1755993354,
-        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_8": {
-      "locked": {
-        "lastModified": 1755993354,
-        "narHash": "sha256-FCRRAzSaL/+umLIm3RU3O/+fJ2ssaPHseI2SSFL8yZU=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "25bd41b24426c7734278c2ff02e53258851db914",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
-    "crane_9": {
       "locked": {
         "lastModified": 1776394852,
         "narHash": "sha256-K0i9GoNk2To1RQkW348EY4c7RYf3mD74hWlGSc/9sk0=",
@@ -486,11 +448,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -508,7 +470,7 @@
           "android-nixpkgs",
           "nixpkgs"
         ],
-        "systems": "systems_12"
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1695195896,
@@ -534,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -579,20 +541,20 @@
         "flakebox": "flakebox_2",
         "nixpkgs": "nixpkgs_4",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "wild": "wild_2"
+        "wild": "wild"
       },
       "locked": {
-        "lastModified": 1768965582,
-        "narHash": "sha256-x2AC5SLXVqwV/1wNhDzfjfAPFH3ByOyGh5ogbOjSJ2k=",
+        "lastModified": 1787776384,
+        "narHash": "sha256-t8WmVSL2IQoMdifKQxUeC1yF14jutoB+hAleR8/f1ps=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "76f6c7ce5435a609a256d58b0924161c5fc9b3ec",
+        "rev": "6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
-        "ref": "v0.10.0",
         "repo": "fedimint",
+        "rev": "6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff",
         "type": "github"
       }
     },
@@ -602,24 +564,24 @@
         "bundlers": "bundlers_2",
         "cargo-deluxe": "cargo-deluxe_2",
         "fenix": "fenix_4",
-        "flake-utils": "flake-utils_13",
+        "flake-utils": "flake-utils_12",
         "flakebox": "flakebox_4",
         "nixpkgs": "nixpkgs_8",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "wild": "wild_4"
+        "wild": "wild_2"
       },
       "locked": {
-        "lastModified": 1779209232,
-        "narHash": "sha256-X8tW55Sc306zYM6L+ISPpLienb0kGLnyv/Y0E90DzIY=",
+        "lastModified": 1787776384,
+        "narHash": "sha256-t8WmVSL2IQoMdifKQxUeC1yF14jutoB+hAleR8/f1ps=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "382afc209c80e5445c65ccfabd37edf282669291",
+        "rev": "6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "382afc209c80e5445c65ccfabd37edf282669291",
+        "rev": "6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff",
         "type": "github"
       }
     },
@@ -656,16 +618,17 @@
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
-        "lastModified": 1757659051,
-        "narHash": "sha256-pQfaow3cp1YJtV0JZiz8jC4Y8VQjT4CYZ3OAfFe41Zs=",
+        "lastModified": 1770708269,
+        "narHash": "sha256-OnZW86app7hHJJoB5lC9GNXY5QBBIESJB+sIdwEyld0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "9479f6dd16e83add0ef0186662d65e7763b37ebe",
+        "rev": "6b5325a017a9a9fe7e6252ccac3680cc7181cd63",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
+        "rev": "6b5325a017a9a9fe7e6252ccac3680cc7181cd63",
         "type": "github"
       }
     },
@@ -758,7 +721,7 @@
     },
     "flake-utils_10": {
       "inputs": {
-        "systems": "systems_11"
+        "systems": "systems_12"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -775,24 +738,6 @@
       }
     },
     "flake-utils_11": {
-      "inputs": {
-        "systems": "systems_13"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_12": {
       "inputs": {
         "systems": [
           "fedimint-wasm",
@@ -815,9 +760,31 @@
         "type": "github"
       }
     },
+    "flake-utils_12": {
+      "inputs": {
+        "systems": "systems_14"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flake-utils_13": {
       "inputs": {
-        "systems": "systems_15"
+        "systems": [
+          "fedimint-wasm",
+          "flakebox",
+          "systems"
+        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -852,46 +819,6 @@
       }
     },
     "flake-utils_15": {
-      "inputs": {
-        "systems": [
-          "fedimint-wasm",
-          "flakebox",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_16": {
-      "inputs": {
-        "systems": "systems_18"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_17": {
       "inputs": {
         "systems": [
           "flakebox",
@@ -1006,24 +933,6 @@
     },
     "flake-utils_7": {
       "inputs": {
-        "systems": "systems_8"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_8": {
-      "inputs": {
         "systems": [
           "fedimint",
           "flakebox",
@@ -1044,13 +953,31 @@
         "type": "github"
       }
     },
-    "flake-utils_9": {
+    "flake-utils_8": {
       "locked": {
         "lastModified": 1623875721,
         "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_9": {
+      "inputs": {
+        "systems": "systems_10"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -1069,16 +996,17 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1728662483,
-        "narHash": "sha256-phVyjjgVmHFUF6+DGFRA+1fCV0zs8ipwRn/M33LtIYY=",
+        "lastModified": 1755720430,
+        "narHash": "sha256-oDgZKL9U5RExRgmoTAmy+H+wZaN2/mHBPitT5Hnv1ic=",
         "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "1a65534520d8a592fd7d75f7db18cfed40fa5c09",
+        "rev": "2f15f65d60c198fe49d849d68c2a2c95dc771ae5",
         "type": "github"
       },
       "original": {
         "owner": "rustshop",
         "repo": "flakebox",
+        "rev": "2f15f65d60c198fe49d849d68c2a2c95dc771ae5",
         "type": "github"
       }
     },
@@ -1090,37 +1018,36 @@
           "fedimint",
           "fenix"
         ],
-        "flake-utils": "flake-utils_8",
+        "flake-utils": "flake-utils_7",
         "nixpkgs": [
           "fedimint",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ],
-        "systems": "systems_9",
-        "wild": "wild"
+        "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1768010000,
-        "narHash": "sha256-/oUVHAj020wdMzgmBtojT58hwHkS9/CoHp/2x1k6dEE=",
-        "owner": "dpc",
+        "lastModified": 1785380176,
+        "narHash": "sha256-38BJhZV6ILSu4Sz3PdZsmYMZDTxvikFJXv2stjfDVw0=",
+        "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
+        "rev": "b36f6b7cb77652c1d4cb7279d8f47fddf07066ae",
         "type": "github"
       },
       "original": {
-        "owner": "dpc",
+        "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "3e20ed1239ea83da3790ae2f2d207b508b429c2b",
+        "rev": "b36f6b7cb77652c1d4cb7279d8f47fddf07066ae",
         "type": "github"
       }
     },
     "flakebox_3": {
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_4",
-        "crane": "crane_5",
+        "crane": "crane_4",
         "fenix": "fenix_3",
-        "flake-utils": "flake-utils_12",
+        "flake-utils": "flake-utils_11",
         "nixpkgs": "nixpkgs_7",
-        "systems": "systems_14"
+        "systems": "systems_13"
       },
       "locked": {
         "lastModified": 1755720430,
@@ -1140,46 +1067,45 @@
     "flakebox_4": {
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_5",
-        "crane": "crane_6",
+        "crane": "crane_5",
         "fenix": [
           "fedimint-wasm",
           "fenix"
         ],
-        "flake-utils": "flake-utils_15",
+        "flake-utils": "flake-utils_13",
         "nixpkgs": [
           "fedimint-wasm",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ],
-        "systems": "systems_17",
-        "wild": "wild_3"
+        "systems": "systems_15"
       },
       "locked": {
-        "lastModified": 1771959411,
-        "narHash": "sha256-klo6EjxtQfCoVwcNhJfUag4tf+u4Z+qhC7BqvzqAqHM=",
-        "owner": "dpc",
+        "lastModified": 1785380176,
+        "narHash": "sha256-38BJhZV6ILSu4Sz3PdZsmYMZDTxvikFJXv2stjfDVw0=",
+        "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "d4f37f5d9508b85cd020e3f7d3aa966725457a61",
+        "rev": "b36f6b7cb77652c1d4cb7279d8f47fddf07066ae",
         "type": "github"
       },
       "original": {
-        "owner": "dpc",
+        "owner": "rustshop",
         "repo": "flakebox",
-        "rev": "d4f37f5d9508b85cd020e3f7d3aa966725457a61",
+        "rev": "b36f6b7cb77652c1d4cb7279d8f47fddf07066ae",
         "type": "github"
       }
     },
     "flakebox_5": {
       "inputs": {
         "android-nixpkgs": "android-nixpkgs_6",
-        "crane": "crane_9",
+        "crane": "crane_7",
         "fenix": [
           "fenix"
         ],
-        "flake-utils": "flake-utils_17",
+        "flake-utils": "flake-utils_15",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_19"
+        "systems": "systems_17"
       },
       "locked": {
         "lastModified": 1776404855,
@@ -1263,7 +1189,7 @@
     },
     "nix-utils_2": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
+        "flake-utils": "flake-utils_8",
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
@@ -1297,33 +1223,33 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1762605048,
-        "narHash": "sha256-prkwN3TKiG1T7Qi4PwAknD6h8iLapgqt4nfyUdsVFKg=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
         "type": "github"
       }
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1762605048,
-        "narHash": "sha256-prkwN3TKiG1T7Qi4PwAknD6h8iLapgqt4nfyUdsVFKg=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "rev": "d157ecd9b559c9103c4d69904277c37e062344bf",
         "type": "github"
       }
     },
@@ -1345,32 +1271,32 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1758216857,
+        "narHash": "sha256-h1BW2y7CY4LI9w61R02wPaOYfmYo82FyRqHIwukQ6SY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "d2ed99647a4b195f0bcc440f76edfa10aeb3b743",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1766473571,
-        "narHash": "sha256-5G1NDO2PulBx1RoaA6U1YoUDX0qZslpPxv+n5GX6Qto=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "76701a179d3a98b07653e2b0409847499b2a07d3",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1424,16 +1350,16 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1775002709,
-        "narHash": "sha256-d3Yx83vSrN+2z/loBh4mJpyRqr9aAJqlke4TkpFmRJA=",
+        "lastModified": 1785133411,
+        "narHash": "sha256-Yjv0WEg39KRYS0rBdTbu6Fc/or/ihAKk13W9sQ6VWd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bcd464ccd2a1a7cd09aa2f8d4ffba83b761b1d0e",
+        "rev": "2f5a153c270b70cb0f8c11f46d96d6d3bc39f4e3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1460,7 +1386,7 @@
         "fedimint": "fedimint",
         "fedimint-wasm": "fedimint-wasm",
         "fenix": "fenix_5",
-        "flake-utils": "flake-utils_16",
+        "flake-utils": "flake-utils_14",
         "flakebox": "flakebox_5",
         "nixpkgs": "nixpkgs_9"
       }
@@ -1485,11 +1411,11 @@
     "rust-analyzer-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1757362324,
-        "narHash": "sha256-/PAhxheUq4WBrW5i/JHzcCqK5fGWwLKdH6/Lu1tyS18=",
+        "lastModified": 1770668050,
+        "narHash": "sha256-Q05yaIZtQrBKHpyWaPmyJmDRj0lojnVf8nUFE0vydcY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "9edc9cbe5d8e832b5864e09854fa94861697d2fd",
+        "rev": "9efc1f709f3c8134c3acac5d3592a8e4c184a0c6",
         "type": "github"
       },
       "original": {
@@ -1685,36 +1611,6 @@
         "type": "github"
       }
     },
-    "systems_18": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_19": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "systems_2": {
       "locked": {
         "lastModified": 1681028828,
@@ -1855,7 +1751,7 @@
     },
     "utils_2": {
       "inputs": {
-        "systems": "systems_10"
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -1876,87 +1772,43 @@
         "crane": "crane_3",
         "nixpkgs": [
           "fedimint",
-          "flakebox",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
-        "lastModified": 1762215977,
-        "narHash": "sha256-x0IZuWjj0LRMj4pu2FVaD8SENm/UVtE1e4rl0EOZZZM=",
+        "lastModified": 1779575783,
+        "narHash": "sha256-v4lPgZDPvRTAekkU9Vku9llgpOsaVtKt91VFUGrEeKw=",
         "owner": "davidlattimore",
         "repo": "wild",
-        "rev": "7daaf0c89f7b4b9c9ded36e7b3c72aa6512537a1",
+        "rev": "318af2cef56fbfe81b6ac6985406bf7891dcf08d",
         "type": "github"
       },
       "original": {
         "owner": "davidlattimore",
-        "ref": "0.7.0",
+        "ref": "0.9.0",
         "repo": "wild",
         "type": "github"
       }
     },
     "wild_2": {
       "inputs": {
-        "crane": "crane_4",
-        "nixpkgs": [
-          "fedimint",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762215977,
-        "narHash": "sha256-x0IZuWjj0LRMj4pu2FVaD8SENm/UVtE1e4rl0EOZZZM=",
-        "owner": "davidlattimore",
-        "repo": "wild",
-        "rev": "7daaf0c89f7b4b9c9ded36e7b3c72aa6512537a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davidlattimore",
-        "repo": "wild",
-        "type": "github"
-      }
-    },
-    "wild_3": {
-      "inputs": {
-        "crane": "crane_7",
+        "crane": "crane_6",
         "nixpkgs": [
           "fedimint-wasm",
-          "nixpkgs"
+          "nixpkgs-unstable"
         ]
       },
       "locked": {
-        "lastModified": 1775089439,
-        "narHash": "sha256-Ef2A6YON5N9GsapHg0Tvidig5Fn2kZxHo9NdqzEA6vk=",
+        "lastModified": 1779575783,
+        "narHash": "sha256-v4lPgZDPvRTAekkU9Vku9llgpOsaVtKt91VFUGrEeKw=",
         "owner": "davidlattimore",
         "repo": "wild",
-        "rev": "9a7ad7cb05bce0487a7089bffe95452b43d07cfb",
+        "rev": "318af2cef56fbfe81b6ac6985406bf7891dcf08d",
         "type": "github"
       },
       "original": {
         "owner": "davidlattimore",
-        "repo": "wild",
-        "type": "github"
-      }
-    },
-    "wild_4": {
-      "inputs": {
-        "crane": "crane_8",
-        "nixpkgs": [
-          "fedimint-wasm",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775089439,
-        "narHash": "sha256-Ef2A6YON5N9GsapHg0Tvidig5Fn2kZxHo9NdqzEA6vk=",
-        "owner": "davidlattimore",
-        "repo": "wild",
-        "rev": "9a7ad7cb05bce0487a7089bffe95452b43d07cfb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "davidlattimore",
+        "ref": "0.9.0",
         "repo": "wild",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,13 @@
       # tested against come from the same commit.
       url = "github:fedimint/fedimint?rev=6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff";
     };
+    nixpkgs-playwright = {
+      # Playwright browsers have to match the `playwright` version pnpm-lock.yaml
+      # resolves (1.56.1), which is why they get their own pin instead of coming
+      # from whichever nixpkgs the fedimint input happens to carry: bumping that
+      # input moved the browsers to 1.59.1 and the tests could not find them.
+      url = "github:NixOS/nixpkgs/76701a179d3a98b07653e2b0409847499b2a07d3";
+    };
     # nixpkgs, fenix, flakebox and android-nixpkgs feed the FFI cross-compile
     # derivations in nix/ffi.nix (see #androidBundle / #iosBundle). Pinned to
     # the same revisions the fedimint-sdk-ffi repo's flake.lock used before it
@@ -45,6 +52,7 @@
       fedimint,
       fedimint-wasm,
       nixpkgs,
+      nixpkgs-playwright,
       fenix,
       flakebox,
       android-nixpkgs,
@@ -62,6 +70,10 @@
             android_sdk.accept_license = true;
           };
         };
+        # Kept separate from `pkgs` on purpose: these have to match the
+        # `playwright` version in pnpm-lock.yaml, not the fedimint bump.
+        playwrightBrowsers =
+          (import nixpkgs-playwright { inherit system; }).playwright-driver.browsers;
         # No emulator system images: nothing in this repo runs an emulator, and
         # each ABI's image adds gigabytes to the dev shell closure.
         androidSdk = pkgs.androidenv.composeAndroidPackages {
@@ -152,11 +164,11 @@
             pkgs.which
             pkgs.go
             pkgs.libclang
-            pkgs.playwright-driver.browsers
+            playwrightBrowsers
           ];
 
           wasmShellHook = ''
-            export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+            export PLAYWRIGHT_BROWSERS_PATH=${playwrightBrowsers}
             export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
             export LIBCLANG_PATH="${pkgs.libclang.lib}/lib"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,16 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     fedimint = {
-      # Devimint input - Should point to a release tag, as it doesn't need to be updated often.
-      url = "github:fedimint/fedimint/v0.10.0";
+      # Devimint input - should point to a release tag, as it doesn't need to be
+      # updated often. On a master revision for now: the fixes for the CI
+      # flakiness this repo tracks (#330, #340) are not in any tag yet.
+      url = "github:fedimint/fedimint?rev=6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff";
     };
     fedimint-wasm = {
-         url = "github:fedimint/fedimint?rev=382afc209c80e5445c65ccfabd37edf282669291";
-         
+      # The wasm client is built from this revision; keep it in sync with the
+      # devimint input above, so that the client and the federation it is
+      # tested against come from the same commit.
+      url = "github:fedimint/fedimint?rev=6ba0479a96dfc95b0fa2fbf4f010b6cf9ee976ff";
     };
     # nixpkgs, fenix, flakebox and android-nixpkgs feed the FFI cross-compile
     # derivations in nix/ffi.nix (see #androidBundle / #iosBundle). Pinned to

--- a/scripts/setup_test_shell.sh
+++ b/scripts/setup_test_shell.sh
@@ -2,6 +2,18 @@
 
 set -euo pipefail
 
+# This SDK speaks the v1 mint, wallet and lightning modules, and fedimint has
+# made all three opt-in while defaulting to their v2 counterparts, so ask for a
+# federation that has them. The v2 modules are switched off rather than left
+# alongside: in a federation carrying both, devimint's own gateway peg-in never
+# completes and the setup dies with "Polling gateway pegin claim failed".
+export FM_ENABLE_MODULE_MINT=1
+export FM_ENABLE_MODULE_WALLET=1
+export FM_ENABLE_MODULE_LNV1=1
+export FM_ENABLE_MODULE_MINTV2=0
+export FM_ENABLE_MODULE_WALLETV2=0
+export FM_ENABLE_MODULE_LNV2=0
+
 # devimint now allocates a free faucet port per run and fails the setup if it cannot
 # bind it, so concurrent runs no longer collide (see issue #340). Only a port pinned
 # through FM_FAUCET_PORT can still be occupied by a stale or concurrent devimint, so

--- a/scripts/setup_test_shell.sh
+++ b/scripts/setup_test_shell.sh
@@ -2,12 +2,13 @@
 
 set -euo pipefail
 
-# devimint's faucet listens on a fixed port (hard-coded upstream). If a stale or
-# concurrent devimint already occupies it, devimint only logs the bind failure and its
-# startup probe happily connects to the foreign listener — the tests then run against
-# the wrong federation and fail with confusing fetch errors (see issue #340). Wait for
-# the port to be free, and fail fast with a diagnostic if it never frees up.
-faucet_port="${FM_PORT_FAUCET:-15243}"
+# devimint now allocates a free faucet port per run and fails the setup if it cannot
+# bind it, so concurrent runs no longer collide (see issue #340). Only a port pinned
+# through FM_FAUCET_PORT can still be occupied by a stale or concurrent devimint, so
+# wait for that one, and fail fast with a diagnostic if it never frees up. (devimint
+# reports whichever port it ended up with as FM_PORT_FAUCET, which is what the tests
+# read; that one is set by devimint itself, not by whoever runs this script.)
+faucet_port="${FM_FAUCET_PORT:-}"
 
 # The tests fetch from `localhost`, which may resolve to either loopback address, so a
 # squatter on either one counts as occupied. `timeout` bounds a probe that would
@@ -23,7 +24,7 @@ faucet_port_in_use() {
 }
 
 deadline=$((SECONDS + 120))
-while faucet_port_in_use; do
+while [ -n "$faucet_port" ] && faucet_port_in_use; do
   if ((SECONDS >= deadline)); then
     echo "error: faucet port ${faucet_port} is still in use;" \
       "is a stale or concurrent devimint running on this machine?" >&2


### PR DESCRIPTION
### Summary

The fixes for both tracked CI flakes are merged upstream, but this repo builds its wasm client from a May revision of fedimint and runs devimint from `v0.10.0`, so CI has been running without them. Bump both flake inputs to the fedimint revision that carries them. Closes #330, closes #340.

### Details

- **#330** — `generateAddress` timing out after the worker died with a bare `RuntimeError: unreachable` is fedimint#9046, fixed by fedimint#9059: `WalletClientModule::supports_safe_deposit()` and the wallet module's background version poller both stored the same marker with the panicking commit while holding the transaction across a network round trip, so right after `join_federation` whichever committed second panicked on a routine write conflict. fedimint#9052 also installs a panic hook in the wasm client, so the next panic there arrives with its message instead of a bare trap.
- **#340** — the faucet failing to bind and every test then fetching against a foreign federation is fedimint#9044, fixed by fedimint#9047: devimint allocates a free faucet port per run, exports it as `FM_PORT_FAUCET` (which `vitest.config.ts` already follows since #350), and fails the setup if it cannot bind it instead of only logging.
- The teardown aborts that ended failing runs with `Aborted (core dumped)` and orphaned daemons on the runner are fixed too (fedimint#9053 and fedimint#9065, by fedimint#9062 and fedimint#9068).

No release tag carries the last three yet — `v0.12.0-rc.0` was cut just before them — so the devimint input points at a master revision for now, which the next tag can replace. Both inputs share that revision, so the wasm client and the federation it is tested against come from the same commit; as a side effect the two fedimint trees in `flake.lock` collapse into one (~144 lines smaller).

The third commit fixes the one thing the bump broke: the wasm test shell took `playwright-driver.browsers` from whichever nixpkgs the `fedimint` input carries, and that only worked because it happened to ship the same Playwright version `pnpm-lock.yaml` resolves. With the bump the browsers moved to 1.59.1 (firefox-1495 → firefox-1511) while `playwright-core` stayed at 1.56.1, so vitest could not launch a browser and `Verify / Test` failed before running a single test. The browsers now have their own nixpkgs pin, chosen so its revisions (chromium-1194, firefox-1495, webkit-2215, ffmpeg-1011) are exactly the ones `playwright-core@1.56.1` asks for.

The fourth commit handles the bigger thing the bump surfaced: **fedimint made the v1 `mint`, `wallet` and `ln` modules opt-in back in April**, and a default federation is now `mintv2 + walletv2 + lnv2 + meta`. This SDK's client is v1-only, so the bumped devimint gave it a federation with none of the modules it uses — first `No modules found of kind ln`, then the same for `wallet` and `mint`. Enabling the v1 modules alone was not enough either: in a federation carrying both generations, devimint's own gateway peg-in never completes and `wasm-test-setup` dies with `Polling gateway pegin claim failed after 159 retries`. The setup now asks for a v1-only federation; verified against the bumped devimint that `wasm-test-setup` then completes and the generated client config carries exactly `ln`, `mint`, `wallet` and `meta` (and that the faucet takes a dynamic port).

Worth being explicit about the consequence: this pins the SDK's test federation to a configuration upstream no longer produces by default, and no tag avoids it — `v0.11.2` still defaults to v1 but predates the faucet fix, while every `v0.12.x` is already v2-by-default. **Moving this client to the v2 modules is the real follow-up**, and it is now on a clock rather than optional.

The second commit scopes the faucet-port wait in `setup_test_shell.sh` to an explicitly pinned `FM_PORT_FAUCET`: with dynamic ports the default it waited for is a port nothing uses any more, and an unrelated listener on 15243 would fail the run for no reason.

### Reviewing

- The `fedimint` input also supplies nixpkgs and the daemons for the dev shells, so this bump moves those too (v0.10.0 → master); the dev shells and the wasm bundle build fine here, and the full test suite passes locally — see below.
- The React Native / FFI side is untouched: `fedimint-client-uniffi` depends on the published `0.11.1` crates and `nix/ffi.nix` has its own nixpkgs/fenix pins. It therefore still carries the peg-in crash until a fedimint release ships fedimint#9059 — including the opt-in native repro added in #355 (`REPRO_INVITE_CODE`), which will keep reproducing until then.
- The Playwright pin is coupled to `pnpm-lock.yaml`: whenever the `playwright` version there changes, `nixpkgs-playwright` has to move to a revision shipping that same driver. The comment in `flake.nix` says so; CI catches it immediately if it drifts, as it just did.
- Now that the faucet port is dynamic, the `concurrency: devimint-tests` group in `verify.yml` (added in #350 explicitly "until the port is dynamic upstream") can be dropped to get parallel test jobs back. Left in place here so this PR stays a bump; happy to add the removal if you want it in the same change.

### Testing

Locally, in this repo: `nix flake lock` re-locks cleanly, `pnpm build:wasm` builds the bundle from the new revision (11.3 MB wasm for both `wasm-web` and `wasm-bundler`), and the `.#wasm-tests` shell brings up `devimint`/`fedimintd`/`gatewayd` `0.13.0-alpha`. `prettier --check .` passes.

CI on this PR earned its keep twice: the first run caught the Playwright mismatch (browsers not found, 0 tests run), the second got the browsers working and then failed every Lightning/funding test with `No modules found of kind ln`. Commits three and four fix those; the fourth took three rounds (LNv1, then `mint`/`wallet` too, then switching the v2 modules off), each verified locally against the bumped devimint before pushing.

I could not run the JS suite here: `pnpm` fails on this machine with `[ERROR] unable to open database file` even for `pnpm --version` (the dev shell ships pnpm 11.17.0 while `packageManager` pins 11.22.0, and the corepack/store databases under `~/.cache/pnpm` and `~/.local/share/pnpm` are unhappy). That is unrelated to this change — it reproduces on `main` — so the integration suite is left to CI here.
