### PR TITLE
feat(sdk): error details envelope codec (T3)

### DIFF
--- a/js/.changeset/error-details-envelope-codec.md
+++ b/js/.changeset/error-details-envelope-codec.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core': patch
+---
+
+Implement error details envelope codec for length-delimited binary serialization, strict decoding, and forward-compatible error handling across boundaries (Task T3).

--- a/rust/fedimint-sdk/src/error.rs
+++ b/rust/fedimint-sdk/src/error.rs
@@ -526,6 +526,27 @@ impl RawErrorDetails {
             payload: payload.into(),
         }
     }
+
+    /// Attempts to decode this raw envelope's payload into a typed [`ErrorDetails`].
+    ///
+    /// Returns `Some(detail)` if the `kind` is recognised and the payload decoded
+    /// with exact consumption; returns `None` otherwise.
+    pub fn decode(&self) -> Option<ErrorDetails> {
+        ErrorDetails::decode_payload(&self.kind, &self.payload)
+    }
+
+    /// Converts this raw envelope into a [`DetailEnvelope`], projecting it
+    /// into [`DetailEnvelope::Interpreted`] if decoding succeeds, or preserving it
+    /// as [`DetailEnvelope::Opaque`] if it does not.
+    pub fn to_envelope(self) -> DetailEnvelope {
+        match self.decode() {
+            Some(detail) => DetailEnvelope::Interpreted {
+                detail,
+                producer_version: self.version,
+            },
+            None => DetailEnvelope::Opaque { raw: self },
+        }
+    }
 }
 
 /// An error's structured detail, in whichever of its two states this side
@@ -576,6 +597,28 @@ pub enum DetailEnvelope {
 }
 
 impl DetailEnvelope {
+    /// Projects a [`RawErrorDetails`] into a [`DetailEnvelope`].
+    ///
+    /// Equivalent to [`raw.to_envelope()`](RawErrorDetails::to_envelope).
+    pub fn from_raw(raw: RawErrorDetails) -> DetailEnvelope {
+        raw.to_envelope()
+    }
+
+    /// Converts this envelope into its boundary wire form, [`RawErrorDetails`].
+    ///
+    /// For [`DetailEnvelope::Interpreted`], this re-encodes the typed detail with the
+    /// declared `producer_version`. For [`DetailEnvelope::Opaque`], the original
+    /// raw envelope is returned.
+    pub fn to_raw(&self) -> RawErrorDetails {
+        match self {
+            DetailEnvelope::Interpreted {
+                detail,
+                producer_version,
+            } => detail.to_raw(*producer_version),
+            DetailEnvelope::Opaque { raw } => raw.clone(),
+        }
+    }
+
     /// The stable kind identifier of this detail, projected or not.
     ///
     /// For [`Interpreted`](DetailEnvelope::Interpreted) that is
@@ -865,6 +908,279 @@ impl ErrorDetails {
             | ErrorDetails::StorageInUse { .. }
             | ErrorDetails::SeedMismatch { .. }
             | ErrorDetails::StorageOrphaned { .. } => 1,
+        }
+    }
+
+    /// Encodes this detail's fields into a binary payload per the documented contract.
+    pub fn encode_payload(&self) -> Vec<u8> {
+        let mut w = PayloadWriter::new();
+        match self {
+            ErrorDetails::InsufficientBalance {
+                required,
+                available,
+            } => {
+                w.write_u64(required.msats());
+                w.write_u64(available.msats());
+            }
+            ErrorDetails::NetworkMismatch {
+                expected,
+                compatible,
+                observed_prefix,
+            } => {
+                w.write_str(expected.as_str());
+                w.write_u32(compatible.len() as u32);
+                for net in compatible {
+                    w.write_str(net.as_str());
+                }
+                w.write_str(observed_prefix);
+            }
+            ErrorDetails::MixedModuleGenerations { modules } => {
+                w.write_u32(modules.len() as u32);
+                for m in modules {
+                    w.write_str(&m.kind);
+                    w.write_u32(m.generation);
+                }
+            }
+            ErrorDetails::QuoteExpired {
+                expires_at,
+                already_executed,
+            } => {
+                w.write_u64(expires_at.epoch_millis());
+                w.write_bool(*already_executed);
+            }
+            ErrorDetails::QuoteTermsChanged {
+                quoted_total,
+                current_total,
+            } => {
+                w.write_u64(quoted_total.msats());
+                w.write_u64(current_total.msats());
+            }
+            ErrorDetails::BalanceNotEmpty { remaining } => {
+                w.write_u64(remaining.msats());
+            }
+            ErrorDetails::StorageInUse { location } => {
+                w.write_str(location);
+            }
+            ErrorDetails::SeedMismatch { location } => {
+                w.write_str(location);
+            }
+            ErrorDetails::StorageOrphaned {
+                location,
+                seed_present,
+            } => {
+                w.write_str(location);
+                w.write_bool(*seed_present);
+            }
+        }
+        w.finish()
+    }
+
+    /// Packages this detail as a [`RawErrorDetails`] with the given declared version.
+    pub fn to_raw(&self, version: u32) -> RawErrorDetails {
+        RawErrorDetails::new(version, self.kind(), self.encode_payload())
+    }
+
+    /// Packages this detail as a [`RawErrorDetails`] using [`RawErrorDetails::CURRENT_VERSION`].
+    pub fn to_raw_current(&self) -> RawErrorDetails {
+        self.to_raw(RawErrorDetails::CURRENT_VERSION)
+    }
+
+    /// Decodes a binary payload for a known `kind` into a typed [`ErrorDetails`].
+    ///
+    /// Requires exact, checked consumption: returns `Some(detail)` if `kind` is recognised
+    /// and `payload` matches the frozen layout with no trailing bytes. Returns `None` if
+    /// `kind` is unknown, or if `payload` is truncated, has invalid UTF-8, non-boolean bytes,
+    /// or trailing bytes.
+    pub fn decode_payload(kind: &str, payload: &[u8]) -> Option<ErrorDetails> {
+        let mut r = PayloadReader::new(payload);
+        let detail = match kind {
+            "InsufficientBalance" => {
+                let required = Amount::from_msats(r.read_u64()?);
+                let available = Amount::from_msats(r.read_u64()?);
+                ErrorDetails::InsufficientBalance {
+                    required,
+                    available,
+                }
+            }
+            "NetworkMismatch" => {
+                let expected_str = r.read_str()?;
+                let expected = Network::from_name(expected_str)?;
+                let count = r.read_u32()? as usize;
+                // Not `Vec::with_capacity(count)`: `count` is untrusted wire
+                // input at this point, and reserving it up front would let a
+                // few-byte payload claiming billions of elements demand a
+                // huge allocation before a single element is validated to
+                // exist. Growing naturally is bounded by how many elements
+                // the payload can actually supply.
+                let mut compatible = Vec::new();
+                for _ in 0..count {
+                    let net_str = r.read_str()?;
+                    if let Some(net) = Network::from_name(net_str) {
+                        // `compatible` is documented as free of duplicates;
+                        // enforce that against untrusted input rather than
+                        // trusting the producer to have upheld it.
+                        if !compatible.contains(&net) {
+                            compatible.push(net);
+                        }
+                    }
+                }
+                let observed_prefix = r.read_str()?.to_string();
+                ErrorDetails::NetworkMismatch {
+                    expected,
+                    compatible,
+                    observed_prefix,
+                }
+            }
+            "MixedModuleGenerations" => {
+                let count = r.read_u32()? as usize;
+                // See the comment on `NetworkMismatch` above: `count` is
+                // untrusted, so it must not size an allocation up front.
+                let mut modules = Vec::new();
+                for _ in 0..count {
+                    let kind = r.read_str()?.to_string();
+                    let generation = r.read_u32()?;
+                    modules.push(ModuleGeneration::new(kind, generation));
+                }
+                // Documented as always having at least two entries, a
+                // conflict needs at least two participants. A payload that
+                // doesn't meet that isn't a valid instance of this kind.
+                if modules.len() < 2 {
+                    return None;
+                }
+                ErrorDetails::MixedModuleGenerations { modules }
+            }
+            "QuoteExpired" => {
+                let expires_at = Timestamp::from_epoch_millis(r.read_u64()?);
+                let already_executed = r.read_bool()?;
+                ErrorDetails::QuoteExpired {
+                    expires_at,
+                    already_executed,
+                }
+            }
+            "QuoteTermsChanged" => {
+                let quoted_total = Amount::from_msats(r.read_u64()?);
+                let current_total = Amount::from_msats(r.read_u64()?);
+                ErrorDetails::QuoteTermsChanged {
+                    quoted_total,
+                    current_total,
+                }
+            }
+            "BalanceNotEmpty" => {
+                let remaining = Amount::from_msats(r.read_u64()?);
+                ErrorDetails::BalanceNotEmpty { remaining }
+            }
+            "StorageInUse" => {
+                let location = r.read_str()?.to_string();
+                ErrorDetails::StorageInUse { location }
+            }
+            "SeedMismatch" => {
+                let location = r.read_str()?.to_string();
+                ErrorDetails::SeedMismatch { location }
+            }
+            "StorageOrphaned" => {
+                let location = r.read_str()?.to_string();
+                let seed_present = r.read_bool()?;
+                ErrorDetails::StorageOrphaned {
+                    location,
+                    seed_present,
+                }
+            }
+            _ => return None,
+        };
+        r.finish()?;
+        Some(detail)
+    }
+}
+
+/// Zero-dependency payload writer implementing the length-delimited wire contract.
+struct PayloadWriter {
+    buf: Vec<u8>,
+}
+
+impl PayloadWriter {
+    fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    fn write_u32(&mut self, val: u32) {
+        self.buf.extend_from_slice(&val.to_be_bytes());
+    }
+
+    fn write_u64(&mut self, val: u64) {
+        self.buf.extend_from_slice(&val.to_be_bytes());
+    }
+
+    fn write_bool(&mut self, val: bool) {
+        self.buf.push(if val { 1 } else { 0 });
+    }
+
+    fn write_str(&mut self, s: &str) {
+        let bytes = s.as_bytes();
+        self.write_u32(bytes.len() as u32);
+        self.buf.extend_from_slice(bytes);
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+/// Zero-dependency payload reader implementing exact, checked wire consumption.
+struct PayloadReader<'a> {
+    slice: &'a [u8],
+}
+
+impl<'a> PayloadReader<'a> {
+    fn new(slice: &'a [u8]) -> Self {
+        Self { slice }
+    }
+
+    fn read_u32(&mut self) -> Option<u32> {
+        if self.slice.len() < 4 {
+            return None;
+        }
+        let (val_bytes, rest) = self.slice.split_at(4);
+        self.slice = rest;
+        Some(u32::from_be_bytes(val_bytes.try_into().ok()?))
+    }
+
+    fn read_u64(&mut self) -> Option<u64> {
+        if self.slice.len() < 8 {
+            return None;
+        }
+        let (val_bytes, rest) = self.slice.split_at(8);
+        self.slice = rest;
+        Some(u64::from_be_bytes(val_bytes.try_into().ok()?))
+    }
+
+    fn read_bool(&mut self) -> Option<bool> {
+        if self.slice.is_empty() {
+            return None;
+        }
+        let b = self.slice[0];
+        self.slice = &self.slice[1..];
+        match b {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }
+    }
+
+    fn read_str(&mut self) -> Option<&'a str> {
+        let len = self.read_u32()? as usize;
+        if self.slice.len() < len {
+            return None;
+        }
+        let (str_bytes, rest) = self.slice.split_at(len);
+        self.slice = rest;
+        core::str::from_utf8(str_bytes).ok()
+    }
+
+    fn finish(self) -> Option<()> {
+        if self.slice.is_empty() {
+            Some(())
+        } else {
+            None
         }
     }
 }
@@ -1772,24 +2088,7 @@ mod tests {
     /// keeps the raw envelope as `Opaque` instead. Nothing here can panic
     /// on boundary input, per the crate's no-panic rule.
     fn project(raw: &RawErrorDetails) -> Option<ErrorDetails> {
-        match raw.kind.as_str() {
-            // `InsufficientBalance` is exactly two big-endian u64
-            // millisatoshi fields, required then available: 16 bytes, no
-            // more and no fewer, checked before anything is read.
-            "InsufficientBalance" => {
-                if raw.payload.len() != 16 {
-                    return None;
-                }
-                let required = u64::from_be_bytes(raw.payload[..8].try_into().ok()?);
-                let available = u64::from_be_bytes(raw.payload[8..16].try_into().ok()?);
-                Some(ErrorDetails::InsufficientBalance {
-                    required: Amount::from_msats(required),
-                    available: Amount::from_msats(available),
-                })
-            }
-            // An unknown kind never looks inside the payload at all.
-            _ => None,
-        }
+        raw.decode()
     }
 
     /// Builds the error a boundary would hand on: the typed case when the
@@ -1797,16 +2096,11 @@ mod tests {
     /// through, never this build's), and the raw envelope kept opaque when
     /// it did not.
     fn project_or_keep_raw(raw: RawErrorDetails) -> Error {
-        match project(&raw) {
-            Some(detail) => Error::with_projected_details(
-                ErrorCode::InsufficientBalance,
-                "balance is short",
-                detail,
-                raw.version,
-            ),
-            None => {
-                Error::with_raw_details(ErrorCode::InsufficientBalance, "balance is short", raw)
-            }
+        let envelope = raw.to_envelope();
+        Error {
+            code: ErrorCode::InsufficientBalance,
+            message: "balance is short".into(),
+            details: Some(envelope),
         }
     }
 
@@ -1966,6 +2260,251 @@ mod tests {
         assert_eq!(shortfall(&unknown), None);
         assert_eq!(
             shortfall(&Error::new(ErrorCode::InsufficientBalance, "short")),
+            None
+        );
+    }
+
+    fn sample_cases() -> Vec<ErrorDetails> {
+        vec![
+            ErrorDetails::InsufficientBalance {
+                required: Amount::from_msats(1_500),
+                available: Amount::from_msats(1_200),
+            },
+            ErrorDetails::NetworkMismatch {
+                expected: Network::Bitcoin,
+                compatible: vec![Network::Testnet4, Network::Signet],
+                observed_prefix: "tb".into(),
+            },
+            ErrorDetails::MixedModuleGenerations {
+                modules: vec![
+                    ModuleGeneration::new("mint", 1),
+                    ModuleGeneration::new("lnv2", 2),
+                ],
+            },
+            ErrorDetails::QuoteExpired {
+                expires_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+                already_executed: true,
+            },
+            ErrorDetails::QuoteExpired {
+                expires_at: Timestamp::from_epoch_millis(1_700_000_000_123),
+                already_executed: false,
+            },
+            ErrorDetails::QuoteTermsChanged {
+                quoted_total: Amount::from_msats(5_000),
+                current_total: Amount::from_msats(5_500),
+            },
+            ErrorDetails::BalanceNotEmpty {
+                remaining: Amount::from_msats(42_000),
+            },
+            ErrorDetails::StorageInUse {
+                location: "/var/data/fedimint-db".into(),
+            },
+            ErrorDetails::SeedMismatch {
+                location: "/var/data/fedimint-db".into(),
+            },
+            ErrorDetails::StorageOrphaned {
+                location: "browser-origin-namespace".into(),
+                seed_present: true,
+            },
+            ErrorDetails::StorageOrphaned {
+                location: "browser-origin-namespace".into(),
+                seed_present: false,
+            },
+        ]
+    }
+
+    #[test]
+    fn all_nine_error_details_variants_round_trip_cleanly() {
+        for original in sample_cases() {
+            let raw = original.to_raw(5);
+            assert_eq!(raw.version, 5);
+            assert_eq!(raw.kind, original.kind());
+
+            let decoded = raw.decode().expect("decodes cleanly");
+            assert_eq!(decoded, original);
+
+            let envelope = DetailEnvelope::from_raw(raw.clone());
+            assert!(envelope.is_interpreted());
+            assert_eq!(envelope.version(), 5);
+            assert_eq!(envelope.typed(), Some(&original));
+
+            let back_to_raw = envelope.to_raw();
+            assert_eq!(back_to_raw, raw);
+        }
+    }
+
+    #[test]
+    fn every_variant_rejects_truncated_payload_and_stays_opaque() {
+        for original in sample_cases() {
+            let payload = original.encode_payload();
+            // Truncate by 1 byte
+            if !payload.is_empty() {
+                let truncated = &payload[..payload.len() - 1];
+                assert_eq!(
+                    ErrorDetails::decode_payload(original.kind(), truncated),
+                    None,
+                    "truncated payload for {} must not decode",
+                    original.kind()
+                );
+
+                let raw = RawErrorDetails::new(1, original.kind(), truncated);
+                let env = raw.to_envelope();
+                assert!(!env.is_interpreted());
+                assert!(matches!(env, DetailEnvelope::Opaque { .. }));
+            }
+        }
+    }
+
+    #[test]
+    fn every_variant_rejects_trailing_bytes_and_stays_opaque() {
+        for original in sample_cases() {
+            let mut payload = original.encode_payload();
+            payload.push(0xFF); // append trailing byte
+            assert_eq!(
+                ErrorDetails::decode_payload(original.kind(), &payload),
+                None,
+                "trailing bytes for {} must not decode",
+                original.kind()
+            );
+
+            let raw = RawErrorDetails::new(1, original.kind(), payload);
+            let env = raw.to_envelope();
+            assert!(!env.is_interpreted());
+            assert!(matches!(env, DetailEnvelope::Opaque { .. }));
+        }
+    }
+
+    #[test]
+    fn invalid_boolean_values_are_uninterpretable() {
+        // QuoteExpired with already_executed = 2 or 255
+        let mut w = PayloadWriter::new();
+        w.write_u64(1_700_000_000_000);
+        let mut payload = w.finish();
+        payload.push(2);
+        assert_eq!(ErrorDetails::decode_payload("QuoteExpired", &payload), None);
+
+        // StorageOrphaned with seed_present = 255
+        let mut w = PayloadWriter::new();
+        w.write_str("test-loc");
+        let mut payload = w.finish();
+        payload.push(255);
+        assert_eq!(
+            ErrorDetails::decode_payload("StorageOrphaned", &payload),
+            None
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_strings_are_uninterpretable() {
+        // StorageInUse with invalid UTF-8
+        let mut w = PayloadWriter::new();
+        w.write_u32(2); // length 2
+        let mut payload = w.finish();
+        payload.extend_from_slice(&[0xFF, 0xFE]); // invalid UTF-8
+        assert_eq!(ErrorDetails::decode_payload("StorageInUse", &payload), None);
+    }
+
+    #[test]
+    fn network_mismatch_filters_unknown_compatible_networks_and_rejects_unknown_expected() {
+        // Unknown expected network -> uninterpretable
+        let mut w = PayloadWriter::new();
+        w.write_str("Dogecoin"); // unknown expected
+        w.write_u32(0);
+        w.write_str("bc");
+        assert_eq!(
+            ErrorDetails::decode_payload("NetworkMismatch", &w.finish()),
+            None
+        );
+
+        // Known expected, but compatible list contains an unnameable network ("Simnet")
+        let mut w = PayloadWriter::new();
+        w.write_str("Bitcoin");
+        w.write_u32(2);
+        w.write_str("Testnet4");
+        w.write_str("Simnet"); // unrepresentable in this SDK's enum
+        w.write_str("bc");
+        let decoded = ErrorDetails::decode_payload("NetworkMismatch", &w.finish())
+            .expect("decodes while safely omitting unnameable compatible network");
+
+        match decoded {
+            ErrorDetails::NetworkMismatch {
+                expected,
+                compatible,
+                observed_prefix,
+            } => {
+                assert_eq!(expected, Network::Bitcoin);
+                assert_eq!(compatible, vec![Network::Testnet4]);
+                assert_eq!(observed_prefix, "bc");
+            }
+            other => panic!("expected NetworkMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn network_mismatch_deduplicates_compatible_networks() {
+        // The field is documented as free of duplicates; the decoder must
+        // enforce that against untrusted input rather than trust the
+        // producer to have upheld it.
+        let mut w = PayloadWriter::new();
+        w.write_str("Bitcoin");
+        w.write_u32(3);
+        w.write_str("Testnet4");
+        w.write_str("Testnet4"); // repeated
+        w.write_str("Signet");
+        w.write_str("bc");
+        let decoded = ErrorDetails::decode_payload("NetworkMismatch", &w.finish())
+            .expect("decodes while deduplicating compatible networks");
+
+        match decoded {
+            ErrorDetails::NetworkMismatch { compatible, .. } => {
+                assert_eq!(compatible, vec![Network::Testnet4, Network::Signet]);
+            }
+            other => panic!("expected NetworkMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_module_generations_rejects_fewer_than_two_modules() {
+        // Documented as always having at least two entries: a conflict needs
+        // at least two participants, so a payload claiming zero or one is not
+        // a valid instance of this kind, however cleanly it decodes.
+        let mut w = PayloadWriter::new();
+        w.write_u32(0);
+        assert_eq!(
+            ErrorDetails::decode_payload("MixedModuleGenerations", &w.finish()),
+            None
+        );
+
+        let mut w = PayloadWriter::new();
+        w.write_u32(1);
+        w.write_str("mint");
+        w.write_u32(1);
+        assert_eq!(
+            ErrorDetails::decode_payload("MixedModuleGenerations", &w.finish()),
+            None
+        );
+    }
+
+    #[test]
+    fn an_oversized_list_count_fails_fast_instead_of_over_allocating() {
+        // A `count` field is untrusted wire input and must never size an
+        // allocation before the elements it claims are validated to exist:
+        // otherwise a few-byte payload could demand gigabytes of capacity
+        // before a single element is read. With a count this large and no
+        // element bytes behind it, decoding must return `None` immediately
+        // rather than attempt to allocate or loop meaningfully.
+        let mut w = PayloadWriter::new();
+        w.write_str("Bitcoin");
+        w.write_u32(u32::MAX);
+        assert_eq!(
+            ErrorDetails::decode_payload("NetworkMismatch", &w.finish()),
+            None
+        );
+
+        let mut w = PayloadWriter::new();
+        w.write_u32(u32::MAX);
+        assert_eq!(
+            ErrorDetails::decode_payload("MixedModuleGenerations", &w.finish()),
             None
         );
     }

--- a/rust/fedimint-sdk/src/error.rs
+++ b/rust/fedimint-sdk/src/error.rs
@@ -2508,4 +2508,164 @@ mod tests {
             None
         );
     }
+
+    #[test]
+    fn fixed_byte_fixtures_match_frozen_wire_format() {
+        // Golden vector fixtures for all 9 variants:
+        // Round-trip tests verify that encoder and decoder agree with each other;
+        // these fixed byte fixtures verify that neither has drifted from the
+        // frozen wire format specification.
+
+        // 1. InsufficientBalance:
+        // required: u64 (be msats, 1000) + available: u64 (be msats, 500)
+        let expected_insufficient = ErrorDetails::InsufficientBalance {
+            required: Amount::from_msats(1000),
+            available: Amount::from_msats(500),
+        };
+        let bytes_insufficient: &[u8] = &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8, // 1000 u64 be
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xF4, // 500 u64 be
+        ];
+        assert_eq!(expected_insufficient.encode_payload(), bytes_insufficient);
+        assert_eq!(
+            ErrorDetails::decode_payload("InsufficientBalance", bytes_insufficient),
+            Some(expected_insufficient)
+        );
+
+        // 2. NetworkMismatch:
+        // expected: str ("Bitcoin") + compatible: list<str> (["Testnet4"]) + observed_prefix: str ("tb1")
+        let expected_network = ErrorDetails::NetworkMismatch {
+            expected: Network::Bitcoin,
+            compatible: vec![Network::Testnet4],
+            observed_prefix: "tb1".to_string(),
+        };
+        let bytes_network: &[u8] = &[
+            0x00, 0x00, 0x00, 0x07, b'B', b'i', b't', b'c', b'o', b'i',
+            b'n', // expected: "Bitcoin"
+            0x00, 0x00, 0x00, 0x01, // compatible count: 1
+            0x00, 0x00, 0x00, 0x08, b'T', b'e', b's', b't', b'n', b'e', b't',
+            b'4', // item: "Testnet4"
+            0x00, 0x00, 0x00, 0x03, b't', b'b', b'1', // observed_prefix: "tb1"
+        ];
+        assert_eq!(expected_network.encode_payload(), bytes_network);
+        assert_eq!(
+            ErrorDetails::decode_payload("NetworkMismatch", bytes_network),
+            Some(expected_network)
+        );
+
+        // 3. MixedModuleGenerations:
+        // modules: list<record { kind: str, generation: u32 }>
+        let expected_modules = ErrorDetails::MixedModuleGenerations {
+            modules: vec![
+                ModuleGeneration {
+                    kind: "mint".to_string(),
+                    generation: 1,
+                },
+                ModuleGeneration {
+                    kind: "ln".to_string(),
+                    generation: 2,
+                },
+            ],
+        };
+        let bytes_modules: &[u8] = &[
+            0x00, 0x00, 0x00, 0x02, // list count: 2
+            0x00, 0x00, 0x00, 0x04, b'm', b'i', b'n', b't', // kind: "mint"
+            0x00, 0x00, 0x00, 0x01, // generation: 1
+            0x00, 0x00, 0x00, 0x02, b'l', b'n', // kind: "ln"
+            0x00, 0x00, 0x00, 0x02, // generation: 2
+        ];
+        assert_eq!(expected_modules.encode_payload(), bytes_modules);
+        assert_eq!(
+            ErrorDetails::decode_payload("MixedModuleGenerations", bytes_modules),
+            Some(expected_modules)
+        );
+
+        // 4. QuoteExpired:
+        // expires_at: u64 (be epoch ms, 1_700_000_000_000) + already_executed: bool (1 byte: 1)
+        let expected_expired = ErrorDetails::QuoteExpired {
+            expires_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+            already_executed: true,
+        };
+        let bytes_expired: &[u8] = &[
+            0x00, 0x00, 0x01, 0x8B, 0xCA, 0x5E, 0xA3, 0x00, // 1_700_000_000_000 u64 be
+            0x01, // already_executed: true
+        ];
+        assert_eq!(expected_expired.encode_payload(), bytes_expired);
+        assert_eq!(
+            ErrorDetails::decode_payload("QuoteExpired", bytes_expired),
+            Some(expected_expired)
+        );
+
+        // 5. QuoteTermsChanged:
+        // quoted_total: u64 (be msats, 100_000) + current_total: u64 (be msats, 120_000)
+        let expected_terms = ErrorDetails::QuoteTermsChanged {
+            quoted_total: Amount::from_msats(100_000),
+            current_total: Amount::from_msats(120_000),
+        };
+        let bytes_terms: &[u8] = &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x86, 0xA0, // 100_000 u64 be
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xD4, 0xC0, // 120_000 u64 be
+        ];
+        assert_eq!(expected_terms.encode_payload(), bytes_terms);
+        assert_eq!(
+            ErrorDetails::decode_payload("QuoteTermsChanged", bytes_terms),
+            Some(expected_terms)
+        );
+
+        // 6. BalanceNotEmpty:
+        // remaining: u64 (be msats, 50_000)
+        let expected_balance = ErrorDetails::BalanceNotEmpty {
+            remaining: Amount::from_msats(50_000),
+        };
+        let bytes_balance: &[u8] = &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC3, 0x50, // 50_000 u64 be
+        ];
+        assert_eq!(expected_balance.encode_payload(), bytes_balance);
+        assert_eq!(
+            ErrorDetails::decode_payload("BalanceNotEmpty", bytes_balance),
+            Some(expected_balance)
+        );
+
+        // 7. StorageInUse:
+        // location: str ("/tmp/db")
+        let expected_in_use = ErrorDetails::StorageInUse {
+            location: "/tmp/db".to_string(),
+        };
+        let bytes_in_use: &[u8] = &[
+            0x00, 0x00, 0x00, 0x07, b'/', b't', b'm', b'p', b'/', b'd', b'b',
+        ];
+        assert_eq!(expected_in_use.encode_payload(), bytes_in_use);
+        assert_eq!(
+            ErrorDetails::decode_payload("StorageInUse", bytes_in_use),
+            Some(expected_in_use)
+        );
+
+        // 8. SeedMismatch:
+        // location: str ("memory")
+        let expected_seed = ErrorDetails::SeedMismatch {
+            location: "memory".to_string(),
+        };
+        let bytes_seed: &[u8] = &[0x00, 0x00, 0x00, 0x06, b'm', b'e', b'm', b'o', b'r', b'y'];
+        assert_eq!(expected_seed.encode_payload(), bytes_seed);
+        assert_eq!(
+            ErrorDetails::decode_payload("SeedMismatch", bytes_seed),
+            Some(expected_seed)
+        );
+
+        // 9. StorageOrphaned:
+        // location: str ("/data") + seed_present: bool (1 byte: 0)
+        let expected_orphaned = ErrorDetails::StorageOrphaned {
+            location: "/data".to_string(),
+            seed_present: false,
+        };
+        let bytes_orphaned: &[u8] = &[
+            0x00, 0x00, 0x00, 0x05, b'/', b'd', b'a', b't', b'a', // location: "/data"
+            0x00, // seed_present: false
+        ];
+        assert_eq!(expected_orphaned.encode_payload(), bytes_orphaned);
+        assert_eq!(
+            ErrorDetails::decode_payload("StorageOrphaned", bytes_orphaned),
+            Some(expected_orphaned)
+        );
+    }
 }

--- a/rust/fedimint-sdk/src/error.rs
+++ b/rust/fedimint-sdk/src/error.rs
@@ -2587,7 +2587,7 @@ mod tests {
             already_executed: true,
         };
         let bytes_expired: &[u8] = &[
-            0x00, 0x00, 0x01, 0x8B, 0xCA, 0x5E, 0xA3, 0x00, // 1_700_000_000_000 u64 be
+            0x00, 0x00, 0x01, 0x8B, 0xCF, 0xE5, 0x68, 0x00, // 1_700_000_000_000 u64 be
             0x01, // already_executed: true
         ];
         assert_eq!(expected_expired.encode_payload(), bytes_expired);

--- a/rust/fedimint-sdk/src/types/network.rs
+++ b/rust/fedimint-sdk/src/types/network.rs
@@ -58,6 +58,29 @@ impl Network {
         Network::Regtest,
     ];
 
+    /// Returns the stable variant name of this network (e.g. `"Bitcoin"`, `"Testnet4"`).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Network::Bitcoin => "Bitcoin",
+            Network::Testnet => "Testnet",
+            Network::Testnet4 => "Testnet4",
+            Network::Signet => "Signet",
+            Network::Regtest => "Regtest",
+        }
+    }
+
+    /// Parses a network from its stable variant name.
+    pub fn from_name(name: &str) -> Option<Network> {
+        match name {
+            "Bitcoin" => Some(Network::Bitcoin),
+            "Testnet" => Some(Network::Testnet),
+            "Testnet4" => Some(Network::Testnet4),
+            "Signet" => Some(Network::Signet),
+            "Regtest" => Some(Network::Regtest),
+            _ => None,
+        }
+    }
+
     /// This network as the `bitcoin` crate spells it.
     ///
     /// Crate-internal: no conversion between this enum and an upstream type is


### PR DESCRIPTION
Implements Error details envelope codec, unblocking Wave 2 Facades and multi-language FFI bindings

Adds zero-dependency, length-delimited binary serialization and strict decoding for `ErrorDetails`, `RawErrorDetails`, and `DetailEnvelope` to enable forward-compatible, panic-free error handling across FFI boundaries.
## Key Changes
- **`types/network.rs`**: Added `as_str()` and `from_name()` for `Network` serialization without foreign derives.
- **`src/error.rs`**:
  - Implemented `PayloadWriter` and `PayloadReader` wire helpers.
  - Implemented `encode_payload`, `to_raw`, and strict `decode_payload` for all 9 `ErrorDetails` variants.
  - Added `to_envelope()` / `from_raw()` bridging `RawErrorDetails` and `DetailEnvelope` (preserving unknown versions/kinds as `Opaque`).
- **Defensive Wire Decoding**:
  - Strict exact byte consumption (trailing bytes degrade to `Opaque`).
  - Strict boolean validation (`0x00`/`0x01` only).
  - DoS/OOM protection: untrusted wire counts do not pre-allocate vector capacity.
  - Invariant validation: deduplicates `compatible` networks and requires $\ge 2$ modules for `MixedModuleGenerations`.