### PR TITLE
Stop retrying the integration tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,14 +19,6 @@ export default defineConfig({
           name: 'integration-tests',
           include: ['packages/integration-tests/**/*.test.ts'],
           exclude: ['packages/create-fedimint-app/**/*.test.ts'],
-          // These tests run against a live devimint federation and a fresh
-          // wallet per test, so they can hit transient failures — most notably
-          // a wasm client crash when an RPC lands right after joining the
-          // federation (issues #330/#340). Fixtures re-run on retry, so each
-          // attempt gets a fresh worker and wallet. NOTE: config-level retry
-          // works for test.extend-based tests; per-test `{ retry }` options are
-          // silently ignored for them (vitest 3.2.x).
-          retry: 2,
           browser: {
             enabled: true,
             provider: playwright(),


### PR DESCRIPTION
`retry: 2` on the `integration-tests` project came in with #350, as a blanket over two known bugs: the wasm client crashing when an RPC landed right after joining a federation (#330), and the faucet port collision (#340). Both are fixed upstream and pinned here since #358.

What the retry buys now is silence. If either bug returns, or a new one takes their place, the suite still goes green on the second attempt and nobody finds out until it fails three times in a row.

For what it's worth, the `Verify / Test` run on #359 needed no retries at all: 10/10 test files, 79.5s, no retry markers in the log.

I'll re-run the Test job on this branch a few times before this is merged, to check that a green run is the norm rather than the lucky case. That's cheap now that #359 removed the serialization — the reruns don't block anyone else's PR.

Generated by Claude Opus 5.