### PR TITLE
Stop serializing the devimint-backed test jobs

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,13 +77,6 @@ jobs:
     name: Test
     runs-on: [self-hosted, linux, x64]
     timeout-minutes: 45
-    # devimint's faucet listens on a fixed port (15243, hard-coded upstream), so two of
-    # these jobs on the same host race for it and the loser's tests talk to the winner's
-    # federation. Serialize all devimint-backed test jobs until the port is dynamic.
-    # See https://github.com/fedimint/fedimint-sdk/issues/340.
-    concurrency:
-      group: devimint-tests
-      queue: max
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
The `Test` job carried a `devimint-tests` concurrency group so only one devimint-backed run could touch a self-hosted runner at a time. The reason was the faucet: devimint hard-coded it to port 15243, so a second job's faucet failed to bind and its tests silently talked to the first job's federation (#340).

That is fixed upstream and pinned here since #358 — devimint now allocates a free faucet port per run and fails the setup if it cannot bind it. Every other port devimint opens already goes through `fedimint-portalloc`, which coordinates across processes with a lock file plus a real `bind`, and vitest's browser server walks up from 63315 when that port is occupied, so nothing else in the job is pinned to a fixed port either.

Net effect: PRs stop queueing behind each other for up to 45 minutes apiece.

Generated by Claude Opus 5.