### PR TITLE
feat(sdk): the lightning facade, over either module generation (T8)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -545,17 +545,17 @@
         "wild": "wild"
       },
       "locked": {
-        "lastModified": 1788560774,
-        "narHash": "sha256-dkZLVL9FKo+RXCMfB+VRIUX8CvCreVNJQVc25xL6X+c=",
+        "lastModified": 1788974773,
+        "narHash": "sha256-GO4LtwR/DUxvfulrA3KfohKIdZr8/+soSNkNdc6TcZc=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "84fd7e635d959c9855a81a55f247bdfacdad8826",
+        "rev": "1ab15e4b89aaa35727ca16e401d0cbc7d066de58",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "84fd7e635d959c9855a81a55f247bdfacdad8826",
+        "rev": "1ab15e4b89aaa35727ca16e401d0cbc7d066de58",
         "type": "github"
       }
     },
@@ -573,17 +573,17 @@
         "wild": "wild_2"
       },
       "locked": {
-        "lastModified": 1788560774,
-        "narHash": "sha256-dkZLVL9FKo+RXCMfB+VRIUX8CvCreVNJQVc25xL6X+c=",
+        "lastModified": 1788974773,
+        "narHash": "sha256-GO4LtwR/DUxvfulrA3KfohKIdZr8/+soSNkNdc6TcZc=",
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "84fd7e635d959c9855a81a55f247bdfacdad8826",
+        "rev": "1ab15e4b89aaa35727ca16e401d0cbc7d066de58",
         "type": "github"
       },
       "original": {
         "owner": "fedimint",
         "repo": "fedimint",
-        "rev": "84fd7e635d959c9855a81a55f247bdfacdad8826",
+        "rev": "1ab15e4b89aaa35727ca16e401d0cbc7d066de58",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,14 +9,14 @@
       # input, fedimint-wasm below, and rust/fedimint-sdk/Cargo.toml together —
       # the pins-agree job in .github/workflows/rust-sdk-ci.yaml fails the build
       # when they drift.
-      url = "github:fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826";
+      url = "github:fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58";
     };
     fedimint-wasm = {
       # The wasm client is built from this revision; keep it in sync with the
       # devimint input above and with rust/fedimint-sdk/Cargo.toml, so that
       # every client in this repo and the federation they are tested against
       # come from the same commit.
-      url = "github:fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826";
+      url = "github:fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58";
     };
     nixpkgs-playwright = {
       # Playwright browsers have to match the `playwright` version pnpm-lock.yaml

--- a/rust/fedimint-sdk/Cargo.lock
+++ b/rust/fedimint-sdk/Cargo.lock
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "fedimint-aead"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "fedimint-api-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1705,7 +1705,7 @@ dependencies = [
 [[package]]
 name = "fedimint-bip39"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "bip39",
  "fedimint-client",
@@ -1717,22 +1717,22 @@ dependencies = [
 [[package]]
 name = "fedimint-bitcoind"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
- "anyhow",
  "async-trait",
  "bitcoin",
  "esplora-client",
  "fedimint-core",
  "fedimint-logging",
  "fedimint-metrics",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
 [[package]]
 name = "fedimint-build"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "serde_json",
 ]
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "fedimint-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "fedimint-client-module"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "fedimint-connectors"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "fedimint-core"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1882,6 +1882,7 @@ dependencies = [
  "rand 0.8.8",
  "scopeguard",
  "secp256k1",
+ "semver",
  "serde",
  "serde_json",
  "serdect 0.2.0",
@@ -1901,7 +1902,7 @@ dependencies = [
 [[package]]
 name = "fedimint-cursed-redb"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1920,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "fedimint-db-locked"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1933,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "fedimint-derive"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -1944,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "fedimint-derive-secret"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -1956,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "fedimint-eventlog"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1967,6 +1968,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1974,7 +1976,7 @@ dependencies = [
 [[package]]
 name = "fedimint-hkdf"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "bitcoin_hashes",
 ]
@@ -1982,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "fedimint-ln-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2016,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "fedimint-ln-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2032,6 +2034,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "subtle",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -2040,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "fedimint-lnurl"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "bech32",
  "lightning-invoice",
@@ -2052,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "fedimint-lnv2-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2084,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "fedimint-lnv2-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2105,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "fedimint-logging"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "tracing-subscriber",
@@ -2114,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "fedimint-meta-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2136,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "fedimint-meta-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "fedimint-core",
@@ -2151,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "fedimint-metrics"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "axum",
@@ -2164,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "fedimint-mint-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2204,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "fedimint-mint-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -2218,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "fedimint-mintv2-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2256,7 +2259,7 @@ dependencies = [
 [[package]]
 name = "fedimint-mintv2-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -2270,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "fedimint-rocksdb"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2322,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "fedimint-tbs"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "bls12_381",
  "fedimint-core",
@@ -2359,7 +2362,7 @@ dependencies = [
 [[package]]
 name = "fedimint-tpe"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "bitcoin_hashes",
  "bls12_381",
@@ -2374,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "fedimint-util-error"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
 ]
@@ -2382,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "fedimint-wallet-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -2413,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "fedimint-wallet-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -2429,7 +2432,7 @@ dependencies = [
 [[package]]
 name = "fedimint-walletv2-client"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2457,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "fedimint-walletv2-common"
 version = "0.13.0-alpha"
-source = "git+https://github.com/fedimint/fedimint?rev=84fd7e635d959c9855a81a55f247bdfacdad8826#84fd7e635d959c9855a81a55f247bdfacdad8826"
+source = "git+https://github.com/fedimint/fedimint?rev=1ab15e4b89aaa35727ca16e401d0cbc7d066de58#1ab15e4b89aaa35727ca16e401d0cbc7d066de58"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/rust/fedimint-sdk/Cargo.toml
+++ b/rust/fedimint-sdk/Cargo.toml
@@ -81,4 +81,4 @@ web-sys = { version = "0.3.83", features = [
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tempfile = "3.20.0"
-tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros", "time"] }

--- a/rust/fedimint-sdk/Cargo.toml
+++ b/rust/fedimint-sdk/Cargo.toml
@@ -22,20 +22,20 @@ publish = false   # flip when the name is reserved and the API settles
 # is crate-owned (see fedimint/fedimint#8821 for the upstream structured-error
 # work this stays decoupled from), which is also why `anyhow` is absent: the
 # upstream calls that still return it are mapped where they are made.
-fedimint-bip39 = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-client-module = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-connectors = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-core = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-ln-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-ln-common = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-lnv2-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-lnv2-common = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-meta-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-mint-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-mintv2-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-wallet-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
-fedimint-walletv2-client = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
+fedimint-bip39 = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-client-module = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-connectors = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-core = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-ln-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-ln-common = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-lnv2-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-lnv2-common = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-meta-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-mint-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-mintv2-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-wallet-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
+fedimint-walletv2-client = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
 
 # `bip39` is named directly only to switch its `zeroize` feature on, which
 # `fedimint-bip39` does not: features are unioned, so this is the same single
@@ -55,11 +55,11 @@ tracing = "0.1.44"
 # lock: this one is the SDK's single-opener claim, and it has to fail fast on
 # contention rather than block. See src/storage.rs.
 fd-lock = "4"
-fedimint-rocksdb = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
+fedimint-rocksdb = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
 tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-fedimint-cursed-redb = { git = "https://github.com/fedimint/fedimint", rev = "84fd7e635d959c9855a81a55f247bdfacdad8826" }
+fedimint-cursed-redb = { git = "https://github.com/fedimint/fedimint", rev = "1ab15e4b89aaa35727ca16e401d0cbc7d066de58" }
 js-sys = "0.3.83"
 # `macros` is not about tests here: `tokio::select!` lives behind it, and both
 # subscription types select a stream against a shutdown watch on every target.

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -833,7 +833,7 @@ impl FederationInner {
         let meta: serde_json::Value = entry.try_meta().unwrap_or(serde_json::Value::Null);
         let claimed = crate::operation::backfillers()
             .into_iter()
-            .find_map(|backfiller| backfiller.backfill(&module, &meta));
+            .find_map(|backfiller| backfiller.backfill(&module, &meta, created_at));
         let record = match claimed {
             Some(claimed) => crate::db::OperationRecord {
                 schema_version: crate::operation::READABLE_STATE_SCHEMA,

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -443,6 +443,10 @@ pub(crate) struct FederationInner {
     /// Flipped once the federation stops running, so a pending subscriber resolves promptly
     /// instead of waiting on a stream that will never yield again.
     closed: tokio::sync::watch::Sender<bool>,
+    /// Serialises the start of a lightning claim retry per federation: the read of the record,
+    /// the upstream call that starts the retry and the write that records it happen under this
+    /// lock, so two subscribers that see the same rejected claim start exactly one retry.
+    reclaim_starts: tokio::sync::Mutex<()>,
 }
 
 /// Whether a record is the placeholder `FederationInner::backfill_at`'s no-backfiller branch
@@ -478,6 +482,7 @@ impl FederationInner {
             record: std::sync::RwLock::new(record),
             status: std::sync::RwLock::new(status),
             closed: tokio::sync::watch::Sender::new(!running),
+            reclaim_starts: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -595,6 +600,11 @@ impl FederationInner {
     /// A receiver that fires when this federation stops running.
     pub(crate) fn closed(&self) -> tokio::sync::watch::Receiver<bool> {
         self.closed.subscribe()
+    }
+
+    /// The lock that serialises starting a lightning claim retry for this federation.
+    pub(crate) async fn lock_reclaim_starts(&self) -> tokio::sync::MutexGuard<'_, ()> {
+        self.reclaim_starts.lock().await
     }
 
     /// `Ok` while this federation is still usable, and

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -77,7 +77,9 @@ impl Lightning {
     /// recovery is incomplete,
     /// [`NotSupported`](crate::ErrorCode::NotSupported),
     /// [`FederationUnreachable`](crate::ErrorCode::FederationUnreachable),
-    /// [`Timeout`](crate::ErrorCode::Timeout), and
+    /// [`Timeout`](crate::ErrorCode::Timeout),
+    /// [`Internal`](crate::ErrorCode::Internal) for a failure this crate
+    /// does not expect, which indicates a bug, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn quote(&self, invoice: &Bolt11Invoice) -> Result<LnQuote> {
         // Implementation notes (delete once implemented):
@@ -122,7 +124,9 @@ impl Lightning {
     /// [`NotSupported`](crate::ErrorCode::NotSupported),
     /// [`FederationUnreachable`](crate::ErrorCode::FederationUnreachable),
     /// [`Timeout`](crate::ErrorCode::Timeout),
-    /// [`Storage`](crate::ErrorCode::Storage), and
+    /// [`Storage`](crate::ErrorCode::Storage),
+    /// [`Internal`](crate::ErrorCode::Internal) for a failure this crate
+    /// does not expect, which indicates a bug, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn send(&self, quote: LnQuote) -> Result<Operation<LnSendState>> {
         // Implementation notes (delete once implemented):
@@ -164,7 +168,9 @@ impl Lightning {
     /// [`NotSupported`](crate::ErrorCode::NotSupported),
     /// [`FederationUnreachable`](crate::ErrorCode::FederationUnreachable),
     /// [`Timeout`](crate::ErrorCode::Timeout),
-    /// [`Storage`](crate::ErrorCode::Storage), and
+    /// [`Storage`](crate::ErrorCode::Storage),
+    /// [`Internal`](crate::ErrorCode::Internal) for a failure this crate
+    /// does not expect, which indicates a bug, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn receive(&self, amount: Amount, description: &str) -> Result<LnReceive> {
         // Implementation notes (delete once implemented):

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -88,11 +88,19 @@ impl Lightning {
         // a recovering federation alike.
         let invoice_amount = preflight(invoice, federation.record().network.into())?;
         let client = federation.client(true).await?;
+        let available = balance_of(&client).await?;
+        // The plan's fee dry-run needs the notes on hand to cover the whole contract (the
+        // amount plus fees) and fails inside the primary module rather than reporting a
+        // shortfall when they do not, so a balance that cannot even cover the invoice's own
+        // amount is refused here first, against that amount: no fee has been quoted yet, which
+        // is what `ErrorDetails::InsufficientBalance::required` documents.
+        if available < invoice_amount {
+            return Err(insufficient(invoice_amount, available));
+        }
         let plan = match module(&client)? {
             LnModule::V1(module) => v1::plan(&client, &module, invoice, invoice_amount).await?,
             LnModule::V2(module) => v2::plan(&client, &module, invoice, invoice_amount).await?,
         };
-        let available = balance_of(&client).await?;
         if available < plan.total {
             return Err(insufficient(plan.total, available));
         }
@@ -238,8 +246,12 @@ impl Lightning {
         let federation = &self.inner.federation;
         let client = federation.client(true).await?;
         match module(&client)? {
-            LnModule::V1(module) => v1::receive(federation, &module, amount, description).await,
-            LnModule::V2(module) => v2::receive(federation, &module, amount, description).await,
+            LnModule::V1(module) => {
+                v1::receive(federation, &client, &module, amount, description).await
+            }
+            LnModule::V2(module) => {
+                v2::receive(federation, &client, &module, amount, description).await
+            }
         }
     }
 
@@ -841,6 +853,68 @@ pub(super) fn plan_of(
         route,
         terms,
     })
+}
+
+/// What a fee-quote dry run's failure means, before either mint's answer is turned into an
+/// [`Error`].
+///
+/// The dry run balances the funding transaction against the real notes and fails inside the
+/// primary module when they cannot cover it. The v1 mint (`fedimint-mint-client`) reports that
+/// with the typed [`fedimint_mint_client::InsufficientBalanceError`], which already carries the
+/// amounts that were short; the v2 mint (`fedimint-mintv2-client`) reports the same condition as
+/// a plain-text `anyhow` context, `"Insufficient funds"`
+/// (`fedimint-mintv2-client/src/lib.rs:503`), with no amounts of its own.
+#[derive(Debug)]
+enum FeeQuoteFailure {
+    /// The v1 mint's typed error, carrying its own requested and total amounts.
+    Typed { requested: Amount, total: Amount },
+    /// The v2 mint's plain-text refusal, which names no amounts.
+    Text,
+}
+
+/// Recognizes either mint's insufficient-balance refusal from a fee-quote failure, or reports
+/// neither is a match. Pure so the mapping can be checked without a live `Client`.
+fn classify_fee_quote_failure(
+    short: Option<&fedimint_mint_client::InsufficientBalanceError>,
+    text: &str,
+) -> Option<FeeQuoteFailure> {
+    if let Some(short) = short {
+        return Some(FeeQuoteFailure::Typed {
+            requested: from_upstream(short.requested_amount),
+            total: from_upstream(short.total_amount),
+        });
+    }
+    if text.contains("Insufficient funds") {
+        return Some(FeeQuoteFailure::Text);
+    }
+    None
+}
+
+/// Turns a fee-quote dry run's failure into the [`Error`] it represents, for the four call sites
+/// (v1's and v2's `terms_for` and `receive`) that run one.
+///
+/// `required` is the amount the failed quote was for, used to report the shortfall when the
+/// mint's answer carries no amounts of its own. `context` names the quote for the fallback
+/// message, when `short` is absent and `text` does not match either mint's wording for "the
+/// notes on hand are short".
+pub(super) async fn fee_quote_failure(
+    client: &Client,
+    short: Option<&fedimint_mint_client::InsufficientBalanceError>,
+    text: &str,
+    required: Amount,
+    context: &str,
+) -> Error {
+    match classify_fee_quote_failure(short, text) {
+        Some(FeeQuoteFailure::Typed { requested, total }) => insufficient(requested, total),
+        Some(FeeQuoteFailure::Text) => {
+            // The v2 mint's text names no amounts, so the balance is read again here. A
+            // failed read must not mask the real refusal that was already found, so it
+            // falls back to zero rather than turning this into an unrelated error.
+            let available = balance_of(client).await.unwrap_or(Amount::from_msats(0));
+            insufficient(required, available)
+        }
+        None => internal(format!("{context}: {text}")),
+    }
 }
 
 pub(super) fn to_upstream(amount: Amount) -> fedimint_core::Amount {
@@ -1451,6 +1525,30 @@ mod tests {
             unreachable("down").code,
             crate::ErrorCode::FederationUnreachable
         );
+    }
+
+    #[test]
+    fn fee_quote_failure_is_classified_before_either_mint_is_asked() {
+        // The v1 mint's typed error wins even when the accompanying text also happens to
+        // mention the v2 mint's wording; the typed case is unambiguous and checked first.
+        let typed = fedimint_mint_client::InsufficientBalanceError {
+            requested_amount: fedimint_core::Amount::from_msats(10),
+            total_amount: fedimint_core::Amount::from_msats(3),
+        };
+        match classify_fee_quote_failure(Some(&typed), "Insufficient funds") {
+            Some(FeeQuoteFailure::Typed { requested, total }) => {
+                assert_eq!(requested, Amount::from_msats(10));
+                assert_eq!(total, Amount::from_msats(3));
+            }
+            other => panic!("expected the typed case, got {other:?}"),
+        }
+        // The v2 mint's plain-text refusal, with no typed error at all.
+        assert!(matches!(
+            classify_fee_quote_failure(None, "Insufficient funds"),
+            Some(FeeQuoteFailure::Text)
+        ));
+        // Neither mint's wording: not this crate's problem to interpret.
+        assert!(classify_fee_quote_failure(None, "the federation timed out").is_none());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -41,7 +41,8 @@ impl Lightning {
     /// The returned [`LnQuote`] is the frozen plan for paying `invoice`: the
     /// amount the invoice names, the route, the aggregate fee and the total
     /// debit. Show those numbers to the user, then pass the quote to
-    /// [`Lightning::send`], which executes exactly what was shown.
+    /// [`Lightning::send`], whose docs say exactly what executing it
+    /// guarantees.
     ///
     /// The amount is always the invoice's own. An invoice that names no
     /// amount cannot be paid through fedimint and is refused here with
@@ -123,14 +124,21 @@ impl Lightning {
 
     /// Executes a quoted payment.
     ///
-    /// The quote is consumed. Execution follows it exactly, same amount, same
-    /// fee, same route, or does not happen:
+    /// The quote is consumed. Its terms are checked again immediately before
+    /// funding and execution refuses to proceed if they moved:
     /// [`QuoteExpired`](crate::ErrorCode::QuoteExpired) if the quote's
     /// validity window has passed,
     /// [`QuoteChanged`](crate::ErrorCode::QuoteChanged) if something the
     /// quote depends on moved underneath it, such as the gateway withdrawing
-    /// or changing its fee. Both mean the same thing to a caller: quote again
-    /// and re-confirm with the user.
+    /// or changing its fee before that check runs. Both mean the same thing
+    /// to a caller: quote again and re-confirm with the user.
+    ///
+    /// That check cannot close the gap after itself: a gateway that changes
+    /// its fee in the instant between the check and the payment actually
+    /// being funded is not caught by it, and the payment funds anyway, at
+    /// the fee the gateway actually took rather than the quoted one.
+    /// [`LnSendDetails::fee`] and [`LnSendDetails::total`] report that true
+    /// figure, not the quote's.
     ///
     /// The returned operation tracks the payment from funding to preimage. A
     /// payment that fails ends in a final state, not in an error from this
@@ -261,10 +269,9 @@ impl Lightning {
 
 /// A frozen, executable plan for one lightning payment.
 ///
-/// Produced by [`Lightning::quote`] and consumed by [`Lightning::send`].
-/// Everything a user needs to approve is readable through the accessors
-/// below. The numbers shown are the numbers charged: a quote is executed
-/// exactly or not at all.
+/// Produced by [`Lightning::quote`] and consumed by [`Lightning::send`], whose
+/// docs say exactly what is guaranteed to hold at execution. Everything a
+/// user needs to approve is readable through the accessors below.
 #[derive(Debug)]
 pub struct LnQuote {
     inner: LnQuoteInner,

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -6,6 +6,8 @@ use crate::{
     Amount, Bolt11Invoice, GatewayId, Operation, OperationState, Preimage, Result, Timestamp,
 };
 
+mod wire;
+
 /// The lightning facade for one federation.
 ///
 /// Obtained from [`Federation::lightning`](crate::Federation::lightning),

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -19,6 +19,8 @@ mod v1;
 mod v2;
 mod wire;
 
+pub(crate) use driver::{LnBackfiller, LnReceiveDriver, LnSendDriver};
+
 /// The lightning facade for one federation.
 ///
 /// Obtained from [`Federation::lightning`](crate::Federation::lightning),
@@ -1430,6 +1432,76 @@ mod tests {
         assert_eq!(
             unreachable("down").code,
             crate::ErrorCode::FederationUnreachable
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_recorded_send_reads_its_details_back_through_the_engine() {
+        use crate::db::{federation_namespace, in_memory_root};
+        use crate::federation::FederationInner;
+        use crate::operation::{Driver, kinds};
+
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db, true);
+        let details = send_details();
+        let id = fedimint_core::core::OperationId([4u8; 32]);
+        let operation = federation
+            .create_operation(
+                id,
+                kinds::LN_SEND,
+                "ln",
+                &wire::LnSendDetailsWire::from(&details),
+                Arc::new(LnSendDriver) as Arc<dyn Driver<LnSendState>>,
+            )
+            .await
+            .expect("create");
+        assert_eq!(operation.details().await.expect("details"), details);
+
+        // The lookup path hands the same record to the same driver.
+        let any = federation
+            .operation(id)
+            .await
+            .expect("lookup")
+            .expect("recorded");
+        assert_eq!(any.kind(), crate::OperationKind::LnSend);
+        let typed = any.as_ln_send().expect("a typed handle");
+        assert_eq!(typed.details().await.expect("details"), details);
+        // No client behind a detached federation: observing the state is refused, not faked.
+        assert_eq!(
+            typed.state().await.expect_err("no client").code,
+            crate::ErrorCode::FederationClosed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_recorded_final_state_is_read_without_a_client() {
+        use crate::db::{federation_namespace, in_memory_root};
+        use crate::federation::FederationInner;
+        use crate::operation::{Driver, kinds};
+
+        let db = federation_namespace(&in_memory_root(), [2u8; 32]);
+        let federation = FederationInner::detached(db, true);
+        let id = fedimint_core::core::OperationId([5u8; 32]);
+        let operation = federation
+            .create_operation(
+                id,
+                kinds::LN_RECEIVE,
+                "lnv2",
+                &wire::LnReceiveDetailsWire::from(&receive_details()),
+                Arc::new(LnReceiveDriver) as Arc<dyn Driver<LnReceiveState>>,
+            )
+            .await
+            .expect("create");
+        operation
+            .inner()
+            .record_final_state(
+                wire::encode_receive_state(&LnReceiveState::Claimed).expect("encode"),
+            )
+            .await
+            .expect("record");
+        assert_eq!(
+            operation.state().await.expect("state"),
+            LnReceiveState::Claimed
         );
     }
 }

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -117,6 +117,9 @@ impl Lightning {
     ///
     /// [`QuoteExpired`](crate::ErrorCode::QuoteExpired),
     /// [`QuoteChanged`](crate::ErrorCode::QuoteChanged),
+    /// [`NetworkMismatch`](crate::ErrorCode::NetworkMismatch) on an lnv2
+    /// federation running testnet4, whose module cannot pay a `tb` invoice
+    /// at all,
     /// [`InsufficientBalance`](crate::ErrorCode::InsufficientBalance),
     /// [`GatewayUnavailable`](crate::ErrorCode::GatewayUnavailable),
     /// [`Recovering`](crate::ErrorCode::Recovering) while the federation's
@@ -732,7 +735,7 @@ fn preflight(invoice: &Bolt11Invoice, network: Network) -> Result<Amount> {
 
 /// Every network a BOLT11 currency class could stand for: `tb` is both public testnets, and a
 /// class this crate cannot name (simnet) is the empty set, which still proves a mismatch.
-fn compatible_networks(from_invoice: Option<Network>) -> Vec<Network> {
+pub(super) fn compatible_networks(from_invoice: Option<Network>) -> Vec<Network> {
     match from_invoice {
         Some(Network::Testnet) => vec![Network::Testnet, Network::Testnet4],
         Some(network) => vec![network],

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -312,7 +312,9 @@ impl LnQuote {
     /// [`QuoteChanged`](crate::ErrorCode::QuoteChanged), whose
     /// [`ErrorDetails::QuoteTermsChanged`](crate::ErrorDetails::QuoteTermsChanged)
     /// names this total and the one the payment would now cost. The same
-    /// figure is what [`LnSendDetails::total`] records.
+    /// figure is what [`LnSendDetails::total`] records, unless the gateway's
+    /// fee moved in the instant [`Lightning::send`] funds the payment; its
+    /// docs say what is recorded then.
     pub fn total(&self) -> Amount {
         self.inner.plan.total
     }
@@ -494,11 +496,14 @@ pub struct LnSendDetails {
     /// charge is known not to have applied and the rest of the fee is the
     /// quote's estimate, so this is an upper bound.
     ///
-    /// Exact for an operation this SDK created — including one recovered
-    /// after a restart — other than the residual case above, which after a
-    /// restart still reports the quote's upper bound rather than the
-    /// corrected figure. An estimate only for a log entry this SDK did not
-    /// create.
+    /// Exact for an operation this SDK created, including one recovered
+    /// after a restart, except for the residual case above.
+    ///
+    /// That residual case is never corrected: even once recovered after a
+    /// restart, it still reports the quote's upper bound, not the settled
+    /// figure.
+    ///
+    /// An estimate only for a log entry this SDK did not create.
     pub total: Amount,
     /// How the payment is routed, [`LnQuote::route`].
     pub route: LightningRoute,

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -632,31 +632,31 @@ struct LightningInner {
 /// A quote's frozen plan: the invoice, the amount it names, the fee and its parts, the route, and
 /// the upstream terms the fee was computed from, so that `send` can tell whether they moved.
 #[derive(Debug)]
-struct LnQuoteInner {
+pub(super) struct LnQuoteInner {
     /// The federation the quote was made against. A quote is refused on any other.
-    federation_id: config::FederationId,
-    invoice: Bolt11Invoice,
-    invoice_amount: Amount,
-    plan: Plan,
-    expires_at: Timestamp,
+    pub(super) federation_id: config::FederationId,
+    pub(super) invoice: Bolt11Invoice,
+    pub(super) invoice_amount: Amount,
+    pub(super) plan: Plan,
+    pub(super) expires_at: Timestamp,
 }
 
 /// What a payment will cost and how it will go, for either module generation.
 #[derive(Debug)]
-struct Plan {
-    breakdown: LnFeeBreakdown,
+pub(super) struct Plan {
+    pub(super) breakdown: LnFeeBreakdown,
     /// The sum of `breakdown`.
-    fee: Amount,
+    pub(super) fee: Amount,
     /// The invoice amount plus `fee`.
-    total: Amount,
-    route: LightningRoute,
-    terms: Terms,
+    pub(super) total: Amount,
+    pub(super) route: LightningRoute,
+    pub(super) terms: Terms,
 }
 
 /// The upstream inputs a plan was computed from. `send` recomputes the plan from the same
 /// inputs read again and refuses on any difference in the total.
 #[derive(Debug)]
-enum Terms {
+pub(super) enum Terms {
     /// v1: the gateway the payment goes out through, or `None` for an internal payment.
     ///
     /// Boxed: `LightningGateway` is large enough on its own to make this the dominant variant,
@@ -678,7 +678,7 @@ const QUOTE_VALIDITY_MILLIS: u64 = 60_000;
 
 /// The expiry every invoice this facade issues carries. lnv2 refuses anything over one day
 /// (`MAX_INVOICE_EXPIRY_SECS` in fedimint-lnv2-common's gateway_api.rs).
-const INVOICE_EXPIRY_SECS: u32 = 3_600;
+pub(super) const INVOICE_EXPIRY_SECS: u32 = 3_600;
 
 /// The longest description a BOLT11 invoice can carry, in bytes: 1023 five-bit groups
 /// (lightning-invoice-0.33.3/src/lib.rs:1687-1697, `Description::new`).
@@ -789,7 +789,7 @@ fn ensure_executable(
 /// includes that explicit fee (`fedimint-client/src/client.rs:865-935`): the primary module's
 /// share is what is left of the quote's input and output fees once the lightning module's
 /// explicit fee is taken back out.
-fn plan_of(
+pub(super) fn plan_of(
     gateway: Amount,
     lightning_module: Amount,
     quote: &FeeQuote,
@@ -825,20 +825,20 @@ fn plan_of(
     })
 }
 
-fn to_upstream(amount: Amount) -> fedimint_core::Amount {
+pub(super) fn to_upstream(amount: Amount) -> fedimint_core::Amount {
     fedimint_core::Amount::from_msats(amount.msats())
 }
 
-fn from_upstream(amount: fedimint_core::Amount) -> Amount {
+pub(super) fn from_upstream(amount: fedimint_core::Amount) -> Amount {
     Amount::from_msats(amount.msats)
 }
 
-fn add(left: Amount, right: Amount) -> Result<Amount> {
+pub(super) fn add(left: Amount, right: Amount) -> Result<Amount> {
     left.checked_add(right)
         .ok_or_else(|| Error::new(ErrorCode::Internal, "an amount overflowed"))
 }
 
-fn quote_changed(quoted_total: Amount, current_total: Amount) -> Error {
+pub(super) fn quote_changed(quoted_total: Amount, current_total: Amount) -> Error {
     Error::with_details(
         ErrorCode::QuoteChanged,
         format!(
@@ -853,7 +853,7 @@ fn quote_changed(quoted_total: Amount, current_total: Amount) -> Error {
     )
 }
 
-fn quote_expired(expires_at: Timestamp, already_executed: bool) -> Error {
+pub(super) fn quote_expired(expires_at: Timestamp, already_executed: bool) -> Error {
     let message = if already_executed {
         "this invoice has already been paid or is being paid"
     } else {
@@ -869,7 +869,7 @@ fn quote_expired(expires_at: Timestamp, already_executed: bool) -> Error {
     )
 }
 
-fn insufficient(required: Amount, available: Amount) -> Error {
+pub(super) fn insufficient(required: Amount, available: Amount) -> Error {
     Error::with_details(
         ErrorCode::InsufficientBalance,
         format!(
@@ -884,21 +884,21 @@ fn insufficient(required: Amount, available: Amount) -> Error {
     )
 }
 
-fn gateway_unavailable(cause: impl core::fmt::Display) -> Error {
+pub(super) fn gateway_unavailable(cause: impl core::fmt::Display) -> Error {
     Error::new(
         ErrorCode::GatewayUnavailable,
         format!("no usable lightning gateway: {cause}"),
     )
 }
 
-fn unreachable(cause: impl core::fmt::Display) -> Error {
+pub(super) fn unreachable(cause: impl core::fmt::Display) -> Error {
     Error::new(
         ErrorCode::FederationUnreachable,
         format!("the federation did not answer: {cause}"),
     )
 }
 
-fn internal(cause: impl core::fmt::Display) -> Error {
+pub(super) fn internal(cause: impl core::fmt::Display) -> Error {
     Error::new(ErrorCode::Internal, cause.to_string())
 }
 
@@ -919,7 +919,7 @@ async fn balance_of(client: &Client) -> Result<Amount> {
         .map_err(|err| internal(format!("this federation cannot report a balance: {err}")))
 }
 
-fn now() -> Timestamp {
+pub(super) fn now() -> Timestamp {
     Timestamp::from_epoch_millis(crate::db::now_millis())
 }
 

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -14,6 +14,8 @@ use crate::{
     OperationState, Preimage, Result, Timestamp,
 };
 
+mod driver;
+mod v1;
 mod wire;
 
 /// The lightning facade for one federation.

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -397,28 +397,6 @@ pub struct LnReceive {
 /// whether returned or never debited; [`Failed`](Self::Failed) means the
 /// payment did not resolve into either. A payment has no cancellation:
 /// once sent it runs to one of those endings.
-// Implementation notes (delete once implemented):
-//
-// This unifies three upstream machines: v1 `LnPayState` (gateway-routed), v1
-// `InternalPayState` (selected by `PayType::Internal`) and lnv2 `SendOperationState`.
-//
-// - Funding-in-progress states map to `Created`/`Funded`; every preimage-obtained state to
-//   `Success`; everything that ends with the funds spendable again to `Refunded`; a refund
-//   that itself failed, or an unresolved error, to `Failed`.
-// - v1 `LnPayState::Canceled`: called off before the gateway took it, nothing debited,
-//   so `Refunded`.
-// - `InternalPayState::FundingFailed`, and lnv2 `Failure` straight after `Funding`: the
-//   federation rejected the funding transaction, nothing debited, so `Refunded`. lnv2 uses
-//   the same `Failure` variant for a failed refund, so key on whether `Funded` was reached
-//   and persist that phase.
-// - lnv2 `Failure` after `Refunding`: neither paid nor back, so `Failed`.
-// - lnv2 `Refunding` is in progress, not final: map to `Funded`, then `Refunded` when it
-//   lands.
-// - Normalise the preimage: v1 reports hex, lnv2 raw bytes.
-// - The v1 progress stream carries neither the fee nor the gateway id. Both come from the
-//   executed quote and are persisted in `LnSendDetails`; `Success` is filled from there.
-//
-// The variant set is provisional until reconciled against the lightning client.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum LnSendState {
@@ -525,34 +503,6 @@ impl crate::operation::DetailedOperationState for LnSendState {
 /// [`Canceled`](Self::Canceled), the receive was called off before anything
 /// was funded; and [`Failed`](Self::Failed), a payment got past "nobody paid"
 /// and still produced no credit. Only the last warrants alarming a user.
-// Implementation notes (delete once implemented):
-//
-// v1 `LnReceiveState` is `Created`, `WaitingForPayment { invoice, timeout }`,
-// `Canceled { reason }`, `Funded`, `AwaitingFunds`, `Claimed`. `AwaitingFunds` folds into
-// `Funded`. The cancellation reason is a typed `LightningReceiveError`; nothing is parsed.
-//
-// | upstream v1                   | phase reached      | here                          |
-// | ----------------------------- | ------------------ | ----------------------------- |
-// | `Canceled { Timeout }`        | any                | `Expired`                     |
-// | `Canceled { ClaimRejected }`  | any                | `Funded`, then reclaim        |
-// | `Canceled { InvalidPreimage }`| any                | `Failed`                      |
-// | `Canceled { Rejected }`       | before `Funded`    | `Canceled`                    |
-// | `Canceled { Rejected }`       | at or after `Funded` | `Failed`                    |
-//
-// - `ClaimRejected` and `InvalidPreimage` presuppose a funded contract and arrive before
-//   upstream's own `Funded` (which is only emitted once the claim is accepted), so the phase
-//   must not be consulted for them. `InvalidPreimage` unwinds the payment: `Failed`.
-//   `ClaimRejected` is not final: move to `Funded` and drive the client's reclaim
-//   (`reclaim_ln_receive`) under the same operation id until `Claimed`, or `Failed` once no
-//   further claim is possible.
-// - `Rejected` is emitted both for the invoice-registration transaction being refused and
-//   for the claim's primary outputs failing after a confirmed payment. Persist whether the
-//   receive ever reached `Funded`; after a restart that is the only way to tell them apart.
-// - lnv2 `ReceiveOperationState` has explicit pending/claiming/claimed/expired states that
-//   map directly. Its `Failure` after an accepted claim is `Failed`; a rejected but still
-//   claimable claim stays `Funded` and reclaims, as for v1.
-//
-// The variant set is provisional until reconciled against the lightning client.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum LnReceiveState {

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -486,6 +486,12 @@ pub struct LnSendDetails {
     /// module settled inside the federation after all, where the gateway's
     /// charge is known not to have applied and the rest of the fee is the
     /// quote's estimate, so this is an upper bound.
+    ///
+    /// Exact for an operation this SDK created — including one recovered
+    /// after a restart — other than the residual case above, which after a
+    /// restart still reports the quote's upper bound rather than the
+    /// corrected figure. An estimate only for a log entry this SDK did not
+    /// create.
     pub total: Amount,
     /// How the payment is routed, [`LnQuote::route`].
     pub route: LightningRoute,
@@ -618,9 +624,11 @@ pub struct LnReceiveDetails {
     ///
     /// This is the whole difference between what the payer pays and what
     /// lands; no other deduction appears later. It can be zero but usually is
-    /// not, since issuing the notes is itself a federation transaction. A
-    /// record rebuilt from the client's own log after a crash reports zero,
-    /// because the log does not keep the fee.
+    /// not, since issuing the notes is itself a federation transaction.
+    ///
+    /// Exact for an operation this SDK created, even one recovered after a
+    /// restart; a record rebuilt from a log entry this SDK did not create
+    /// has no fee to recover and reports zero.
     pub fee: Amount,
     /// What lands in the spendable balance:
     /// [`invoice_amount`](LnReceiveDetails::invoice_amount) minus

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -166,10 +166,6 @@ impl Lightning {
         // The guard is held across the re-check, the funding and the record write, which is what
         // `create_operation` requires of its caller.
         let client = federation.client(true).await?;
-        let available = balance_of(&client).await?;
-        if available < quote.plan.total {
-            return Err(insufficient(quote.plan.total, available));
-        }
         match (module(&client)?, &quote.plan.terms) {
             (LnModule::V1(module), Terms::V1 { gateway }) => {
                 v1::send(federation, &client, &module, &quote, gateway.clone()).await
@@ -486,6 +482,10 @@ pub struct LnSendDetails {
     ///
     /// This is a term, not an outcome. On [`LnSendState::Success`] it is what
     /// was debited; on [`LnSendState::Refunded`] it is what was at stake.
+    /// The one exception is a payment quoted through a gateway that the
+    /// module settled inside the federation after all, where the gateway's
+    /// charge is known not to have applied and the rest of the fee is the
+    /// quote's estimate, so this is an upper bound.
     pub total: Amount,
     /// How the payment is routed, [`LnQuote::route`].
     pub route: LightningRoute,
@@ -618,7 +618,9 @@ pub struct LnReceiveDetails {
     ///
     /// This is the whole difference between what the payer pays and what
     /// lands; no other deduction appears later. It can be zero but usually is
-    /// not, since issuing the notes is itself a federation transaction.
+    /// not, since issuing the notes is itself a federation transaction. A
+    /// record rebuilt from the client's own log after a crash reports zero,
+    /// because the log does not keep the fee.
     pub fee: Amount,
     /// What lands in the spendable balance:
     /// [`invoice_amount`](LnReceiveDetails::invoice_amount) minus
@@ -1003,7 +1005,7 @@ pub(super) fn subscribe_error(cause: impl core::fmt::Display) -> Error {
 }
 
 /// The spendable balance, as `Federation::balance` reads it.
-async fn balance_of(client: &Client) -> Result<Amount> {
+pub(super) async fn balance_of(client: &Client) -> Result<Amount> {
     client
         .get_balance_for_btc()
         .await

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -16,6 +16,7 @@ use crate::{
 
 mod driver;
 mod v1;
+mod v2;
 mod wire;
 
 /// The lightning facade for one federation.

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -2,8 +2,16 @@
 
 use std::sync::Arc;
 
+use fedimint_client::Client;
+use fedimint_client_module::ClientModuleInstance;
+use fedimint_client_module::transaction::FeeQuote;
+use fedimint_core::config;
+use fedimint_core::util::SafeUrl;
+use fedimint_lnv2_common::gateway_api::PaymentFee;
+
 use crate::{
-    Amount, Bolt11Invoice, GatewayId, Operation, OperationState, Preimage, Result, Timestamp,
+    Amount, Bolt11Invoice, Error, ErrorCode, ErrorDetails, GatewayId, Network, Operation,
+    OperationState, Preimage, Result, Timestamp,
 };
 
 mod wire;
@@ -184,7 +192,7 @@ pub struct LnQuote {
 impl LnQuote {
     /// The invoice's amount: what will reach the payee.
     pub fn invoice_amount(&self) -> Amount {
-        unimplemented!()
+        self.inner.invoice_amount
     }
 
     /// The aggregate fee this payment will cost, on top of
@@ -199,13 +207,13 @@ impl LnQuote {
     /// [`LnQuote::fee_breakdown`] itemises this same number. This accessor
     /// is authoritative and the breakdown sums to it exactly.
     pub fn fee(&self) -> Amount {
-        unimplemented!()
+        self.inner.plan.fee
     }
 
     /// The parts [`LnQuote::fee`] is made of, for an approval screen that
     /// itemises them.
     pub fn fee_breakdown(&self) -> LnFeeBreakdown {
-        unimplemented!()
+        self.inner.plan.breakdown.clone()
     }
 
     /// The whole debit this payment will make against the balance:
@@ -218,12 +226,12 @@ impl LnQuote {
     /// names this total and the one the payment would now cost. The same
     /// figure is what [`LnSendDetails::total`] records.
     pub fn total(&self) -> Amount {
-        unimplemented!()
+        self.inner.plan.total
     }
 
     /// How this payment will be routed.
     pub fn route(&self) -> LightningRoute {
-        unimplemented!()
+        self.inner.plan.route.clone()
     }
 
     /// When this quote stops being executable.
@@ -231,7 +239,7 @@ impl LnQuote {
     /// Past this point [`Lightning::send`] fails with
     /// [`QuoteExpired`](crate::ErrorCode::QuoteExpired).
     pub fn expires_at(&self) -> Timestamp {
-        unimplemented!()
+        self.inner.expires_at
     }
 }
 
@@ -616,11 +624,299 @@ struct LightningInner {
     federation: Arc<crate::federation::FederationInner>,
 }
 
-/// Placeholder for a quote's frozen plan: invoice, the amount it names,
-/// verified gateway, the aggregate fee and its components, the bound note
-/// selection, and the configuration context they were computed against.
+/// A quote's frozen plan: the invoice, the amount it names, the fee and its parts, the route, and
+/// the upstream terms the fee was computed from, so that `send` can tell whether they moved.
 #[derive(Debug)]
-struct LnQuoteInner;
+struct LnQuoteInner {
+    /// The federation the quote was made against. A quote is refused on any other.
+    federation_id: config::FederationId,
+    invoice: Bolt11Invoice,
+    invoice_amount: Amount,
+    plan: Plan,
+    expires_at: Timestamp,
+}
+
+/// What a payment will cost and how it will go, for either module generation.
+#[derive(Debug)]
+struct Plan {
+    breakdown: LnFeeBreakdown,
+    /// The sum of `breakdown`.
+    fee: Amount,
+    /// The invoice amount plus `fee`.
+    total: Amount,
+    route: LightningRoute,
+    terms: Terms,
+}
+
+/// The upstream inputs a plan was computed from. `send` recomputes the plan from the same
+/// inputs read again and refuses on any difference in the total.
+#[derive(Debug)]
+enum Terms {
+    /// v1: the gateway the payment goes out through, or `None` for an internal payment.
+    ///
+    /// Boxed: `LightningGateway` is large enough on its own to make this the dominant variant,
+    /// which `clippy::large_enum_variant` flags across every `Terms` value, most of which carry
+    /// no gateway at all.
+    V1 {
+        gateway: Option<Box<fedimint_ln_common::LightningGateway>>,
+    },
+    /// lnv2: the gateway's API and the fee schedule it quoted for this invoice.
+    V2 {
+        gateway: SafeUrl,
+        send_fee: PaymentFee,
+        expiration_delta: u64,
+    },
+}
+
+/// How long a quote stays executable after it is issued, unless the invoice expires first.
+const QUOTE_VALIDITY_MILLIS: u64 = 60_000;
+
+/// The expiry every invoice this facade issues carries. lnv2 refuses anything over one day
+/// (`MAX_INVOICE_EXPIRY_SECS` in fedimint-lnv2-common's gateway_api.rs).
+const INVOICE_EXPIRY_SECS: u32 = 3_600;
+
+/// The longest description a BOLT11 invoice can carry, in bytes: 1023 five-bit groups
+/// (lightning-invoice-0.33.3/src/lib.rs:1687-1697, `Description::new`).
+const MAX_DESCRIPTION_BYTES: usize = 639;
+
+/// The lightning module the live client has, whichever generation it is.
+enum LnModule<'a> {
+    V1(ClientModuleInstance<'a, fedimint_ln_client::LightningClientModule>),
+    V2(ClientModuleInstance<'a, fedimint_lnv2_client::LightningClientModule>),
+}
+
+/// Picks the generation by asking the client, not the stored record: a facade obtained while a
+/// module was present and used after the configuration dropped it is the `NotSupported` case.
+fn module(client: &Client) -> Result<LnModule<'_>> {
+    if let Ok(module) = client.get_first_module::<fedimint_lnv2_client::LightningClientModule>() {
+        return Ok(LnModule::V2(module));
+    }
+    if let Ok(module) = client.get_first_module::<fedimint_ln_client::LightningClientModule>() {
+        return Ok(LnModule::V1(module));
+    }
+    Err(Error::new(
+        ErrorCode::NotSupported,
+        "this federation no longer has a lightning module",
+    ))
+}
+
+/// The checks every quote runs before anything touches the network, in the documented order:
+/// amountless first, then the network, then expiry.
+fn preflight(invoice: &Bolt11Invoice, network: Network) -> Result<Amount> {
+    let Some(amount) = invoice.amount() else {
+        return Err(Error::new(
+            ErrorCode::AmountlessInvoice,
+            "this invoice names no amount and cannot be paid through fedimint",
+        ));
+    };
+    check_network(invoice, network)?;
+    if invoice.is_expired() {
+        return Err(Error::new(
+            ErrorCode::InvalidInput,
+            "this invoice has already expired",
+        ));
+    }
+    Ok(amount)
+}
+
+/// Every network a BOLT11 currency class could stand for: `tb` is both public testnets, and a
+/// class this crate cannot name (simnet) is the empty set, which still proves a mismatch.
+fn compatible_networks(from_invoice: Option<Network>) -> Vec<Network> {
+    match from_invoice {
+        Some(Network::Testnet) => vec![Network::Testnet, Network::Testnet4],
+        Some(network) => vec![network],
+        None => Vec::new(),
+    }
+}
+
+fn check_network(invoice: &Bolt11Invoice, expected: Network) -> Result<()> {
+    let compatible = compatible_networks(invoice.network());
+    if compatible.contains(&expected) {
+        return Ok(());
+    }
+    let observed_prefix = invoice.observed_prefix();
+    Err(Error::with_details(
+        ErrorCode::NetworkMismatch,
+        format!(
+            "the invoice is for {observed_prefix} but the federation runs on {}",
+            expected.as_str()
+        ),
+        ErrorDetails::NetworkMismatch {
+            expected,
+            compatible,
+            observed_prefix,
+        },
+    ))
+}
+
+fn check_description(description: &str) -> Result<()> {
+    if description.len() > MAX_DESCRIPTION_BYTES {
+        return Err(Error::new(
+            ErrorCode::InvalidInput,
+            format!(
+                "the description exceeds the {MAX_DESCRIPTION_BYTES} bytes an invoice can carry"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Refuses a quote made for another federation or past its window.
+fn ensure_executable(
+    quote: &LnQuoteInner,
+    federation_id: config::FederationId,
+    now_millis: u64,
+) -> Result<()> {
+    if quote.federation_id != federation_id {
+        return Err(Error::new(
+            ErrorCode::InvalidInput,
+            "this quote was issued by another federation",
+        ));
+    }
+    if now_millis > quote.expires_at.epoch_millis() {
+        return Err(quote_expired(quote.expires_at, false));
+    }
+    Ok(())
+}
+
+/// Assembles a plan from the gateway's charge, the lightning module's own fee on the explicit
+/// output (or input), and the shared fee quote, whose `output` (or `input`) total already
+/// includes that explicit fee (`fedimint-client/src/client.rs:865-935`): the primary module's
+/// share is what is left of the quote's input and output fees once the lightning module's
+/// explicit fee is taken back out.
+fn plan_of(
+    gateway: Amount,
+    lightning_module: Amount,
+    quote: &FeeQuote,
+    invoice_amount: Amount,
+    route: LightningRoute,
+    terms: Terms,
+) -> Result<Plan> {
+    let input = from_upstream(quote.input.get_bitcoin());
+    let output = from_upstream(quote.output.get_bitcoin());
+    let dust = from_upstream(quote.dust.get_bitcoin());
+    let primary_module = add(input, output)?
+        .checked_sub(lightning_module)
+        .ok_or_else(|| {
+            Error::new(
+                ErrorCode::Internal,
+                "the fee quote is smaller than the lightning module's own fee",
+            )
+        })?;
+    let breakdown = LnFeeBreakdown {
+        gateway,
+        lightning_module,
+        primary_module,
+        dust,
+    };
+    let fee = add(add(add(gateway, lightning_module)?, primary_module)?, dust)?;
+    let total = add(invoice_amount, fee)?;
+    Ok(Plan {
+        breakdown,
+        fee,
+        total,
+        route,
+        terms,
+    })
+}
+
+fn to_upstream(amount: Amount) -> fedimint_core::Amount {
+    fedimint_core::Amount::from_msats(amount.msats())
+}
+
+fn from_upstream(amount: fedimint_core::Amount) -> Amount {
+    Amount::from_msats(amount.msats)
+}
+
+fn add(left: Amount, right: Amount) -> Result<Amount> {
+    left.checked_add(right)
+        .ok_or_else(|| Error::new(ErrorCode::Internal, "an amount overflowed"))
+}
+
+fn quote_changed(quoted_total: Amount, current_total: Amount) -> Error {
+    Error::with_details(
+        ErrorCode::QuoteChanged,
+        format!(
+            "the payment would now debit {} msat instead of the quoted {} msat",
+            current_total.msats(),
+            quoted_total.msats()
+        ),
+        ErrorDetails::QuoteTermsChanged {
+            quoted_total,
+            current_total,
+        },
+    )
+}
+
+fn quote_expired(expires_at: Timestamp, already_executed: bool) -> Error {
+    let message = if already_executed {
+        "this invoice has already been paid or is being paid"
+    } else {
+        "this quote is no longer executable; quote again"
+    };
+    Error::with_details(
+        ErrorCode::QuoteExpired,
+        message,
+        ErrorDetails::QuoteExpired {
+            expires_at,
+            already_executed,
+        },
+    )
+}
+
+fn insufficient(required: Amount, available: Amount) -> Error {
+    Error::with_details(
+        ErrorCode::InsufficientBalance,
+        format!(
+            "the payment needs {} msat but only {} msat is spendable",
+            required.msats(),
+            available.msats()
+        ),
+        ErrorDetails::InsufficientBalance {
+            required,
+            available,
+        },
+    )
+}
+
+fn gateway_unavailable(cause: impl core::fmt::Display) -> Error {
+    Error::new(
+        ErrorCode::GatewayUnavailable,
+        format!("no usable lightning gateway: {cause}"),
+    )
+}
+
+fn unreachable(cause: impl core::fmt::Display) -> Error {
+    Error::new(
+        ErrorCode::FederationUnreachable,
+        format!("the federation did not answer: {cause}"),
+    )
+}
+
+fn internal(cause: impl core::fmt::Display) -> Error {
+    Error::new(ErrorCode::Internal, cause.to_string())
+}
+
+/// An upstream subscription that could not be opened, for either generation's driver.
+pub(super) fn subscribe_error(cause: impl core::fmt::Display) -> Error {
+    Error::new(
+        ErrorCode::Internal,
+        format!("could not follow this operation upstream: {cause}"),
+    )
+}
+
+/// The spendable balance, as `Federation::balance` reads it.
+async fn balance_of(client: &Client) -> Result<Amount> {
+    client
+        .get_balance_for_btc()
+        .await
+        .map(from_upstream)
+        .map_err(|err| internal(format!("this federation cannot report a balance: {err}")))
+}
+
+fn now() -> Timestamp {
+    Timestamp::from_epoch_millis(crate::db::now_millis())
+}
 
 #[cfg(test)]
 mod tests {
@@ -898,5 +1194,239 @@ mod tests {
     #[test]
     fn ln_receive_state_failed_is_final() {
         assert!(LnReceiveState::Failed.is_final());
+    }
+
+    /// The mainnet fixture from `types/invoice.rs`: 25 mBTC, expired in 2017.
+    // The brief's transcription of this and `MAINNET_AMOUNTLESS` below dropped a few characters
+    // each, breaking their bech32 checksum; both are corrected here to the byte-exact fixtures
+    // `types/invoice.rs` already parses and tests against (`MAINNET_25M` there).
+    const MAINNET_EXPIRED: &str = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqpqsq67gye39hfg3zd8rgc80k32tvy9xk2xunwm5lzexnvpx6fd77en8qaq424dxgt56cag2dpt359k3ssyhetktkpqh24jqnjyw6uqd08sgptq44qu";
+    /// An amountless mainnet invoice, from the same file.
+    const MAINNET_AMOUNTLESS: &str = "lnbc1pj48ugqdq0dehjqctdda6kuaqpp5yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3qsp5xvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxves9qrsgqcqzyswm4efuu52zkzgrcc35fra9fmvj7s9ppxmej85s83hjkh7crcy9vqlradwalsmq40knf3552panjvlhjlrfazmvs86krxuaygut8v30sq0y0422";
+
+    fn regtest(text: &str) -> Bolt11Invoice {
+        text.parse().expect("a valid invoice")
+    }
+
+    #[test]
+    fn preflight_refuses_an_amountless_invoice_first() {
+        let err = preflight(&regtest(MAINNET_AMOUNTLESS), crate::Network::Regtest)
+            .expect_err("amountless");
+        assert_eq!(err.code, crate::ErrorCode::AmountlessInvoice);
+    }
+
+    #[test]
+    fn preflight_reports_a_network_mismatch_with_details() {
+        let err = preflight(&regtest(SEND_INVOICE), crate::Network::Bitcoin).expect_err("bcrt");
+        assert_eq!(err.code, crate::ErrorCode::NetworkMismatch);
+        match err.detail() {
+            Some(crate::ErrorDetails::NetworkMismatch {
+                expected,
+                compatible,
+                observed_prefix,
+            }) => {
+                assert_eq!(*expected, crate::Network::Bitcoin);
+                assert_eq!(compatible, &vec![crate::Network::Regtest]);
+                assert_eq!(observed_prefix, "bcrt");
+            }
+            other => panic!("expected NetworkMismatch details, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_tb_invoice_is_compatible_with_either_public_testnet() {
+        // No `tb` fixture exists, so the expansion is checked directly.
+        assert_eq!(
+            compatible_networks(Some(crate::Network::Testnet)),
+            vec![crate::Network::Testnet, crate::Network::Testnet4]
+        );
+        assert_eq!(compatible_networks(None), Vec::<crate::Network>::new());
+        assert_eq!(
+            compatible_networks(Some(crate::Network::Signet)),
+            vec![crate::Network::Signet]
+        );
+    }
+
+    #[test]
+    fn preflight_refuses_an_expired_invoice_as_invalid_input() {
+        let err =
+            preflight(&regtest(MAINNET_EXPIRED), crate::Network::Bitcoin).expect_err("expired");
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+    }
+
+    #[test]
+    fn preflight_checks_expiry_last() {
+        // The regtest fixture expired in 2023, so on a matching network the expiry is the only
+        // refusal left, which is what proves the amount and network checks ran before it.
+        let err = preflight(&regtest(SEND_INVOICE), crate::Network::Regtest).expect_err("expired");
+        assert_eq!(err.code, crate::ErrorCode::InvalidInput);
+        assert_eq!(
+            regtest(SEND_INVOICE).amount(),
+            Some(Amount::from_msats(100_000))
+        );
+    }
+
+    #[test]
+    fn a_description_longer_than_bolt11_allows_is_invalid_input() {
+        assert!(check_description("coffee").is_ok());
+        assert!(check_description(&"x".repeat(639)).is_ok());
+        assert_eq!(
+            check_description(&"x".repeat(640))
+                .expect_err("too long")
+                .code,
+            crate::ErrorCode::InvalidInput
+        );
+        // Bytes, not characters: a three-byte character counts three times.
+        assert_eq!(
+            check_description(&"€".repeat(214))
+                .expect_err("too long")
+                .code,
+            crate::ErrorCode::InvalidInput
+        );
+    }
+
+    #[test]
+    fn the_fee_breakdown_is_built_from_the_shared_fee_quote() {
+        use fedimint_client_module::transaction::FeeQuote;
+        use fedimint_core::module::Amounts;
+
+        let quote = FeeQuote {
+            input: Amounts::new_bitcoin(fedimint_core::Amount::from_msats(10)),
+            output: Amounts::new_bitcoin(fedimint_core::Amount::from_msats(35)),
+            dust: Amounts::new_bitcoin(fedimint_core::Amount::from_msats(5)),
+        };
+        let plan = plan_of(
+            Amount::from_msats(1_000),
+            Amount::from_msats(25),
+            &quote,
+            Amount::from_msats(100_000),
+            LightningRoute::Internal,
+            Terms::V1 { gateway: None },
+        )
+        .expect("a plan");
+        assert_eq!(
+            plan.breakdown,
+            LnFeeBreakdown {
+                gateway: Amount::from_msats(1_000),
+                lightning_module: Amount::from_msats(25),
+                primary_module: Amount::from_msats(20),
+                dust: Amount::from_msats(5),
+            }
+        );
+        assert_eq!(plan.fee, Amount::from_msats(1_050));
+        assert_eq!(plan.total, Amount::from_msats(101_050));
+    }
+
+    #[test]
+    fn a_fee_quote_below_the_modules_own_fee_is_internal() {
+        use fedimint_client_module::transaction::FeeQuote;
+
+        let err = plan_of(
+            Amount::from_msats(0),
+            Amount::from_msats(25),
+            &FeeQuote::ZERO,
+            Amount::from_msats(1),
+            LightningRoute::Internal,
+            Terms::V1 { gateway: None },
+        )
+        .expect_err("inconsistent");
+        assert_eq!(err.code, crate::ErrorCode::Internal);
+    }
+
+    fn a_quote(expires_at: u64) -> LnQuoteInner {
+        LnQuoteInner {
+            federation_id: fedimint_core::config::FederationId::dummy(),
+            invoice: regtest(SEND_INVOICE),
+            invoice_amount: Amount::from_msats(100_000),
+            plan: Plan {
+                breakdown: LnFeeBreakdown {
+                    gateway: Amount::from_msats(0),
+                    lightning_module: Amount::from_msats(0),
+                    primary_module: Amount::from_msats(0),
+                    dust: Amount::from_msats(0),
+                },
+                fee: Amount::from_msats(0),
+                total: Amount::from_msats(100_000),
+                route: LightningRoute::Internal,
+                terms: Terms::V1 { gateway: None },
+            },
+            expires_at: Timestamp::from_epoch_millis(expires_at),
+        }
+    }
+
+    #[test]
+    fn a_quote_is_executable_until_it_expires_and_only_on_its_federation() {
+        let quote = a_quote(1_000);
+        let id = fedimint_core::config::FederationId::dummy();
+        assert!(ensure_executable(&quote, id, 999).is_ok());
+        assert!(ensure_executable(&quote, id, 1_000).is_ok());
+        let err = ensure_executable(&quote, id, 1_001).expect_err("expired");
+        assert_eq!(err.code, crate::ErrorCode::QuoteExpired);
+        match err.detail() {
+            Some(crate::ErrorDetails::QuoteExpired {
+                expires_at,
+                already_executed,
+            }) => {
+                assert_eq!(*expires_at, Timestamp::from_epoch_millis(1_000));
+                assert!(!already_executed);
+            }
+            other => panic!("expected QuoteExpired details, got {other:?}"),
+        }
+        let other = fedimint_core::config::FederationId(
+            fedimint_core::bitcoin::hashes::Hash::hash(b"another federation"),
+        );
+        assert_eq!(
+            ensure_executable(&quote, other, 0)
+                .expect_err("wrong federation")
+                .code,
+            crate::ErrorCode::InvalidInput
+        );
+    }
+
+    #[test]
+    fn quote_accessors_read_the_frozen_plan() {
+        let quote = LnQuote { inner: a_quote(5) };
+        assert_eq!(quote.invoice_amount(), Amount::from_msats(100_000));
+        assert_eq!(quote.fee(), Amount::from_msats(0));
+        assert_eq!(quote.total(), Amount::from_msats(100_000));
+        assert_eq!(quote.route(), LightningRoute::Internal);
+        assert_eq!(quote.expires_at(), Timestamp::from_epoch_millis(5));
+        assert_eq!(quote.fee_breakdown().gateway, Amount::from_msats(0));
+    }
+
+    #[test]
+    fn the_error_helpers_carry_their_details() {
+        match quote_changed(Amount::from_msats(10), Amount::from_msats(12)).detail() {
+            Some(crate::ErrorDetails::QuoteTermsChanged {
+                quoted_total,
+                current_total,
+            }) => {
+                assert_eq!(*quoted_total, Amount::from_msats(10));
+                assert_eq!(*current_total, Amount::from_msats(12));
+            }
+            other => panic!("expected QuoteTermsChanged, got {other:?}"),
+        }
+        match insufficient(Amount::from_msats(10), Amount::from_msats(3)).detail() {
+            Some(crate::ErrorDetails::InsufficientBalance {
+                required,
+                available,
+            }) => {
+                assert_eq!(*required, Amount::from_msats(10));
+                assert_eq!(*available, Amount::from_msats(3));
+            }
+            other => panic!("expected InsufficientBalance, got {other:?}"),
+        }
+        assert_eq!(
+            quote_expired(Timestamp::from_epoch_millis(1), true).code,
+            crate::ErrorCode::QuoteExpired
+        );
+        assert_eq!(
+            gateway_unavailable("offline").code,
+            crate::ErrorCode::GatewayUnavailable
+        );
+        assert_eq!(
+            unreachable("down").code,
+            crate::ErrorCode::FederationUnreachable
+        );
     }
 }

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -145,9 +145,9 @@ impl Lightning {
     ///
     /// [`QuoteExpired`](crate::ErrorCode::QuoteExpired),
     /// [`QuoteChanged`](crate::ErrorCode::QuoteChanged),
-    /// [`NetworkMismatch`](crate::ErrorCode::NetworkMismatch) on an lnv2
-    /// federation running testnet4, whose module cannot pay a `tb` invoice
-    /// at all,
+    /// [`NetworkMismatch`](crate::ErrorCode::NetworkMismatch) on a
+    /// federation running testnet4, whose lightning module cannot pay a
+    /// `tb` invoice at all,
     /// [`InsufficientBalance`](crate::ErrorCode::InsufficientBalance),
     /// [`GatewayUnavailable`](crate::ErrorCode::GatewayUnavailable),
     /// [`Recovering`](crate::ErrorCode::Recovering) while the federation's
@@ -978,6 +978,29 @@ pub(super) fn insufficient(required: Amount, available: Amount) -> Error {
     )
 }
 
+// Neither lightning generation can name testnet4 as such, so a testnet4 federation's module
+// refuses a `tb` invoice as an unrelated failure rather than the network mismatch it is: lnv2
+// compares the configured network to the invoice's BOLT11 currency class strictly
+// (`self.cfg.network != invoice.currency().into()`,
+// `fedimint-lnv2-client/src/lib.rs:560-565`), and `Currency::BitcoinTestnet` converts only to
+// `bitcoin::Network::Testnet`; v1 converts the configured network through lightning-invoice's
+// `From<bitcoin::Network> for Currency` (`lightning-invoice-0.33.3/src/lib.rs:451-463`), which
+// has no `Testnet4` arm and falls to a `_` arm yielding `Currency::Regtest`, so its own check
+// (`fedimint-ln-client/src/lib.rs:834-839`) never matches a `tb` invoice either. Tracked
+// upstream as fedimint/fedimint#9100; both generations report this refusal with the same
+// detail `check_network` would have produced, rather than the SDK working around it.
+pub(super) fn network_refusal(quote: &LnQuoteInner, expected: Network) -> Error {
+    Error::with_details(
+        ErrorCode::NetworkMismatch,
+        "the lightning module refused the invoice's network",
+        ErrorDetails::NetworkMismatch {
+            expected,
+            compatible: compatible_networks(quote.invoice.network()),
+            observed_prefix: quote.invoice.observed_prefix(),
+        },
+    )
+}
+
 pub(super) fn gateway_unavailable(cause: impl core::fmt::Display) -> Error {
     Error::new(
         ErrorCode::GatewayUnavailable,
@@ -1450,6 +1473,25 @@ mod tests {
                 terms: Terms::V1 { gateway: None },
             },
             expires_at: Timestamp::from_epoch_millis(expires_at),
+        }
+    }
+
+    #[test]
+    fn network_refusal_carries_the_regtest_invoices_networks() {
+        let quote = a_quote(0);
+        let err = network_refusal(&quote, crate::Network::Testnet4);
+        assert_eq!(err.code, crate::ErrorCode::NetworkMismatch);
+        match err.detail() {
+            Some(crate::ErrorDetails::NetworkMismatch {
+                expected,
+                compatible,
+                observed_prefix,
+            }) => {
+                assert_eq!(*expected, crate::Network::Testnet4);
+                assert_eq!(compatible, &vec![crate::Network::Regtest]);
+                assert_eq!(observed_prefix, "bcrt");
+            }
+            other => panic!("expected NetworkMismatch details, got {other:?}"),
         }
     }
 

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -82,15 +82,35 @@ impl Lightning {
     /// does not expect, which indicates a bug, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn quote(&self, invoice: &Bolt11Invoice) -> Result<LnQuote> {
-        // Implementation notes (delete once implemented):
-        // - Amountless invoices are rejected by both the v1 and the lnv2 payment paths and
-        //   upstream considers supporting them unsafe, so no amount parameter is offered.
-        // - The network check lives here so it runs before anything is committed and on both
-        //   module generations; lnv2's own `WrongCurrency` failure would only surface
-        //   mid-payment on one of them.
-        // - Bind the note selection into the quote: dust depends on which notes are spent, and
-        //   binding it is what makes `LnQuote::total` exact rather than a ceiling.
-        unimplemented!()
+        let federation = &self.inner.federation;
+        // The three generation-independent refusals run before the client is touched, so an
+        // amountless or foreign-network invoice fails the same way on both generations and on
+        // a recovering federation alike.
+        let invoice_amount = preflight(invoice, federation.record().network.into())?;
+        let client = federation.client(true).await?;
+        let plan = match module(&client)? {
+            LnModule::V1(module) => v1::plan(&client, &module, invoice, invoice_amount).await?,
+            LnModule::V2(module) => v2::plan(&client, &module, invoice, invoice_amount).await?,
+        };
+        let available = balance_of(&client).await?;
+        if available < plan.total {
+            return Err(insufficient(plan.total, available));
+        }
+        let issued = crate::db::now_millis();
+        let expires_at = Timestamp::from_epoch_millis(
+            issued
+                .saturating_add(QUOTE_VALIDITY_MILLIS)
+                .min(invoice.expires_at().epoch_millis()),
+        );
+        Ok(LnQuote {
+            inner: LnQuoteInner {
+                federation_id: federation.id,
+                invoice: invoice.clone(),
+                invoice_amount,
+                plan,
+                expires_at,
+            },
+        })
     }
 
     /// Executes a quoted payment.
@@ -132,14 +152,46 @@ impl Lightning {
     /// does not expect, which indicates a bug, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn send(&self, quote: LnQuote) -> Result<Operation<LnSendState>> {
-        // Implementation notes (delete once implemented):
-        // - Re-check every bound input of the quote (gateway, its fee, federation config,
-        //   note selection) before funding; any drift is `QuoteChanged`, never a different
-        //   debit.
-        // - Write `LnSendDetails` in the same storage transaction that creates the operation.
-        //   The v1 progress stream reports neither the fee nor the gateway id, so the record
-        //   is the only source for them on a refunded or failed payment.
-        unimplemented!()
+        let federation = &self.inner.federation;
+        let quote = quote.inner;
+        ensure_executable(&quote, federation.id, crate::db::now_millis())?;
+        // The guard is held across the re-check, the funding and the record write, which is what
+        // `create_operation` requires of its caller.
+        let client = federation.client(true).await?;
+        let available = balance_of(&client).await?;
+        if available < quote.plan.total {
+            return Err(insufficient(quote.plan.total, available));
+        }
+        match (module(&client)?, &quote.plan.terms) {
+            (LnModule::V1(module), Terms::V1 { gateway }) => {
+                v1::send(federation, &client, &module, &quote, gateway.clone()).await
+            }
+            (
+                LnModule::V2(module),
+                Terms::V2 {
+                    gateway,
+                    send_fee,
+                    expiration_delta,
+                },
+            ) => {
+                v2::send(
+                    federation,
+                    &client,
+                    &module,
+                    &quote,
+                    gateway.clone(),
+                    *send_fee,
+                    *expiration_delta,
+                )
+                .await
+            }
+            // The federation changed generation between the quote and now, which the
+            // generation rule makes a different federation for every practical purpose.
+            _ => Err(Error::new(
+                ErrorCode::QuoteChanged,
+                "this federation's lightning module changed since the quote was issued",
+            )),
+        }
     }
 
     /// Issues an invoice payable into this federation.
@@ -176,12 +228,19 @@ impl Lightning {
     /// does not expect, which indicates a bug, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn receive(&self, amount: Amount, description: &str) -> Result<LnReceive> {
-        // Implementation notes (delete once implemented):
-        // - Write `LnReceiveDetails` in the same storage transaction that creates the
-        //   operation.
-        // - Record the phase the receive reaches durably (see the notes on `LnReceiveState`):
-        //   the terminal v1 event alone does not say whether a payment was ever confirmed.
-        unimplemented!()
+        if amount == Amount::from_msats(0) {
+            return Err(Error::new(
+                ErrorCode::InvalidInput,
+                "an invoice for nothing cannot be issued",
+            ));
+        }
+        check_description(description)?;
+        let federation = &self.inner.federation;
+        let client = federation.client(true).await?;
+        match module(&client)? {
+            LnModule::V1(module) => v1::receive(federation, &module, amount, description).await,
+            LnModule::V2(module) => v2::receive(federation, &module, amount, description).await,
+        }
     }
 
     /// Builds the facade for one federation. Handed out by `Federation::lightning`.

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -124,21 +124,14 @@ impl Lightning {
 
     /// Executes a quoted payment.
     ///
-    /// The quote is consumed. Its terms are checked again immediately before
-    /// funding and execution refuses to proceed if they moved:
+    /// The quote is consumed. Execution follows it exactly, same amount, same
+    /// fee, same route, or does not happen:
     /// [`QuoteExpired`](crate::ErrorCode::QuoteExpired) if the quote's
     /// validity window has passed,
     /// [`QuoteChanged`](crate::ErrorCode::QuoteChanged) if something the
     /// quote depends on moved underneath it, such as the gateway withdrawing
-    /// or changing its fee before that check runs. Both mean the same thing
-    /// to a caller: quote again and re-confirm with the user.
-    ///
-    /// That check cannot close the gap after itself: a gateway that changes
-    /// its fee in the instant between the check and the payment actually
-    /// being funded is not caught by it, and the payment funds anyway, at
-    /// the fee the gateway actually took rather than the quoted one.
-    /// [`LnSendDetails::fee`] and [`LnSendDetails::total`] report that true
-    /// figure, not the quote's.
+    /// or changing its fee. Both mean the same thing to a caller: quote again
+    /// and re-confirm with the user.
     ///
     /// The returned operation tracks the payment from funding to preimage. A
     /// payment that fails ends in a final state, not in an error from this
@@ -312,9 +305,7 @@ impl LnQuote {
     /// [`QuoteChanged`](crate::ErrorCode::QuoteChanged), whose
     /// [`ErrorDetails::QuoteTermsChanged`](crate::ErrorDetails::QuoteTermsChanged)
     /// names this total and the one the payment would now cost. The same
-    /// figure is what [`LnSendDetails::total`] records, unless the gateway's
-    /// fee moved in the instant [`Lightning::send`] funds the payment; its
-    /// docs say what is recorded then.
+    /// figure is what [`LnSendDetails::total`] records.
     pub fn total(&self) -> Amount {
         self.inner.plan.total
     }

--- a/rust/fedimint-sdk/src/lightning/driver.rs
+++ b/rust/fedimint-sdk/src/lightning/driver.rs
@@ -1,12 +1,18 @@
 //! The two lightning drivers, the backfiller, and the stream helpers they share.
 
 use core::time::Duration;
+use std::any::Any;
 
+use fedimint_core::core::OperationId;
 use fedimint_core::task::MaybeSend;
-use fedimint_core::util::BoxStream;
+use fedimint_core::util::{BoxFuture, BoxStream};
 use futures::{Stream, StreamExt, future};
 
-use crate::{Error, ErrorCode, OperationState, Result};
+use super::{v1, v2, wire};
+use crate::db::OperationRecord;
+use crate::federation::FederationInner;
+use crate::operation::{Backfilled, Backfiller, Driver};
+use crate::{Error, ErrorCode, LnReceiveState, LnSendState, OperationState, Result};
 
 /// How long `current` waits for the next replayed state before calling the last one current.
 ///
@@ -60,4 +66,125 @@ where
             "this operation's subscription yielded no state",
         )
     })
+}
+
+/// Observes an outgoing lightning payment of either generation, chosen by the record's module.
+pub(crate) struct LnSendDriver;
+
+impl Driver<LnSendState> for LnSendDriver {
+    fn current<'a>(
+        &'a self,
+        federation: &'a FederationInner,
+        id: OperationId,
+        record: &'a OperationRecord,
+    ) -> BoxFuture<'a, Result<LnSendState>> {
+        Box::pin(async move {
+            if let Some(encoded) = &record.final_state {
+                return wire::decode_send_state(encoded);
+            }
+            settle(self.subscribe(federation, id, record).await?).await
+        })
+    }
+
+    fn subscribe<'a>(
+        &'a self,
+        federation: &'a FederationInner,
+        id: OperationId,
+        record: &'a OperationRecord,
+    ) -> BoxFuture<'a, Result<BoxStream<'static, Result<LnSendState>>>> {
+        Box::pin(async move {
+            let details = wire::decode_send_details(&record.details)?;
+            match record.module.as_str() {
+                "ln" => v1::subscribe_send(federation, id, &details).await,
+                "lnv2" => {
+                    v2::subscribe_send(federation, id, record.phase.unwrap_or(0), &details).await
+                }
+                other => Err(unknown_module(other)),
+            }
+        })
+    }
+
+    fn same_state(&self, previous: &LnSendState, next: &LnSendState) -> bool {
+        previous == next
+    }
+
+    fn encode_state(&self, state: &LnSendState) -> Result<String> {
+        wire::encode_send_state(state)
+    }
+
+    fn decode_details(&self, json: &str) -> Result<Box<dyn Any + Send + Sync>> {
+        Ok(Box::new(wire::decode_send_details(json)?))
+    }
+}
+
+/// Observes an incoming lightning payment of either generation.
+pub(crate) struct LnReceiveDriver;
+
+impl Driver<LnReceiveState> for LnReceiveDriver {
+    fn current<'a>(
+        &'a self,
+        federation: &'a FederationInner,
+        id: OperationId,
+        record: &'a OperationRecord,
+    ) -> BoxFuture<'a, Result<LnReceiveState>> {
+        Box::pin(async move {
+            if let Some(encoded) = &record.final_state {
+                return wire::decode_receive_state(encoded);
+            }
+            settle(self.subscribe(federation, id, record).await?).await
+        })
+    }
+
+    fn subscribe<'a>(
+        &'a self,
+        federation: &'a FederationInner,
+        id: OperationId,
+        record: &'a OperationRecord,
+    ) -> BoxFuture<'a, Result<BoxStream<'static, Result<LnReceiveState>>>> {
+        Box::pin(async move {
+            let phase = record.phase.unwrap_or(0);
+            match record.module.as_str() {
+                "ln" => v1::subscribe_receive(federation, id, phase, &record.details).await,
+                "lnv2" => v2::subscribe_receive(federation, id, phase).await,
+                other => Err(unknown_module(other)),
+            }
+        })
+    }
+
+    fn same_state(&self, previous: &LnReceiveState, next: &LnReceiveState) -> bool {
+        previous == next
+    }
+
+    fn encode_state(&self, state: &LnReceiveState) -> Result<String> {
+        wire::encode_receive_state(state)
+    }
+
+    fn decode_details(&self, json: &str) -> Result<Box<dyn Any + Send + Sync>> {
+        Ok(Box::new(wire::decode_receive_details(json)?))
+    }
+}
+
+/// Rebuilds a lightning record from the module's own log entry, for either generation.
+pub(crate) struct LnBackfiller;
+
+impl Backfiller for LnBackfiller {
+    fn backfill(
+        &self,
+        module_kind: &str,
+        meta: &serde_json::Value,
+        created_at: u64,
+    ) -> Option<Backfilled> {
+        match module_kind {
+            "ln" => v1::backfill(meta, created_at),
+            "lnv2" => v2::backfill(meta, created_at),
+            _ => None,
+        }
+    }
+}
+
+fn unknown_module(module: &str) -> Error {
+    Error::new(
+        ErrorCode::Internal,
+        format!("a lightning record names a module this build cannot observe: {module:?}"),
+    )
 }

--- a/rust/fedimint-sdk/src/lightning/driver.rs
+++ b/rust/fedimint-sdk/src/lightning/driver.rs
@@ -1,0 +1,63 @@
+//! The two lightning drivers, the backfiller, and the stream helpers they share.
+
+use core::time::Duration;
+
+use fedimint_core::task::MaybeSend;
+use fedimint_core::util::BoxStream;
+use futures::{Stream, StreamExt, future};
+
+use crate::{Error, ErrorCode, OperationState, Result};
+
+/// How long `current` waits for the next replayed state before calling the last one current.
+///
+/// Neither upstream module offers a "current state" read: v1's `subscribe_*` are generators that
+/// re-run from the first state and resolve each already-passed stage immediately, and lnv2's
+/// notifier replays the stored states before streaming new ones. Draining with a short wait per
+/// item is how a point-in-time answer is produced from that.
+const CURRENT_STATE_SETTLE: Duration = Duration::from_millis(500);
+
+/// Ends a stream after its first final state, and on the first error.
+pub(super) fn until_final<S>(
+    stream: impl Stream<Item = Result<S>> + MaybeSend + 'static,
+) -> BoxStream<'static, Result<S>>
+where
+    S: OperationState,
+{
+    Box::pin(stream.scan(false, |done, item| {
+        if *done {
+            return future::ready(None);
+        }
+        *done = match &item {
+            Ok(state) => state.is_final(),
+            Err(_) => true,
+        };
+        future::ready(Some(item))
+    }))
+}
+
+/// The last state a fresh subscription yields promptly: the current one.
+pub(super) async fn settle<S>(mut stream: BoxStream<'static, Result<S>>) -> Result<S>
+where
+    S: OperationState,
+{
+    let mut last = None;
+    loop {
+        match fedimint_core::runtime::timeout(CURRENT_STATE_SETTLE, stream.next()).await {
+            Ok(Some(Ok(state))) => {
+                let done = state.is_final();
+                last = Some(state);
+                if done {
+                    break;
+                }
+            }
+            Ok(Some(Err(err))) => return Err(err),
+            Ok(None) | Err(_) => break,
+        }
+    }
+    last.ok_or_else(|| {
+        Error::new(
+            ErrorCode::Internal,
+            "this operation's subscription yielded no state",
+        )
+    })
+}

--- a/rust/fedimint-sdk/src/lightning/driver.rs
+++ b/rust/fedimint-sdk/src/lightning/driver.rs
@@ -41,31 +41,54 @@ where
     }))
 }
 
-/// The last state a fresh subscription yields promptly: the current one.
-pub(super) async fn settle<S>(mut stream: BoxStream<'static, Result<S>>) -> Result<S>
+/// A subscription that yields the current state first: the replayed history is drained the way
+/// `settle` drains it, the last state it produced is yielded, and every state after that is
+/// forwarded as it comes.
+///
+/// If the inner stream ends before producing anything, this ends too, without yielding: that is
+/// not an "empty" current state, it is the absence of one, and `OperationUpdates::next`'s
+/// `current` fallback is what turns it into an answer. If the yielded state is final (or an
+/// error), nothing more is drained for it; the underlying stream is expected to end right after,
+/// per `Driver::subscribe`'s contract, so the next pull simply observes that.
+pub(super) fn settled<S>(stream: BoxStream<'static, Result<S>>) -> BoxStream<'static, Result<S>>
 where
     S: OperationState,
 {
-    let mut last = None;
-    loop {
-        match fedimint_core::runtime::timeout(CURRENT_STATE_SETTLE, stream.next()).await {
-            Ok(Some(Ok(state))) => {
-                let done = state.is_final();
-                last = Some(state);
-                if done {
-                    break;
+    Box::pin(futures::stream::unfold(
+        (stream, false),
+        |(mut stream, started)| async move {
+            if started {
+                return stream.next().await.map(|item| (item, (stream, true)));
+            }
+            // The first item is awaited without a timeout: both generations yield it promptly,
+            // and the engine already races every wait in this call against the federation's
+            // `closed` watch. Every item after that is drained with the same per-item timeout
+            // `settle` used to apply itself, stopping at the first final state, the first error,
+            // or the first timeout.
+            let mut last = stream.next().await?;
+            while !matches!(&last, Ok(state) if state.is_final()) && last.is_ok() {
+                match fedimint_core::runtime::timeout(CURRENT_STATE_SETTLE, stream.next()).await {
+                    Ok(Some(item)) => last = item,
+                    Ok(None) | Err(_) => break,
                 }
             }
-            Ok(Some(Err(err))) => return Err(err),
-            Ok(None) | Err(_) => break,
-        }
-    }
-    last.ok_or_else(|| {
-        Error::new(
+            Some((last, (stream, true)))
+        },
+    ))
+}
+
+/// The last state a fresh subscription yields promptly: the current one.
+pub(super) async fn settle<S>(stream: BoxStream<'static, Result<S>>) -> Result<S>
+where
+    S: OperationState,
+{
+    match settled(stream).next().await {
+        Some(item) => item,
+        None => Err(Error::new(
             ErrorCode::Internal,
             "this operation's subscription yielded no state",
-        )
-    })
+        )),
+    }
 }
 
 /// Observes an outgoing lightning payment of either generation, chosen by the record's module.
@@ -94,13 +117,14 @@ impl Driver<LnSendState> for LnSendDriver {
     ) -> BoxFuture<'a, Result<BoxStream<'static, Result<LnSendState>>>> {
         Box::pin(async move {
             let details = wire::decode_send_details(&record.details)?;
-            match record.module.as_str() {
+            let stream = match record.module.as_str() {
                 "ln" => v1::subscribe_send(federation, id, &details).await,
                 "lnv2" => {
                     v2::subscribe_send(federation, id, record.phase.unwrap_or(0), &details).await
                 }
                 other => Err(unknown_module(other)),
-            }
+            }?;
+            Ok(settled(stream))
         })
     }
 
@@ -143,11 +167,12 @@ impl Driver<LnReceiveState> for LnReceiveDriver {
     ) -> BoxFuture<'a, Result<BoxStream<'static, Result<LnReceiveState>>>> {
         Box::pin(async move {
             let phase = record.phase.unwrap_or(0);
-            match record.module.as_str() {
+            let stream = match record.module.as_str() {
                 "ln" => v1::subscribe_receive(federation, id, phase, &record.details).await,
                 "lnv2" => v2::subscribe_receive(federation, id, phase).await,
                 other => Err(unknown_module(other)),
-            }
+            }?;
+            Ok(settled(stream))
         })
     }
 
@@ -187,4 +212,106 @@ fn unknown_module(module: &str) -> Error {
         ErrorCode::Internal,
         format!("a lightning record names a module this build cannot observe: {module:?}"),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    // Only `LnSendState`'s non-final (`Created`, `Funded`) and final (`Refunded`, `Failed`)
+    // variants that need no fields are used below; `settled` treats every state the same way
+    // regardless of which state enum it is instantiated with.
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn late_subscriber_sees_settled_state_first() {
+        let stream: BoxStream<'static, Result<LnSendState>> = Box::pin(
+            stream::iter([Ok(LnSendState::Created), Ok(LnSendState::Funded)])
+                .chain(stream::pending()),
+        );
+        let mut settled_stream = settled(stream);
+
+        let first = settled_stream.next().await;
+        assert_eq!(
+            first.expect("stream ended").expect("stream errored"),
+            LnSendState::Funded
+        );
+
+        // The replayed history is exhausted and the tail is still pending, so nothing more
+        // should arrive within a settle window.
+        let second = tokio::time::timeout(Duration::from_millis(50), settled_stream.next()).await;
+        assert!(
+            second.is_err(),
+            "a second item arrived when none should have"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn transitions_after_the_first_item_are_forwarded() {
+        let (tx, rx) = oneshot::channel::<()>();
+        let gated = stream::once(async move {
+            rx.await.expect("gate sender dropped");
+            Ok(LnSendState::Funded)
+        });
+        let stream: BoxStream<'static, Result<LnSendState>> = Box::pin(
+            stream::iter([Ok(LnSendState::Created)])
+                .chain(gated)
+                .chain(stream::iter([Ok(LnSendState::Refunded)])),
+        );
+        let mut settled_stream = settled(stream);
+
+        // The settle window elapses waiting for the gated state, so the first pull settles on
+        // `Created`.
+        let first = settled_stream.next().await;
+        assert_eq!(
+            first.expect("stream ended").expect("stream errored"),
+            LnSendState::Created
+        );
+
+        tx.send(()).expect("gate receiver dropped");
+        let second = settled_stream.next().await;
+        assert_eq!(
+            second.expect("stream ended").expect("stream errored"),
+            LnSendState::Funded
+        );
+        let third = settled_stream.next().await;
+        assert_eq!(
+            third.expect("stream ended").expect("stream errored"),
+            LnSendState::Refunded
+        );
+        assert!(settled_stream.next().await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn replay_ending_in_a_final_state_yields_only_that_state() {
+        let stream: BoxStream<'static, Result<LnSendState>> = Box::pin(stream::iter([
+            Ok(LnSendState::Created),
+            Ok(LnSendState::Funded),
+            Ok(LnSendState::Refunded),
+        ]));
+        let mut settled_stream = settled(stream);
+
+        let first = settled_stream.next().await;
+        assert_eq!(
+            first.expect("stream ended").expect("stream errored"),
+            LnSendState::Refunded
+        );
+        assert!(settled_stream.next().await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_stream_yields_nothing() {
+        let stream: BoxStream<'static, Result<LnSendState>> = Box::pin(stream::empty());
+        let mut settled_stream = settled(stream);
+        assert!(settled_stream.next().await.is_none());
+
+        // `settle` (the engine's own direct read) turns that into its usual "no state" error.
+        let stream: BoxStream<'static, Result<LnSendState>> = Box::pin(stream::empty());
+        let err = settle(stream)
+            .await
+            .expect_err("an empty stream must not settle");
+        assert_eq!(err.code, ErrorCode::Internal);
+    }
 }

--- a/rust/fedimint-sdk/src/lightning/driver.rs
+++ b/rust/fedimint-sdk/src/lightning/driver.rs
@@ -41,9 +41,9 @@ where
     }))
 }
 
-/// A subscription that yields the current state first: the replayed history is drained the way
-/// `settle` drains it, the last state it produced is yielded, and every state after that is
-/// forwarded as it comes.
+/// A subscription that yields the current state first: the replayed history is drained until it
+/// settles, the last state it produced is yielded, and every state after that is forwarded as it
+/// comes.
 ///
 /// If the inner stream ends before producing anything, this ends too, without yielding: that is
 /// not an "empty" current state, it is the absence of one, and `OperationUpdates::next`'s
@@ -62,11 +62,10 @@ where
             }
             // The first item is awaited without a timeout: both generations yield it promptly,
             // and the engine already races every wait in this call against the federation's
-            // `closed` watch. Every item after that is drained with the same per-item timeout
-            // `settle` used to apply itself, stopping at the first final state, the first error,
-            // or the first timeout.
+            // `closed` watch. Every item after that is drained with the same per-item timeout,
+            // stopping at the first final state, the first error, or the first timeout.
             let mut last = stream.next().await?;
-            while !matches!(&last, Ok(state) if state.is_final()) && last.is_ok() {
+            while matches!(&last, Ok(state) if !state.is_final()) {
                 match fedimint_core::runtime::timeout(CURRENT_STATE_SETTLE, stream.next()).await {
                     Ok(Some(item)) => last = item,
                     Ok(None) | Err(_) => break,
@@ -77,12 +76,15 @@ where
     ))
 }
 
-/// The last state a fresh subscription yields promptly: the current one.
-pub(super) async fn settle<S>(stream: BoxStream<'static, Result<S>>) -> Result<S>
+/// The first state a stream yields, mapping an ended stream to this operation's "no state" error.
+///
+/// `Driver::subscribe` already returns a stream wrapped in [`settled`], so this drains it once
+/// rather than draining it a second time the way calling [`settled`] again over it would.
+pub(super) async fn first_state<S>(mut stream: BoxStream<'static, Result<S>>) -> Result<S>
 where
     S: OperationState,
 {
-    match settled(stream).next().await {
+    match stream.next().await {
         Some(item) => item,
         None => Err(Error::new(
             ErrorCode::Internal,
@@ -105,7 +107,7 @@ impl Driver<LnSendState> for LnSendDriver {
             if let Some(encoded) = &record.final_state {
                 return wire::decode_send_state(encoded);
             }
-            settle(self.subscribe(federation, id, record).await?).await
+            first_state(self.subscribe(federation, id, record).await?).await
         })
     }
 
@@ -155,7 +157,7 @@ impl Driver<LnReceiveState> for LnReceiveDriver {
             if let Some(encoded) = &record.final_state {
                 return wire::decode_receive_state(encoded);
             }
-            settle(self.subscribe(federation, id, record).await?).await
+            first_state(self.subscribe(federation, id, record).await?).await
         })
     }
 
@@ -307,9 +309,10 @@ mod tests {
         let mut settled_stream = settled(stream);
         assert!(settled_stream.next().await.is_none());
 
-        // `settle` (the engine's own direct read) turns that into its usual "no state" error.
+        // `first_state` (what `current` calls on `subscribe`'s stream) turns that into its usual
+        // "no state" error.
         let stream: BoxStream<'static, Result<LnSendState>> = Box::pin(stream::empty());
-        let err = settle(stream)
+        let err = first_state(stream)
             .await
             .expect_err("an empty stream must not settle");
         assert_eq!(err.code, ErrorCode::Internal);

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -514,10 +514,21 @@ async fn terms_for(
         from_upstream(gateway.fees.to_amount(&to_upstream(amount)))
     });
     let contract_amount = add(amount, gateway_fee)?;
+    // A dry run of the primary module's balancing fails with `InsufficientBalanceError` when the
+    // notes on hand cannot cover the contract; that is reported as the balance problem it is,
+    // rather than as an opaque internal failure.
     let quote = module
         .send_fee_quote(to_upstream(contract_amount))
         .await
-        .map_err(|err| internal(format!("could not quote the funding fee: {err}")))?;
+        .map_err(|err| {
+            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
+                Some(short) => insufficient(
+                    from_upstream(short.requested_amount),
+                    from_upstream(short.total_amount),
+                ),
+                None => internal(format!("could not quote the funding fee: {err}")),
+            }
+        })?;
     let lightning_module = from_upstream(module.cfg.fee_consensus.contract_output);
     let route = match &gateway {
         None => LightningRoute::Internal,
@@ -538,10 +549,23 @@ async fn terms_for(
 /// Executes a v1 quote: re-reads every bound input, refuses on drift, funds, records.
 pub(super) async fn send(
     federation: &Arc<FederationInner>,
+    client: &Client,
     module: &ClientModuleInstance<'_, LightningClientModule>,
     quote: &LnQuoteInner,
     gateway: Option<Box<LightningGateway>>,
 ) -> Result<Operation<LnSendState>> {
+    // `pay_bolt11_invoice` decides internal-vs-gateway for itself, from the invoice and the
+    // gateway cache as they stand when it is called (`fedimint-ln-client/src/lib.rs:1405-1418`).
+    // That cache is shared and can move between the quote and this call, so the same decision is
+    // read again here, before anything is funded: a route that moved is `QuoteChanged`, not a
+    // fee mismatch discovered only after the payment went out.
+    let quoted_internal = matches!(quote.plan.route, LightningRoute::Internal);
+    if is_internal(client, module, &quote.invoice).await? != quoted_internal {
+        return Err(Error::new(
+            ErrorCode::QuoteChanged,
+            "the payment's route changed since the quote was issued; quote again",
+        ));
+    }
     // The gateway may have withdrawn or changed its fees since the quote; the cache is what the
     // module pays through, so it is what is checked.
     let gateway = match gateway {
@@ -594,9 +618,15 @@ pub(super) async fn send(
                     | PayBolt11InvoiceError::FundedContractAlreadyExists { .. } => {
                         quote_expired(quote.expires_at, true)
                     }
-                    PayBolt11InvoiceError::NoLnGatewayAvailable => {
-                        gateway_unavailable("the module found no gateway for this route")
-                    }
+                    // A `None` gateway is only ever passed for a quote whose route was checked
+                    // internal just above; this fires only when the shared cache moved again
+                    // between that check and this call, so the module's own re-derivation no
+                    // longer agrees the payment is internal. The same drift the check above
+                    // guards against, caught one call later instead of missed.
+                    PayBolt11InvoiceError::NoLnGatewayAvailable => Error::new(
+                        ErrorCode::QuoteChanged,
+                        "the payment's route changed since the quote was issued; quote again",
+                    ),
                 };
             }
             if let Some(short) =
@@ -611,20 +641,42 @@ pub(super) async fn send(
             if text.contains("Invoice has expired") {
                 return quote_expired(quote.expires_at, false);
             }
-            if text.contains("Insufficient balance") {
-                return Error::new(ErrorCode::InsufficientBalance, text);
-            }
             internal(format!("the payment could not be started: {text}"))
         })?;
-    let (id, route) = match payment.payment_type {
-        PayType::Internal(id) => (id, LightningRoute::Internal),
-        PayType::Lightning(id) => (id, quote.plan.route.clone()),
+    // The module's own answer is authoritative for what actually happened, so the record reflects
+    // what was debited, not what was quoted. The two normally agree, because the check above
+    // reads the same decision the module is about to make; they can still disagree once more,
+    // since the gateway cache the module reads from is shared and can move again between that
+    // check and this call. When a payment quoted through a gateway settles internally after all,
+    // no gateway fee was ever charged, so it is backed out of the quoted fee and total.
+    let (id, route, fee, total) = match payment.payment_type {
+        PayType::Internal(id) if quoted_internal => (
+            id,
+            LightningRoute::Internal,
+            quote.plan.fee,
+            quote.plan.total,
+        ),
+        PayType::Internal(id) => {
+            let fee = quote
+                .plan
+                .fee
+                .checked_sub(quote.plan.breakdown.gateway)
+                .ok_or_else(|| internal("the quoted fee is smaller than the quoted gateway fee"))?;
+            let total = add(quote.invoice_amount, fee)?;
+            (id, LightningRoute::Internal, fee, total)
+        }
+        PayType::Lightning(id) => (
+            id,
+            quote.plan.route.clone(),
+            quote.plan.fee,
+            quote.plan.total,
+        ),
     };
     let details = crate::LnSendDetails {
         invoice: quote.invoice.clone(),
         invoice_amount: quote.invoice_amount,
-        fee: quote.plan.fee,
-        total: quote.plan.total,
+        fee,
+        total,
         route,
         created_at: now(),
     };
@@ -662,10 +714,21 @@ pub(super) async fn receive(
         .map_err(gateway_unavailable)?;
     // v1 takes no gateway fee on the way in: the gateway funds the contract for the invoice's
     // amount and the only deduction is the federation's fee for claiming it.
+    // Same as in `terms_for`: a dry run of the primary module's balancing fails with
+    // `InsufficientBalanceError` when the notes on hand cannot cover the contract, which is
+    // reported as the balance problem it is.
     let quote = module
         .receive_fee_quote(to_upstream(amount))
         .await
-        .map_err(|err| internal(format!("could not quote the claim fee: {err}")))?;
+        .map_err(|err| {
+            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
+                Some(short) => insufficient(
+                    from_upstream(short.requested_amount),
+                    from_upstream(short.total_amount),
+                ),
+                None => internal(format!("could not quote the claim fee: {err}")),
+            }
+        })?;
     let fee = from_upstream(quote.total().get_bitcoin());
     let net_credit = amount.checked_sub(fee).ok_or_else(|| {
         Error::new(

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -23,9 +23,9 @@ use futures::{StreamExt, stream};
 use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
 use super::{
-    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, fee_quote_failure, from_upstream,
-    gateway_unavailable, insufficient, internal, now, plan_of, quote_changed, quote_expired,
-    subscribe_error, to_upstream, unreachable,
+    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, balance_of, fee_quote_failure,
+    from_upstream, gateway_unavailable, insufficient, internal, now, plan_of, quote_changed,
+    quote_expired, subscribe_error, to_upstream, unreachable,
 };
 use crate::federation::FederationInner;
 use crate::operation::{Backfilled, Driver, kinds, record_phase_in, write_details_in};
@@ -221,6 +221,10 @@ pub(super) fn map_reclaim(state: &UpstreamReceiveState) -> LnReceiveState {
 ///
 /// A stream outlives the borrow it was made from, so it cannot hold a client guard; it holds the
 /// instance and the federation id instead and takes a guard again when the retry happens.
+///
+/// `Clone` so a copy can be moved into the spawned task that runs `start`: the fields are a
+/// `Weak`, a `Copy` id, a `Clone` handle and another `Copy` id, none of which mind two owners.
+#[derive(Clone)]
 struct ReclaimContext {
     sdk: Weak<SdkInner>,
     federation_id: fedimint_core::config::FederationId,
@@ -238,7 +242,11 @@ enum ReclaimStart {
 impl ReclaimContext {
     /// Starts the retry upstream, records which operation it runs under, and returns its
     /// stream — or the module's word that no further claim is possible.
-    async fn start(&self) -> Result<ReclaimStart> {
+    ///
+    /// Takes `self` by value because `step` runs this as a spawned task (see its comment on
+    /// why), and a spawned future must own everything it touches rather than borrow from a
+    /// stream state that may be dropped before the task finishes.
+    async fn start(self) -> Result<ReclaimStart> {
         let closed = || {
             Error::new(
                 ErrorCode::FederationClosed,
@@ -368,31 +376,56 @@ async fn step(mut follow: Follow) -> Option<(Result<LnReceiveState>, Follow)> {
             ReceiveStep::State(state) => state,
             // `ClaimRejected` is not final here: the claim is retried under the same SDK
             // operation, and only a retry that cannot be started is the end.
-            ReceiveStep::Reclaim => match follow.context.start().await {
-                Ok(ReclaimStart::Started(upstream)) => {
-                    follow.upstream = upstream;
-                    follow.following = Following::Reclaim;
-                    LnReceiveState::Funded
+            //
+            // `start` registers the retry with the module and then persists its id; the
+            // registration upstream and the record of it must not be separated by a poll that
+            // `settle` cancels between the two, or the SDK's record never learns the retry's id
+            // and the next subscription repeats the sequence, starting another retry forever.
+            // Running it as a task the poller only waits for keeps the two together: a poller
+            // dropped mid-wait leaves the task to finish on its own, and the next subscription
+            // then finds the persisted id and follows it instead of registering yet another
+            // retry. The stream a completed task returns is dropped along with its result if
+            // nobody awaited it in time; that is fine, since the persisted id, not this stream,
+            // is what the next subscription follows.
+            ReceiveStep::Reclaim => {
+                let started = match fedimint_core::task::spawn(
+                    "ln receive: start a claim retry",
+                    follow.context.clone().start(),
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(err) => Err(Error::new(
+                        ErrorCode::Internal,
+                        format!("the claim retry's startup task did not finish: {err}"),
+                    )),
+                };
+                match started {
+                    Ok(ReclaimStart::Started(upstream)) => {
+                        follow.upstream = upstream;
+                        follow.following = Following::Reclaim;
+                        LnReceiveState::Funded
+                    }
+                    // The module says no further claim is possible: that is the one ending the
+                    // contract reserves `Failed` for. The reason is logged here, its only
+                    // reader, since `LnReceiveState::Failed` does not carry it.
+                    Ok(ReclaimStart::Impossible(reason)) => {
+                        tracing::warn!(
+                            target: "fedimint_sdk",
+                            operation = %follow.context.id.fmt_full(),
+                            reason = %reason,
+                            "a rejected lightning claim cannot be retried",
+                        );
+                        LnReceiveState::Failed
+                    }
+                    // Anything else is an observation failure, not an outcome: the next
+                    // subscription replays the rejection and tries again.
+                    Err(err) => {
+                        follow.done = true;
+                        return Some((Err(err), follow));
+                    }
                 }
-                // The module says no further claim is possible: that is the one ending the
-                // contract reserves `Failed` for. The reason is logged here, its only reader,
-                // since `LnReceiveState::Failed` does not carry it.
-                Ok(ReclaimStart::Impossible(reason)) => {
-                    tracing::warn!(
-                        target: "fedimint_sdk",
-                        operation = %follow.context.id.fmt_full(),
-                        reason = %reason,
-                        "a rejected lightning claim cannot be retried",
-                    );
-                    LnReceiveState::Failed
-                }
-                // Anything else is an observation failure, not an outcome: the next subscription
-                // replays the rejection and tries again.
-                Err(err) => {
-                    follow.done = true;
-                    return Some((Err(err), follow));
-                }
-            },
+            }
         },
     };
     if matches!(mapped, LnReceiveState::Funded) && follow.phase < PHASE_FUNDED {
@@ -583,6 +616,15 @@ pub(super) async fn send(
         {
             return Err(quote_expired(quote.expires_at, true));
         }
+    }
+    // Checked again here, after the already-executed checks above and before the route and
+    // terms re-checks below: the balance can drop between a quote and this call, and it must be
+    // asked whether the invoice was already paid before it is asked whether the balance still
+    // covers it, or a second quote for an already-paid invoice is misreported as a shortfall
+    // instead of the truth.
+    let available = balance_of(client).await?;
+    if available < quote.plan.total {
+        return Err(insufficient(quote.plan.total, available));
     }
     // `pay_bolt11_invoice` decides internal-vs-gateway for itself, from the invoice and the
     // gateway cache as they stand when it is called (`fedimint-ln-client/src/lib.rs:1405-1418`).

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -290,6 +290,28 @@ impl ReclaimContext {
             ));
         }
 
+        // Upstream commits the reclaim's own operation entry inside `reclaim_ln_receive`
+        // (`manual_operation_start_dbtx` then `dbtx.commit_tx()`,
+        // fedimint-ln-client/src/lib.rs) before this function gets to persist its id on the
+        // record below. A crash in that window would otherwise call `reclaim_ln_receive` again
+        // here and start a second claim state machine competing with the first for the same
+        // contract. The scan is bounded: a reclaim is always newer than the receive it retries,
+        // so nothing the walk finds older than this record's `created_at` can be it.
+        if let Some(reclaim_id) = existing_reclaim(&self.db, self.id, record.created_at).await? {
+            // Persisted before it is followed: same reasoning as below, and this path exists
+            // because that persist step is exactly what a crash could have skipped last time.
+            details.reclaim_operation_id =
+                Some(crate::OperationId::from_upstream(reclaim_id).to_string());
+            write_details_in(&self.db, self.id, wire::encode_receive_wire(&details)?).await?;
+            return Ok(ReclaimStart::Started(
+                module
+                    .subscribe_ln_receive(reclaim_id)
+                    .await
+                    .map_err(subscribe_error)?
+                    .into_stream(),
+            ));
+        }
+
         let reclaim_id = match module.reclaim_ln_receive(self.id).await {
             Ok(id) => id,
             Err(err) => {
@@ -309,6 +331,53 @@ impl ReclaimContext {
                 .into_stream(),
         ))
     }
+}
+
+/// Looks for a reclaim of `original` that upstream already started and committed, so a retry
+/// after a crash follows it instead of starting a competing one.
+///
+/// Walks the client's chronological index newest first, the way
+/// [`FederationInner::creation_time_of`](crate::federation::FederationInner::creation_time_of)
+/// does, and stops at the first entry older than `created_at` (the receive's own creation time):
+/// a reclaim is always newer than the receive it retries, so nothing older can be it.
+async fn existing_reclaim(
+    db: &Database,
+    original: OperationId,
+    created_at: u64,
+) -> Result<Option<OperationId>> {
+    let mut dbtx = db.begin_transaction_nc().await;
+    let keys: Vec<fedimint_client::db::ChronologicalOperationLogKey> = dbtx
+        .find_by_prefix_sorted_descending(&fedimint_client::db::ChronologicalOperationLogKeyPrefix)
+        .await
+        .map(|(key, ())| key)
+        .collect()
+        .await;
+    drop(dbtx);
+
+    let log = fedimint_client::oplog::OperationLog::new(db.clone());
+    for key in keys {
+        if crate::db::millis_of(key.creation_time) < created_at {
+            break;
+        }
+        let Some(entry) = log.get_operation(key.operation_id).await else {
+            continue;
+        };
+        if entry.operation_module_kind() != "ln" {
+            continue;
+        }
+        let Ok(meta) = entry.try_meta::<LightningOperationMeta>() else {
+            continue;
+        };
+        if let LightningOperationMetaVariant::ReceiveReclaim {
+            original_operation_id,
+            ..
+        } = meta.variant
+            && original_operation_id == original
+        {
+            return Ok(Some(key.operation_id));
+        }
+    }
+    Ok(None)
 }
 
 /// Follows a retry that was already started, from the id the record stores for it.
@@ -1263,5 +1332,115 @@ mod tests {
         });
         assert!(backfill(&meta, 0).is_none());
         assert!(backfill(&serde_json::Value::Null, 0).is_none());
+    }
+
+    /// Writes a v1 log entry the way the module itself does, dated at `created_at`.
+    async fn write_ln_log_entry(
+        db: &fedimint_core::db::Database,
+        id: OperationId,
+        meta: serde_json::Value,
+        created_at: u64,
+    ) {
+        use fedimint_client::oplog::OperationLog;
+
+        let mut dbtx = db.begin_transaction().await;
+        OperationLog::new(db.clone())
+            .add_operation_log_entry_dbtx_with_creation_time(
+                &mut dbtx.to_ref_nc(),
+                id,
+                "ln",
+                meta,
+                std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(created_at),
+            )
+            .await;
+        dbtx.commit_tx().await;
+    }
+
+    fn reclaim_meta(original: OperationId) -> serde_json::Value {
+        serde_json::json!({
+            "variant": {
+                "receive_reclaim": {
+                    "original_operation_id": original.fmt_full().to_string(),
+                    "invoice": REGTEST_INVOICE,
+                    "gateway_id": null,
+                }
+            },
+            "extra_meta": null,
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_reclaim_finds_a_retry_committed_after_the_receive() {
+        let db = crate::db::in_memory_root();
+        let original = OperationId([7u8; 32]);
+        let reclaim = OperationId([8u8; 32]);
+        let created_at = 1_700_000_000_000u64;
+        write_ln_log_entry(&db, reclaim, reclaim_meta(original), created_at + 1_000).await;
+
+        let found = existing_reclaim(&db, original, created_at)
+            .await
+            .expect("scan")
+            .expect("the retry the crash lost is still found");
+        assert_eq!(found, reclaim);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_reclaim_ignores_an_entry_older_than_the_receive() {
+        let db = crate::db::in_memory_root();
+        let original = OperationId([7u8; 32]);
+        let reclaim = OperationId([8u8; 32]);
+        let created_at = 1_700_000_000_000u64;
+        // Nothing older than the receive it retries can be its reclaim, so the walk stops here
+        // rather than reporting this unrelated, earlier entry.
+        write_ln_log_entry(&db, reclaim, reclaim_meta(original), created_at - 1_000).await;
+
+        assert_eq!(
+            existing_reclaim(&db, original, created_at)
+                .await
+                .expect("scan"),
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_reclaim_skips_entries_that_are_not_this_receives_retry() {
+        let db = crate::db::in_memory_root();
+        let original = OperationId([7u8; 32]);
+        let other_original = OperationId([9u8; 32]);
+        let created_at = 1_700_000_000_000u64;
+
+        // A reclaim of a different receive: newer, but not a match.
+        write_ln_log_entry(
+            &db,
+            OperationId([8u8; 32]),
+            reclaim_meta(other_original),
+            created_at + 1_000,
+        )
+        .await;
+        // The receive entry itself, at its own creation time: a `Receive`, not a
+        // `ReceiveReclaim`, so it is skipped rather than mistaken for the retry.
+        write_ln_log_entry(
+            &db,
+            original,
+            serde_json::json!({
+                "variant": {
+                    "receive": {
+                        "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                        "invoice": REGTEST_INVOICE,
+                        "gateway_id": GATEWAY_ID,
+                    }
+                },
+                "extra_meta": null,
+            }),
+            created_at,
+        )
+        .await;
+
+        assert_eq!(
+            existing_reclaim(&db, original, created_at)
+                .await
+                .expect("scan"),
+            None
+        );
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -747,11 +747,16 @@ pub(super) async fn send(
         route: quote.plan.route.clone(),
         created_at,
     };
+    let mut quoted_wire = wire::LnSendDetailsWire::from(&quoted_details);
+    // Named so a record rebuilt from the module's log after a crash between upstream's commit
+    // and the SDK's write below can back this out, the same way the internal-settlement branch
+    // just below does, if the module ends up settling the payment internally after all.
+    quoted_wire.gateway_fee_msats = Some(quote.plan.breakdown.gateway.msats());
     let payment: OutgoingLightningPayment = module
         .pay_bolt11_invoice(
             gateway.map(|gateway| *gateway),
             quote.invoice.inner().clone(),
-            wire::custom_meta(&wire::LnSendDetailsWire::from(&quoted_details))?,
+            wire::custom_meta(&quoted_wire)?,
         )
         .await
         .map_err(|err| {
@@ -823,8 +828,10 @@ pub(super) async fn send(
                 .ok_or_else(|| internal("the quoted fee is smaller than the quoted gateway fee"))?;
             let total = add(quote.invoice_amount, fee)?;
             // The metadata copy above carries the quoted `fee`/`total`, not this corrected
-            // figure: a record rebuilt from the log after a crash in this residual case reports
-            // the quote's upper bound rather than what was actually debited.
+            // figure, but it also names its gateway share (`gateway_fee_msats`): a record
+            // rebuilt from the log after a crash in this residual case backs that share out of
+            // the copy's figures the same way this branch just did, instead of reporting the
+            // quote's upper bound.
             (id, LightningRoute::Internal, fee, total)
         }
         PayType::Lightning(id) => (
@@ -981,32 +988,47 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
         LightningOperationMetaVariant::Pay(pay) => {
             let invoice = Bolt11Invoice::from_upstream(pay.invoice);
             let invoice_amount = invoice.amount()?;
+            // The route always comes from upstream's own meta, never from the copy below: the
+            // module decides the route at execution, after the copy was written, and it is what
+            // `LnSendDriver` picks its subscription by (upstream refuses `subscribe_ln_pay` for
+            // a payment it settled internally).
+            let route = if pay.is_internal_payment {
+                LightningRoute::Internal
+            } else {
+                LightningRoute::Gateway {
+                    gateway_id: GatewayId::from_upstream(pay.gateway_id?),
+                }
+            };
             // Trusted only when it names this exact invoice: an entry created by something
-            // other than this SDK could carry anything under the same metadata key. A copy that
-            // passes that check but whose route does not parse (a gateway id from a build this
-            // one cannot read) is no more trustworthy than no copy at all, so it falls back to
-            // the same upstream-derived estimate as a missing copy.
+            // other than this SDK could carry anything under the same metadata key.
             let copy = wire::from_custom_meta::<wire::LnSendDetailsWire>(&extra_meta)
-                .filter(|copy| copy.invoice == invoice.to_string())
-                .and_then(|copy| {
-                    Some((
-                        Amount::from_msats(copy.fee_msats),
-                        Amount::from_msats(copy.total_msats),
-                        LightningRoute::try_from(copy.route).ok()?,
-                    ))
-                });
-            let (fee, total, route) = match copy {
-                Some(values) => values,
+                .filter(|copy| copy.invoice == invoice.to_string());
+            let (fee, total) = match copy {
+                Some(copy) => {
+                    let fee = Amount::from_msats(copy.fee_msats);
+                    let total = Amount::from_msats(copy.total_msats);
+                    let quoted_gateway = matches!(copy.route, wire::RouteWire::Gateway { .. });
+                    match (
+                        pay.is_internal_payment,
+                        quoted_gateway,
+                        copy.gateway_fee_msats,
+                    ) {
+                        // Quoted through a gateway but settled internally after all: the copy's
+                        // figures still include the gateway's share, so it is backed out the
+                        // same way the live send path does for this same residual case.
+                        (true, true, Some(gateway_fee_msats)) => {
+                            let fee = fee.checked_sub(Amount::from_msats(gateway_fee_msats))?;
+                            (fee, invoice_amount.checked_add(fee)?)
+                        }
+                        // Either the quote already agreed with the settlement, or the copy
+                        // predates `gateway_fee_msats` (an older build): its figures are kept as
+                        // written, an upper bound in the latter case.
+                        _ => (fee, total),
+                    }
+                }
                 None => {
                     let fee = from_upstream(pay.fee);
-                    let route = if pay.is_internal_payment {
-                        LightningRoute::Internal
-                    } else {
-                        LightningRoute::Gateway {
-                            gateway_id: GatewayId::from_upstream(pay.gateway_id?),
-                        }
-                    };
-                    (fee, invoice_amount.checked_add(fee)?, route)
+                    (fee, invoice_amount.checked_add(fee)?)
                 }
             };
             let details = crate::LnSendDetails {
@@ -1411,6 +1433,7 @@ mod tests {
                 gateway_id: GATEWAY_ID.to_owned(),
             },
             created_at: 1_650_000_000_000,
+            gateway_fee_msats: None,
         };
         let meta = serde_json::json!({
             "variant": {
@@ -1432,6 +1455,8 @@ mod tests {
         // alone would give.
         assert_eq!(details.fee, Amount::from_msats(1_500));
         assert_eq!(details.total, Amount::from_msats(101_500));
+        // Upstream settled through a gateway, matching the copy's route: upstream's own id,
+        // read regardless of what the copy says.
         assert_eq!(details.route, gateway_route());
         // The record's own creation time, not the copy's.
         assert_eq!(details.created_at.epoch_millis(), 1_700_000_000_000);
@@ -1451,6 +1476,7 @@ mod tests {
                 gateway_id: GATEWAY_ID.to_owned(),
             },
             created_at: 1_650_000_000_000,
+            gateway_fee_msats: None,
         };
         let meta = serde_json::json!({
             "variant": {
@@ -1475,16 +1501,17 @@ mod tests {
     }
 
     #[test]
-    fn a_pay_log_entry_with_a_copy_naming_an_unparseable_gateway_id_falls_back_to_the_estimate() {
+    fn a_gateway_quoted_pay_settled_internally_backs_the_gateway_fee_out_of_the_copy() {
         let copy = wire::LnSendDetailsWire {
             invoice: REGTEST_INVOICE.to_owned(),
             invoice_amount_msats: 100_000,
             fee_msats: 1_500,
             total_msats: 101_500,
             route: wire::RouteWire::Gateway {
-                gateway_id: "not a valid gateway id".to_owned(),
+                gateway_id: GATEWAY_ID.to_owned(),
             },
             created_at: 1_650_000_000_000,
+            gateway_fee_msats: Some(500),
         };
         let meta = serde_json::json!({
             "variant": {
@@ -1493,21 +1520,58 @@ mod tests {
                     "invoice": REGTEST_INVOICE,
                     "fee": 1000,
                     "change": [],
-                    "is_internal_payment": false,
+                    "is_internal_payment": true,
                     "contract_id": "11".repeat(32),
-                    "gateway_id": GATEWAY_ID,
+                    "gateway_id": null,
                 }
             },
             "extra_meta": wire::custom_meta(&copy).expect("encode"),
         });
         let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
         let details = wire::decode_send_details(&claimed.details).expect("decodes");
-        // A copy whose invoice matches but whose route this build cannot parse is no more
-        // trustworthy than a missing copy, so the gateway-fee-only estimate is used instead, and
-        // the record is not dropped the way propagating the parse failure would drop it.
+        // Upstream settled internally, not through the gateway the copy was quoted through: the
+        // route is upstream's, and the copy's fee/total are corrected by backing the quoted
+        // gateway share out of them, the same way the live send path does for this case.
+        assert_eq!(details.route, LightningRoute::Internal);
         assert_eq!(details.fee, Amount::from_msats(1_000));
         assert_eq!(details.total, Amount::from_msats(101_000));
-        assert_eq!(details.route, gateway_route());
+    }
+
+    #[test]
+    fn an_older_copy_without_the_gateway_fee_keeps_its_figures_when_settled_internally() {
+        let copy = wire::LnSendDetailsWire {
+            invoice: REGTEST_INVOICE.to_owned(),
+            invoice_amount_msats: 100_000,
+            fee_msats: 1_500,
+            total_msats: 101_500,
+            route: wire::RouteWire::Gateway {
+                gateway_id: GATEWAY_ID.to_owned(),
+            },
+            created_at: 1_650_000_000_000,
+            gateway_fee_msats: None,
+        };
+        let meta = serde_json::json!({
+            "variant": {
+                "pay": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "fee": 1000,
+                    "change": [],
+                    "is_internal_payment": true,
+                    "contract_id": "11".repeat(32),
+                    "gateway_id": null,
+                }
+            },
+            "extra_meta": wire::custom_meta(&copy).expect("encode"),
+        });
+        let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        // Nothing to back the gateway share out of: an older build's copy is kept as written,
+        // an upper bound on what was actually debited, exactly as the live send path's own
+        // comment describes for this residual case.
+        assert_eq!(details.route, LightningRoute::Internal);
+        assert_eq!(details.fee, Amount::from_msats(1_500));
+        assert_eq!(details.total, Amount::from_msats(101_500));
     }
 
     #[test]

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -333,13 +333,13 @@ impl ReclaimContext {
     }
 }
 
-/// Looks for a reclaim of `original` that upstream already started and committed, so a retry
-/// after a crash follows it instead of starting a competing one.
-///
-/// Walks the client's chronological index newest first, the way
-/// [`FederationInner::creation_time_of`](crate::federation::FederationInner::creation_time_of)
-/// does, and stops at the first entry older than `created_at` (the receive's own creation time):
-/// a reclaim is always newer than the receive it retries, so nothing older can be it.
+// Looks for a reclaim of `original` that upstream already started and committed, so a retry
+// after a crash follows it instead of starting a competing one.
+//
+// Walks the client's chronological index newest first, the way
+// `FederationInner::creation_time_of` does, and stops at the first entry older than
+// `created_at` (the receive's own creation time): a reclaim is always newer than the receive
+// it retries, so nothing older can be it.
 async fn existing_reclaim(
     db: &Database,
     original: OperationId,
@@ -380,7 +380,7 @@ async fn existing_reclaim(
     Ok(None)
 }
 
-/// Follows a retry that was already started, from the id the record stores for it.
+// Follows a retry that was already started, from the id the record stores for it.
 async fn follow_reclaim(
     module: &LightningClientModule,
     reclaim: &str,
@@ -982,15 +982,21 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
             let invoice = Bolt11Invoice::from_upstream(pay.invoice);
             let invoice_amount = invoice.amount()?;
             // Trusted only when it names this exact invoice: an entry created by something
-            // other than this SDK could carry anything under the same metadata key.
+            // other than this SDK could carry anything under the same metadata key. A copy that
+            // passes that check but whose route does not parse (a gateway id from a build this
+            // one cannot read) is no more trustworthy than no copy at all, so it falls back to
+            // the same upstream-derived estimate as a missing copy.
             let copy = wire::from_custom_meta::<wire::LnSendDetailsWire>(&extra_meta)
-                .filter(|copy| copy.invoice == invoice.to_string());
+                .filter(|copy| copy.invoice == invoice.to_string())
+                .and_then(|copy| {
+                    Some((
+                        Amount::from_msats(copy.fee_msats),
+                        Amount::from_msats(copy.total_msats),
+                        LightningRoute::try_from(copy.route).ok()?,
+                    ))
+                });
             let (fee, total, route) = match copy {
-                Some(copy) => (
-                    Amount::from_msats(copy.fee_msats),
-                    Amount::from_msats(copy.total_msats),
-                    LightningRoute::try_from(copy.route).ok()?,
-                ),
+                Some(values) => values,
                 None => {
                     let fee = from_upstream(pay.fee);
                     let route = if pay.is_internal_payment {
@@ -1466,6 +1472,42 @@ mod tests {
         // SDK put it there, so the gateway-fee-only estimate is used instead.
         assert_eq!(details.fee, Amount::from_msats(1_000));
         assert_eq!(details.total, Amount::from_msats(101_000));
+    }
+
+    #[test]
+    fn a_pay_log_entry_with_a_copy_naming_an_unparseable_gateway_id_falls_back_to_the_estimate() {
+        let copy = wire::LnSendDetailsWire {
+            invoice: REGTEST_INVOICE.to_owned(),
+            invoice_amount_msats: 100_000,
+            fee_msats: 1_500,
+            total_msats: 101_500,
+            route: wire::RouteWire::Gateway {
+                gateway_id: "not a valid gateway id".to_owned(),
+            },
+            created_at: 1_650_000_000_000,
+        };
+        let meta = serde_json::json!({
+            "variant": {
+                "pay": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "fee": 1000,
+                    "change": [],
+                    "is_internal_payment": false,
+                    "contract_id": "11".repeat(32),
+                    "gateway_id": GATEWAY_ID,
+                }
+            },
+            "extra_meta": wire::custom_meta(&copy).expect("encode"),
+        });
+        let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        // A copy whose invoice matches but whose route this build cannot parse is no more
+        // trustworthy than a missing copy, so the gateway-fee-only estimate is used instead, and
+        // the record is not dropped the way propagating the parse failure would drop it.
+        assert_eq!(details.fee, Amount::from_msats(1_000));
+        assert_eq!(details.total, Amount::from_msats(101_000));
+        assert_eq!(details.route, gateway_route());
     }
 
     #[test]

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -24,16 +24,16 @@ use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
 use super::{
     INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, balance_of, fee_quote_failure,
-    from_upstream, gateway_unavailable, insufficient, internal, now, plan_of, quote_changed,
-    quote_expired, subscribe_error, to_upstream, unreachable,
+    from_upstream, gateway_unavailable, insufficient, internal, network_refusal, now, plan_of,
+    quote_changed, quote_expired, subscribe_error, to_upstream, unreachable,
 };
 use crate::federation::FederationInner;
 use crate::operation::{Backfilled, Driver, kinds, record_phase_in, write_details_in};
 use crate::sdk::SdkInner;
 use crate::{
     Amount, Bolt11Invoice, Error, ErrorCode, GatewayId, LightningRoute, LnReceive,
-    LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Operation, OperationState,
-    Preimage, Result, Timestamp,
+    LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Network, Operation,
+    OperationState, Preimage, Result, Timestamp,
 };
 
 // Upstream `LnPayState` onto `LnSendState`. The fee and the route come from the executed quote:
@@ -663,6 +663,9 @@ pub(super) async fn send(
     if fresh.total != quote.plan.total {
         return Err(quote_changed(quote.plan.total, fresh.total));
     }
+    // Read once, ahead of the call below, for the `Invalid invoice currency` branch of its
+    // error mapping.
+    let expected: Network = federation.record().network.into();
     let payment: OutgoingLightningPayment = module
         .pay_bolt11_invoice(
             gateway.map(|gateway| *gateway),
@@ -699,6 +702,19 @@ pub(super) async fn send(
             let text = err.to_string();
             if text.contains("Invoice has expired") {
                 return quote_expired(quote.expires_at, false);
+            }
+            // v1 converts the configured network through lightning-invoice's
+            // `From<bitcoin::Network> for Currency`
+            // (lightning-invoice-0.33.3/src/lib.rs:451-463) and compares against it
+            // (`ensure!(federation_currency == invoice_currency, "Invalid invoice
+            // currency: ...")`, fedimint-ln-client/src/lib.rs:834-839). That conversion has no
+            // `Testnet4` arm and falls to a `_` arm yielding `Currency::Regtest`, so a testnet4
+            // federation refuses every `tb` invoice here, the same upstream limitation lnv2's
+            // `WrongCurrency` reports (tracked as fedimint/fedimint#9100). Reported as the
+            // network mismatch it is rather than left to fall through to the internal-failure
+            // branch below.
+            if text.contains("Invalid invoice currency") {
+                return network_refusal(quote, expected);
             }
             internal(format!("the payment could not be started: {text}"))
         })?;

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -238,13 +238,22 @@ impl ReclaimContext {
         let federation = sdk
             .federation_inner(&self.federation_id)
             .ok_or_else(closed)?;
+
+        // Two subscribers can both observe the same `Canceled { ClaimRejected }` and both reach
+        // here. The SDK is the only process that opens this federation's storage (the `fd-lock`
+        // in `src/storage.rs`), so holding this per-federation lock across the record re-read,
+        // the upstream call and the write below is enough, in-process, to make "one retry per
+        // rejected claim" exact rather than a race one side merely tends to lose. Taken before
+        // `federation.client(false)` so a close waiting on the client's write lock is not held
+        // off by a retry that has not started yet.
+        let _serialised = federation.lock_reclaim_starts().await;
+
         let client = federation.client(false).await?;
         let module = module_of(&client)?;
 
         // Re-read the record rather than trust details carried from where this context was
-        // built: two subscribers can observe the same `Canceled { ClaimRejected }` and both
-        // reach here. Reading again right before deciding lets whichever loses that race see the
-        // winner's `reclaim_operation_id` and follow it instead of starting a second retry.
+        // built: with the lock held, whichever subscriber runs second now sees the first's
+        // `reclaim_operation_id` and follows it instead of starting a second retry.
         let mut dbtx = self.db.begin_transaction_nc().await;
         let record = dbtx
             .get_value(&crate::db::OperationRecordKey(self.id))
@@ -257,21 +266,8 @@ impl ReclaimContext {
             })?;
         let mut details = wire::decode_receive_wire(&record.details)?;
         if let Some(reclaim) = details.reclaim_operation_id.as_deref() {
-            let reclaim_id = reclaim
-                .parse::<crate::OperationId>()
-                .map_err(|err| {
-                    Error::new(
-                        ErrorCode::Internal,
-                        format!("a stored operation id does not parse: {err}"),
-                    )
-                })?
-                .upstream();
             return Ok(ReclaimStart::Started(
-                module
-                    .subscribe_ln_receive(reclaim_id)
-                    .await
-                    .map_err(subscribe_error)?
-                    .into_stream(),
+                follow_reclaim(&module, reclaim).await?,
             ));
         }
 
@@ -294,6 +290,27 @@ impl ReclaimContext {
                 .into_stream(),
         ))
     }
+}
+
+/// Follows a retry that was already started, from the id the record stores for it.
+async fn follow_reclaim(
+    module: &LightningClientModule,
+    reclaim: &str,
+) -> Result<BoxStream<'static, UpstreamReceiveState>> {
+    let reclaim_id = reclaim
+        .parse::<crate::OperationId>()
+        .map_err(|err| {
+            Error::new(
+                ErrorCode::Internal,
+                format!("a stored operation id does not parse: {err}"),
+            )
+        })?
+        .upstream();
+    Ok(module
+        .subscribe_ln_receive(reclaim_id)
+        .await
+        .map_err(subscribe_error)?
+        .into_stream())
 }
 
 // Upstream refuses `reclaim_ln_receive` two ways. "Cannot reclaim an active lightning receive"
@@ -347,8 +364,17 @@ async fn step(mut follow: Follow) -> Option<(Result<LnReceiveState>, Follow)> {
                     LnReceiveState::Funded
                 }
                 // The module says no further claim is possible: that is the one ending the
-                // contract reserves `Failed` for.
-                Ok(ReclaimStart::Impossible(_)) => LnReceiveState::Failed,
+                // contract reserves `Failed` for. The reason is logged here, its only reader,
+                // since `LnReceiveState::Failed` does not carry it.
+                Ok(ReclaimStart::Impossible(reason)) => {
+                    tracing::warn!(
+                        target: "fedimint_sdk",
+                        operation = %follow.context.id.fmt_full(),
+                        reason = %reason,
+                        "a rejected lightning claim cannot be retried",
+                    );
+                    LnReceiveState::Failed
+                }
                 // Anything else is an observation failure, not an outcome: the next subscription
                 // replays the rejection and tries again.
                 Err(err) => {
@@ -382,23 +408,7 @@ pub(super) async fn subscribe_receive(
     let client = federation.client(false).await?;
     let module = module_of(&client)?;
     let (upstream, following) = match details.reclaim_operation_id.as_deref() {
-        Some(reclaim) => {
-            let reclaim_id = reclaim
-                .parse::<crate::OperationId>()
-                .map_err(|err| {
-                    Error::new(
-                        ErrorCode::Internal,
-                        format!("a stored operation id does not parse: {err}"),
-                    )
-                })?
-                .upstream();
-            let upstream = module
-                .subscribe_ln_receive(reclaim_id)
-                .await
-                .map_err(subscribe_error)?
-                .into_stream();
-            (upstream, Following::Reclaim)
-        }
+        Some(reclaim) => (follow_reclaim(&module, reclaim).await?, Following::Reclaim),
         None => {
             let upstream = module
                 .subscribe_ln_receive(id)

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -1,0 +1,283 @@
+//! The v1 lightning module (`ln`): mappings, subscriptions, and the facade operations.
+
+use fedimint_client::Client;
+use fedimint_client_module::ClientModuleInstance;
+use fedimint_core::core::OperationId;
+use fedimint_core::util::BoxStream;
+use fedimint_ln_client::{InternalPayState, LightningClientModule, LnPayState};
+use futures::StreamExt;
+
+use super::driver::until_final;
+use super::subscribe_error;
+use crate::federation::FederationInner;
+use crate::{
+    Amount, Error, ErrorCode, LightningRoute, LnSendDetails, LnSendState, Preimage, Result,
+};
+
+// Upstream `LnPayState` onto `LnSendState`. The fee and the route come from the executed quote:
+// the v1 progress stream carries neither.
+//
+// | upstream                          | here                                   |
+// | --------------------------------- | -------------------------------------- |
+// | `Created`                         | `Created`                              |
+// | `Funded`, `AwaitingChange`        | `Funded`                               |
+// | `WaitingForRefund`                | `Funded` (a refund is still in flight) |
+// | `Success { preimage }`            | `Success`                              |
+// | `Canceled` (never funded)         | `Refunded`                             |
+// | `Refunded`                        | `Refunded`                             |
+// | `UnexpectedError`                 | `Failed`                               |
+pub(super) fn map_ln_pay(
+    state: &LnPayState,
+    fee: Amount,
+    route: &LightningRoute,
+) -> Result<LnSendState> {
+    Ok(match state {
+        LnPayState::Created => LnSendState::Created,
+        LnPayState::Funded { .. }
+        | LnPayState::AwaitingChange
+        | LnPayState::WaitingForRefund { .. } => LnSendState::Funded,
+        LnPayState::Success { preimage } => LnSendState::Success {
+            // v1 reports the preimage as the hex text the gateway answered with, unvalidated.
+            preimage: preimage.parse::<Preimage>().map_err(|err| {
+                Error::new(
+                    ErrorCode::Internal,
+                    format!("the gateway reported an unusable preimage: {err}"),
+                )
+            })?,
+            fee,
+            route: route.clone(),
+        },
+        LnPayState::Canceled | LnPayState::Refunded { .. } => LnSendState::Refunded,
+        LnPayState::UnexpectedError { error_message } => LnSendState::Failed {
+            reason: error_message.clone(),
+        },
+    })
+}
+
+// Upstream `InternalPayState` onto `LnSendState`, for a payment settled inside the federation.
+//
+// | upstream                       | here        |
+// | ------------------------------ | ----------- |
+// | `Funding`                      | `Created`   |
+// | `Preimage`                     | `Success`   |
+// | `RefundSuccess`                | `Refunded`  |
+// | `FundingFailed` (never debited)| `Refunded`  |
+// | `RefundError`                  | `Failed`    |
+// | `UnexpectedError`              | `Failed`    |
+pub(super) fn map_internal_pay(
+    state: &InternalPayState,
+    fee: Amount,
+    route: &LightningRoute,
+) -> LnSendState {
+    match state {
+        InternalPayState::Funding => LnSendState::Created,
+        InternalPayState::Preimage(preimage) => LnSendState::Success {
+            preimage: Preimage::from_bytes(preimage.0),
+            fee,
+            route: route.clone(),
+        },
+        InternalPayState::RefundSuccess { .. } | InternalPayState::FundingFailed { .. } => {
+            LnSendState::Refunded
+        }
+        InternalPayState::RefundError { error_message, .. } => LnSendState::Failed {
+            reason: error_message.clone(),
+        },
+        InternalPayState::UnexpectedError(message) => LnSendState::Failed {
+            reason: message.clone(),
+        },
+    }
+}
+
+/// The v1 module on a live client, or `NotSupported` when the federation dropped it.
+pub(super) fn module_of(
+    client: &Client,
+) -> Result<ClientModuleInstance<'_, LightningClientModule>> {
+    client
+        .get_first_module::<LightningClientModule>()
+        .map_err(|_| {
+            Error::new(
+                ErrorCode::NotSupported,
+                "this federation no longer has a v1 lightning module",
+            )
+        })
+}
+
+/// A fresh stream over a v1 send, chosen by the route the record says the payment took.
+///
+/// The client guard is held only for the bounded upstream read that produces the stream; the
+/// stream itself registers with the module's notifier when first polled, as the driver contract
+/// requires.
+pub(super) async fn subscribe_send(
+    federation: &FederationInner,
+    id: OperationId,
+    details: &LnSendDetails,
+) -> Result<BoxStream<'static, Result<LnSendState>>> {
+    let client = federation.client(false).await?;
+    let module = module_of(&client)?;
+    let fee = details.fee;
+    let route = details.route.clone();
+    let stream: BoxStream<'static, Result<LnSendState>> = match &route {
+        LightningRoute::Internal => {
+            let upstream = module
+                .subscribe_internal_pay(id)
+                .await
+                .map_err(subscribe_error)?
+                .into_stream();
+            Box::pin(upstream.map(move |state| Ok(map_internal_pay(&state, fee, &route))))
+        }
+        LightningRoute::Gateway { .. } => {
+            let upstream = module
+                .subscribe_ln_pay(id)
+                .await
+                .map_err(subscribe_error)?
+                .into_stream();
+            Box::pin(upstream.map(move |state| map_ln_pay(&state, fee, &route)))
+        }
+    };
+    Ok(until_final(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_ln_client::pay::GatewayPayError;
+
+    use super::*;
+    use crate::Amount;
+
+    fn fee() -> Amount {
+        Amount::from_msats(1_050)
+    }
+
+    fn gateway_route() -> LightningRoute {
+        LightningRoute::Gateway {
+            gateway_id: "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166"
+                .parse()
+                .expect("a gateway id"),
+        }
+    }
+
+    #[test]
+    fn ln_pay_states_fold_onto_the_send_lifecycle() {
+        let cases = [
+            (LnPayState::Created, LnSendState::Created),
+            (LnPayState::Funded { block_height: 7 }, LnSendState::Funded),
+            (LnPayState::AwaitingChange, LnSendState::Funded),
+            (
+                LnPayState::WaitingForRefund {
+                    error_reason: "no route".to_owned(),
+                },
+                LnSendState::Funded,
+            ),
+            (LnPayState::Canceled, LnSendState::Refunded),
+            (
+                LnPayState::Refunded {
+                    gateway_error: GatewayPayError::OutgoingContractError,
+                },
+                LnSendState::Refunded,
+            ),
+            (
+                LnPayState::UnexpectedError {
+                    error_message: "boom".to_owned(),
+                },
+                LnSendState::Failed {
+                    reason: "boom".to_owned(),
+                },
+            ),
+        ];
+        for (upstream, expected) in cases {
+            assert_eq!(
+                map_ln_pay(&upstream, fee(), &gateway_route()).expect("maps"),
+                expected,
+                "{upstream:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_v1_success_parses_the_hex_preimage_and_carries_the_quoted_terms() {
+        let mapped = map_ln_pay(
+            &LnPayState::Success {
+                preimage: "11".repeat(32),
+            },
+            fee(),
+            &gateway_route(),
+        )
+        .expect("maps");
+        assert_eq!(
+            mapped,
+            LnSendState::Success {
+                preimage: Preimage::from_bytes([0x11; 32]),
+                fee: fee(),
+                route: gateway_route(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_v1_success_with_an_unparsable_preimage_is_internal() {
+        let err = map_ln_pay(
+            &LnPayState::Success {
+                preimage: "not hex".to_owned(),
+            },
+            fee(),
+            &gateway_route(),
+        )
+        .expect_err("refused");
+        assert_eq!(err.code, ErrorCode::Internal);
+    }
+
+    #[test]
+    fn internal_pay_states_fold_onto_the_send_lifecycle() {
+        use fedimint_ln_client::incoming::IncomingSmError;
+
+        let error = IncomingSmError::TimeoutFetchingOffer {
+            payment_hash: fedimint_core::bitcoin::hashes::Hash::hash(b"x"),
+        };
+        let cases = [
+            (InternalPayState::Funding, LnSendState::Created),
+            (
+                InternalPayState::Preimage(fedimint_ln_common::contracts::Preimage([0x22; 32])),
+                LnSendState::Success {
+                    preimage: Preimage::from_bytes([0x22; 32]),
+                    fee: fee(),
+                    route: LightningRoute::Internal,
+                },
+            ),
+            (
+                InternalPayState::RefundSuccess {
+                    out_points: Vec::new(),
+                    error: error.clone(),
+                },
+                LnSendState::Refunded,
+            ),
+            (
+                InternalPayState::FundingFailed {
+                    error: error.clone(),
+                },
+                LnSendState::Refunded,
+            ),
+            (
+                InternalPayState::RefundError {
+                    error_message: "stuck".to_owned(),
+                    error,
+                },
+                LnSendState::Failed {
+                    reason: "stuck".to_owned(),
+                },
+            ),
+            (
+                InternalPayState::UnexpectedError("odd".to_owned()),
+                LnSendState::Failed {
+                    reason: "odd".to_owned(),
+                },
+            ),
+        ];
+        for (upstream, expected) in cases {
+            assert_eq!(
+                map_internal_pay(&upstream, fee(), &LightningRoute::Internal),
+                expected,
+                "{upstream:?}"
+            );
+        }
+    }
+}

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -213,12 +213,21 @@ struct ReclaimContext {
     federation_id: fedimint_core::config::FederationId,
     db: Database,
     id: OperationId,
-    details_json: String,
+}
+
+/// How starting a retry ended: a stream to follow, or the module's word that no retry is
+/// possible.
+enum ReclaimStart {
+    Started(BoxStream<'static, UpstreamReceiveState>),
+    Impossible(String),
 }
 
 impl ReclaimContext {
-    /// Starts the retry upstream, records which operation it runs under, and returns its stream.
-    async fn start(&self) -> Result<BoxStream<'static, UpstreamReceiveState>> {
+    /// Starts the retry upstream, records which operation it runs under, and returns its
+    /// stream — or the module's word that no further claim is possible.
+    async fn start(&self) -> Result<ReclaimStart> {
+        use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+
         let closed = || {
             Error::new(
                 ErrorCode::FederationClosed,
@@ -231,24 +240,76 @@ impl ReclaimContext {
             .ok_or_else(closed)?;
         let client = federation.client(false).await?;
         let module = module_of(&client)?;
-        let reclaim_id = module.reclaim_ln_receive(self.id).await.map_err(|err| {
-            Error::new(
-                ErrorCode::Internal,
-                format!("the rejected claim could not be retried: {err}"),
-            )
-        })?;
+
+        // Re-read the record rather than trust details carried from where this context was
+        // built: two subscribers can observe the same `Canceled { ClaimRejected }` and both
+        // reach here. Reading again right before deciding lets whichever loses that race see the
+        // winner's `reclaim_operation_id` and follow it instead of starting a second retry.
+        let mut dbtx = self.db.begin_transaction_nc().await;
+        let record = dbtx
+            .get_value(&crate::db::OperationRecordKey(self.id))
+            .await
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::Internal,
+                    format!("no record for operation {}", self.id.fmt_full()),
+                )
+            })?;
+        let mut details = wire::decode_receive_wire(&record.details)?;
+        if let Some(reclaim) = details.reclaim_operation_id.as_deref() {
+            let reclaim_id = reclaim
+                .parse::<crate::OperationId>()
+                .map_err(|err| {
+                    Error::new(
+                        ErrorCode::Internal,
+                        format!("a stored operation id does not parse: {err}"),
+                    )
+                })?
+                .upstream();
+            return Ok(ReclaimStart::Started(
+                module
+                    .subscribe_ln_receive(reclaim_id)
+                    .await
+                    .map_err(subscribe_error)?
+                    .into_stream(),
+            ));
+        }
+
+        let reclaim_id = match module.reclaim_ln_receive(self.id).await {
+            Ok(id) => id,
+            Err(err) => {
+                return classify_reclaim_refusal(&err.to_string()).map(ReclaimStart::Impossible);
+            }
+        };
         // Persisted before it is followed: after a restart the record is the only thing that
         // says which upstream operation to follow.
-        let mut details = wire::decode_receive_wire(&self.details_json)?;
         details.reclaim_operation_id =
             Some(crate::OperationId::from_upstream(reclaim_id).to_string());
         write_details_in(&self.db, self.id, wire::encode_receive_wire(&details)?).await?;
-        Ok(module
-            .subscribe_ln_receive(reclaim_id)
-            .await
-            .map_err(subscribe_error)?
-            .into_stream())
+        Ok(ReclaimStart::Started(
+            module
+                .subscribe_ln_receive(reclaim_id)
+                .await
+                .map_err(subscribe_error)?
+                .into_stream(),
+        ))
     }
+}
+
+// Upstream refuses `reclaim_ln_receive` two ways. "Cannot reclaim an active lightning receive"
+// (fedimint-ln-client/src/lib.rs, in `reclaim_ln_receive`) is the race between its notifier
+// reporting `Canceled { ClaimRejected }` and the state machine itself going inactive: retrying
+// later succeeds, so this is an observation failure, not a definitive answer. Any other refusal
+// (not a reclaimable receive, the receiving key unrecoverable from history) is definitive: no
+// further claim is possible.
+fn classify_reclaim_refusal(text: &str) -> Result<String> {
+    if text.contains("active") {
+        return Err(Error::new(
+            ErrorCode::Internal,
+            format!("the rejected claim cannot be retried yet: {text}"),
+        ));
+    }
+    Ok(text.to_owned())
 }
 
 /// Which upstream operation a receive subscription is following.
@@ -280,12 +341,20 @@ async fn step(mut follow: Follow) -> Option<(Result<LnReceiveState>, Follow)> {
             // `ClaimRejected` is not final here: the claim is retried under the same SDK
             // operation, and only a retry that cannot be started is the end.
             ReceiveStep::Reclaim => match follow.context.start().await {
-                Ok(upstream) => {
+                Ok(ReclaimStart::Started(upstream)) => {
                     follow.upstream = upstream;
                     follow.following = Following::Reclaim;
                     LnReceiveState::Funded
                 }
-                Err(_) => LnReceiveState::Failed,
+                // The module says no further claim is possible: that is the one ending the
+                // contract reserves `Failed` for.
+                Ok(ReclaimStart::Impossible(_)) => LnReceiveState::Failed,
+                // Anything else is an observation failure, not an outcome: the next subscription
+                // replays the rejection and tries again.
+                Err(err) => {
+                    follow.done = true;
+                    return Some((Err(err), follow));
+                }
             },
         },
     };
@@ -349,7 +418,6 @@ pub(super) async fn subscribe_receive(
             federation_id: federation.id,
             db: federation.db(),
             id,
-            details_json: details_json.to_owned(),
         },
     };
     Ok(Box::pin(stream::unfold(follow, step)))
@@ -606,5 +674,19 @@ mod tests {
                 LnReceiveState::Failed
             );
         }
+    }
+
+    #[test]
+    fn the_notifiers_active_receive_race_is_retryable() {
+        let err = classify_reclaim_refusal("Cannot reclaim an active lightning receive")
+            .expect_err("the race is retryable, not definitive");
+        assert_eq!(err.code, ErrorCode::Internal);
+    }
+
+    #[test]
+    fn any_other_refusal_is_definitive() {
+        let text = classify_reclaim_refusal("Operation is not a reclaimable lightning receive")
+            .expect("a refusal that is not the race is definitive");
+        assert_eq!(text, "Operation is not a reclaimable lightning receive");
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -735,11 +735,23 @@ pub(super) async fn send(
     // Read once, ahead of the call below, for the `Invalid invoice currency` branch of its
     // error mapping.
     let expected: Network = federation.record().network.into();
+    // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
+    // between upstream's commit and the SDK's write (`federation.create_operation` below) has
+    // the exact quoted terms, not just the gateway's fee the log entry gives on its own.
+    let created_at = now();
+    let quoted_details = crate::LnSendDetails {
+        invoice: quote.invoice.clone(),
+        invoice_amount: quote.invoice_amount,
+        fee: quote.plan.fee,
+        total: quote.plan.total,
+        route: quote.plan.route.clone(),
+        created_at,
+    };
     let payment: OutgoingLightningPayment = module
         .pay_bolt11_invoice(
             gateway.map(|gateway| *gateway),
             quote.invoice.inner().clone(),
-            serde_json::Value::Null,
+            wire::custom_meta(&wire::LnSendDetailsWire::from(&quoted_details))?,
         )
         .await
         .map_err(|err| {
@@ -810,6 +822,9 @@ pub(super) async fn send(
                 .checked_sub(quote.plan.breakdown.gateway)
                 .ok_or_else(|| internal("the quoted fee is smaller than the quoted gateway fee"))?;
             let total = add(quote.invoice_amount, fee)?;
+            // The metadata copy above carries the quoted `fee`/`total`, not this corrected
+            // figure: a record rebuilt from the log after a crash in this residual case reports
+            // the quote's upper bound rather than what was actually debited.
             (id, LightningRoute::Internal, fee, total)
         }
         PayType::Lightning(id) => (
@@ -825,7 +840,7 @@ pub(super) async fn send(
         fee,
         total,
         route,
-        created_at: now(),
+        created_at,
     };
     federation
         .create_operation(
@@ -900,12 +915,30 @@ pub(super) async fn receive(
             "the amount does not cover the receive-side fee",
         )
     })?;
+    // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
+    // between upstream's commit and the SDK's write (`federation.create_operation` below) has
+    // the exact quoted terms, not the zero fee the log entry gives on its own. The invoice is
+    // not known until the call returns, so the copy carries a placeholder for it and
+    // `expires_at`; the backfiller takes both from upstream's own meta instead.
+    let created_at = now();
+    let custom_meta = wire::custom_meta(&wire::LnReceiveDetailsWire {
+        invoice: String::new(),
+        description: description.to_owned(),
+        requested_amount_msats: amount.msats(),
+        invoice_amount_msats: amount.msats(),
+        fee_msats: fee.msats(),
+        net_credit_msats: net_credit.msats(),
+        gateway_id: Some(GatewayId::from_upstream(gateway.gateway_id).to_string()),
+        expires_at: 0,
+        created_at: created_at.epoch_millis(),
+        reclaim_operation_id: None,
+    })?;
     let (id, invoice, _preimage) = module
         .create_bolt11_invoice(
             to_upstream(amount),
             Bolt11InvoiceDescription::Direct(bolt11_description),
             Some(u64::from(INVOICE_EXPIRY_SECS)),
-            serde_json::Value::Null,
+            custom_meta,
             Some(gateway.clone()),
         )
         .await
@@ -920,7 +953,7 @@ pub(super) async fn receive(
         net_credit,
         gateway_id: Some(GatewayId::from_upstream(gateway.gateway_id)),
         expires_at: invoice.expires_at(),
-        created_at: now(),
+        created_at,
     };
     let operation = federation
         .create_operation(
@@ -934,29 +967,47 @@ pub(super) async fn receive(
     Ok(LnReceive { invoice, operation })
 }
 
-/// Rebuilds a record from a v1 log entry. Best effort by nature: the entry carries the gateway's
-/// fee but not the federation's, so a rebuilt send's total is a floor and a rebuilt receive
-/// reports no fee at all.
+/// Rebuilds a record from a v1 log entry: exact for an operation this SDK created, whose
+/// metadata carries the quoted terms verbatim; an estimate — the gateway's fee for a send, no
+/// fee at all for a receive — for an entry the log holds that this SDK did not create.
 pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Backfilled> {
     let meta: LightningOperationMeta = serde_json::from_value(meta.clone()).ok()?;
     let created_at = Timestamp::from_epoch_millis(created_at);
-    match meta.variant {
+    let LightningOperationMeta {
+        variant,
+        extra_meta,
+    } = meta;
+    match variant {
         LightningOperationMetaVariant::Pay(pay) => {
             let invoice = Bolt11Invoice::from_upstream(pay.invoice);
             let invoice_amount = invoice.amount()?;
-            let fee = from_upstream(pay.fee);
-            let route = if pay.is_internal_payment {
-                LightningRoute::Internal
-            } else {
-                LightningRoute::Gateway {
-                    gateway_id: GatewayId::from_upstream(pay.gateway_id?),
+            // Trusted only when it names this exact invoice: an entry created by something
+            // other than this SDK could carry anything under the same metadata key.
+            let copy = wire::from_custom_meta::<wire::LnSendDetailsWire>(&extra_meta)
+                .filter(|copy| copy.invoice == invoice.to_string());
+            let (fee, total, route) = match copy {
+                Some(copy) => (
+                    Amount::from_msats(copy.fee_msats),
+                    Amount::from_msats(copy.total_msats),
+                    LightningRoute::try_from(copy.route).ok()?,
+                ),
+                None => {
+                    let fee = from_upstream(pay.fee);
+                    let route = if pay.is_internal_payment {
+                        LightningRoute::Internal
+                    } else {
+                        LightningRoute::Gateway {
+                            gateway_id: GatewayId::from_upstream(pay.gateway_id?),
+                        }
+                    };
+                    (fee, invoice_amount.checked_add(fee)?, route)
                 }
             };
             let details = crate::LnSendDetails {
                 invoice,
                 invoice_amount,
                 fee,
-                total: invoice_amount.checked_add(fee)?,
+                total,
                 route,
                 created_at,
             };
@@ -973,16 +1024,33 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
         } => {
             let invoice = Bolt11Invoice::from_upstream(invoice);
             let amount = invoice.amount()?;
+            let copy = wire::from_custom_meta::<wire::LnReceiveDetailsWire>(&extra_meta);
+            let (description, requested_amount, fee, net_credit, created_at) = match &copy {
+                Some(copy) => (
+                    copy.description.clone(),
+                    Amount::from_msats(copy.requested_amount_msats),
+                    Amount::from_msats(copy.fee_msats),
+                    Amount::from_msats(copy.net_credit_msats),
+                    Timestamp::from_epoch_millis(copy.created_at),
+                ),
+                None => (
+                    invoice.description(),
+                    amount,
+                    Amount::from_msats(0),
+                    amount,
+                    created_at,
+                ),
+            };
             let details = LnReceiveDetails {
-                description: invoice.description(),
-                requested_amount: amount,
+                invoice: invoice.clone(),
+                description,
+                requested_amount,
                 invoice_amount: amount,
-                fee: Amount::from_msats(0),
-                net_credit: amount,
+                fee,
+                net_credit,
                 gateway_id: gateway_id.map(GatewayId::from_upstream),
                 expires_at: invoice.expires_at(),
                 created_at,
-                invoice,
             };
             Some(Backfilled {
                 kind: kinds::LN_RECEIVE,
@@ -991,7 +1059,9 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
             })
         }
         // A retried claim runs under the original receive's record; the deprecated claim path
-        // and recurring payments are not operations this SDK creates.
+        // and recurring payments are not operations this SDK creates. `reclaim_ln_receive`
+        // copies the receive's own `extra_meta` onto the reclaim entry, but nothing here reads
+        // it: the reclaim never becomes its own record.
         _ => None,
     }
 }
@@ -1321,6 +1391,119 @@ mod tests {
         // The fee is not in the log entry; a rebuilt record reports none.
         assert_eq!(details.fee, Amount::from_msats(0));
         assert_eq!(details.net_credit, Amount::from_msats(100_000));
+        assert_eq!(details.gateway_id, Some(GATEWAY_ID.parse().expect("id")));
+    }
+
+    #[test]
+    fn a_pay_log_entry_with_an_sdk_copy_uses_the_copys_fee_and_total() {
+        let copy = wire::LnSendDetailsWire {
+            invoice: REGTEST_INVOICE.to_owned(),
+            invoice_amount_msats: 100_000,
+            fee_msats: 1_500,
+            total_msats: 101_500,
+            route: wire::RouteWire::Gateway {
+                gateway_id: GATEWAY_ID.to_owned(),
+            },
+            created_at: 1_650_000_000_000,
+        };
+        let meta = serde_json::json!({
+            "variant": {
+                "pay": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "fee": 1000,
+                    "change": [],
+                    "is_internal_payment": false,
+                    "contract_id": "11".repeat(32),
+                    "gateway_id": GATEWAY_ID,
+                }
+            },
+            "extra_meta": wire::custom_meta(&copy).expect("encode"),
+        });
+        let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        // The copy's figures, not the gateway-fee-only estimate (1_000 / 101_000) the log entry
+        // alone would give.
+        assert_eq!(details.fee, Amount::from_msats(1_500));
+        assert_eq!(details.total, Amount::from_msats(101_500));
+        assert_eq!(details.route, gateway_route());
+        // The record's own creation time, not the copy's.
+        assert_eq!(details.created_at.epoch_millis(), 1_700_000_000_000);
+    }
+
+    #[test]
+    fn a_pay_log_entry_with_a_copy_naming_a_different_invoice_falls_back_to_the_estimate() {
+        // Not a real invoice: `backfill` only ever string-compares the copy's `invoice` field
+        // against upstream's, it never parses it, so any value that differs from `REGTEST_INVOICE`
+        // exercises the mismatch.
+        let copy = wire::LnSendDetailsWire {
+            invoice: "not the invoice this entry names".to_owned(),
+            invoice_amount_msats: 100_000,
+            fee_msats: 1_500,
+            total_msats: 101_500,
+            route: wire::RouteWire::Gateway {
+                gateway_id: GATEWAY_ID.to_owned(),
+            },
+            created_at: 1_650_000_000_000,
+        };
+        let meta = serde_json::json!({
+            "variant": {
+                "pay": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "fee": 1000,
+                    "change": [],
+                    "is_internal_payment": false,
+                    "contract_id": "11".repeat(32),
+                    "gateway_id": GATEWAY_ID,
+                }
+            },
+            "extra_meta": wire::custom_meta(&copy).expect("encode"),
+        });
+        let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        // A copy naming a different invoice cannot be this entry's: something other than this
+        // SDK put it there, so the gateway-fee-only estimate is used instead.
+        assert_eq!(details.fee, Amount::from_msats(1_000));
+        assert_eq!(details.total, Amount::from_msats(101_000));
+    }
+
+    #[test]
+    fn a_receive_log_entry_with_an_sdk_copy_uses_the_copys_fee_and_net_credit() {
+        let copy = wire::LnReceiveDetailsWire {
+            invoice: String::new(),
+            description: "coffee".to_owned(),
+            requested_amount_msats: 100_000,
+            invoice_amount_msats: 100_000,
+            fee_msats: 750,
+            net_credit_msats: 99_250,
+            gateway_id: None,
+            expires_at: 0,
+            created_at: 1_650_000_000_000,
+            reclaim_operation_id: None,
+        };
+        let meta = serde_json::json!({
+            "variant": {
+                "receive": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "gateway_id": GATEWAY_ID,
+                }
+            },
+            "extra_meta": wire::custom_meta(&copy).expect("encode"),
+        });
+        let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
+        let details = wire::decode_receive_details(&claimed.details).expect("decodes");
+        // The copy's figures, not the "no fee known" estimate (0 / 100_000) the log entry alone
+        // would give.
+        assert_eq!(details.fee, Amount::from_msats(750));
+        assert_eq!(details.net_credit, Amount::from_msats(99_250));
+        assert_eq!(details.description, "coffee");
+        // The copy's own creation time, known before the invoice call and carried through.
+        assert_eq!(details.created_at.epoch_millis(), 1_650_000_000_000);
+        // The invoice and gateway id still come from upstream's own meta, not the copy's
+        // placeholder.
+        assert_eq!(details.invoice.to_string(), REGTEST_INVOICE);
         assert_eq!(details.gateway_id, Some(GATEWAY_ID.parse().expect("id")));
     }
 

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -643,12 +643,15 @@ pub(super) async fn send(
             }
             internal(format!("the payment could not be started: {text}"))
         })?;
-    // The module's own answer is authoritative for what actually happened, so the record reflects
-    // what was debited, not what was quoted. The two normally agree, because the check above
-    // reads the same decision the module is about to make; they can still disagree once more,
-    // since the gateway cache the module reads from is shared and can move again between that
-    // check and this call. When a payment quoted through a gateway settles internally after all,
-    // no gateway fee was ever charged, so it is backed out of the quoted fee and total.
+    // The module's answer after funding is authoritative for the route; a payment quoted
+    // through a gateway that settled internally paid no gateway fee. The gateway component is
+    // the only part of the fee this code knows for certain was not charged, so it is what is
+    // backed out. The lightning module's fee is a flat consensus figure and carries over
+    // exactly; the primary module's and dust components are the quote's figures for a contract
+    // larger by the gateway fee, kept as a best-effort estimate because upstream gives no way to
+    // read the assembled fee back after funding. The recorded total is therefore an upper bound
+    // on the debit in this residual case, which is reached only if the gateway cache moves
+    // between the route re-check above and the module's own decision.
     let (id, route, fee, total) = match payment.payment_type {
         PayType::Internal(id) if quoted_internal => (
             id,

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -433,6 +433,14 @@ pub(super) async fn subscribe_receive(
     Ok(Box::pin(stream::unfold(follow, step)))
 }
 
+/// Rebuilds a record from the module's log entry; filled in with the facade operations.
+pub(super) fn backfill(
+    _meta: &serde_json::Value,
+    _created_at: u64,
+) -> Option<crate::operation::Backfilled> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use fedimint_ln_client::pay::GatewayPayError;

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -23,9 +23,9 @@ use futures::{StreamExt, stream};
 use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
 use super::{
-    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, from_upstream, gateway_unavailable,
-    insufficient, internal, now, plan_of, quote_changed, quote_expired, subscribe_error,
-    to_upstream, unreachable,
+    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, fee_quote_failure, from_upstream,
+    gateway_unavailable, insufficient, internal, now, plan_of, quote_changed, quote_expired,
+    subscribe_error, to_upstream, unreachable,
 };
 use crate::federation::FederationInner;
 use crate::operation::{Backfilled, Driver, kinds, record_phase_in, write_details_in};
@@ -466,7 +466,7 @@ pub(super) async fn plan(
                 .map_err(gateway_unavailable)?,
         ))
     };
-    terms_for(module, invoice, amount, gateway).await
+    terms_for(client, module, invoice, amount, gateway).await
 }
 
 /// Whether the module will settle this invoice inside the federation: the same two tests
@@ -504,6 +504,7 @@ async fn is_internal(
 /// The gateway is boxed as `Terms::V1` holds it: a `LightningGateway` is a few hundred bytes and
 /// clippy's `large_enum_variant` refuses it inline.
 async fn terms_for(
+    client: &Client,
     module: &LightningClientModule,
     invoice: &Bolt11Invoice,
     amount: Amount,
@@ -515,21 +516,24 @@ async fn terms_for(
         from_upstream(gateway.fees.to_amount(&to_upstream(amount)))
     });
     let contract_amount = add(amount, gateway_fee)?;
-    // A dry run of the primary module's balancing fails with `InsufficientBalanceError` when the
-    // notes on hand cannot cover the contract; that is reported as the balance problem it is,
-    // rather than as an opaque internal failure.
-    let quote = module
-        .send_fee_quote(to_upstream(contract_amount))
-        .await
-        .map_err(|err| {
-            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
-                Some(short) => insufficient(
-                    from_upstream(short.requested_amount),
-                    from_upstream(short.total_amount),
-                ),
-                None => internal(format!("could not quote the funding fee: {err}")),
-            }
-        })?;
+    // A dry run of the primary module's balancing fails when the notes on hand cannot cover
+    // the contract; that is reported as the balance problem it is, rather than as an opaque
+    // internal failure, on either mint generation this module can run against.
+    let quote = match module.send_fee_quote(to_upstream(contract_amount)).await {
+        Ok(quote) => quote,
+        Err(err) => {
+            let text = err.to_string();
+            let short = err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>();
+            return Err(fee_quote_failure(
+                client,
+                short,
+                &text,
+                contract_amount,
+                "could not quote the funding fee",
+            )
+            .await);
+        }
+    };
     let lightning_module = from_upstream(module.cfg.fee_consensus.contract_output);
     let route = match &gateway {
         None => LightningRoute::Internal,
@@ -607,6 +611,7 @@ pub(super) async fn send(
         }
     };
     let fresh = terms_for(
+        client,
         module,
         &quote.invoice,
         quote.invoice_amount,
@@ -722,6 +727,7 @@ fn v1_payment_operation_id(payment_hash: &sha256::Hash, index: u16) -> Operation
 /// Issues a v1 invoice through the cheapest online gateway and records it.
 pub(super) async fn receive(
     federation: &Arc<FederationInner>,
+    client: &Client,
     module: &LightningClientModule,
     amount: Amount,
     description: &str,
@@ -742,21 +748,24 @@ pub(super) async fn receive(
         .map_err(gateway_unavailable)?;
     // v1 takes no gateway fee on the way in: the gateway funds the contract for the invoice's
     // amount and the only deduction is the federation's fee for claiming it.
-    // Same as in `terms_for`: a dry run of the primary module's balancing fails with
-    // `InsufficientBalanceError` when the notes on hand cannot cover the contract, which is
-    // reported as the balance problem it is.
-    let quote = module
-        .receive_fee_quote(to_upstream(amount))
-        .await
-        .map_err(|err| {
-            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
-                Some(short) => insufficient(
-                    from_upstream(short.requested_amount),
-                    from_upstream(short.total_amount),
-                ),
-                None => internal(format!("could not quote the claim fee: {err}")),
-            }
-        })?;
+    // Same as in `terms_for`: a dry run of the primary module's balancing fails when the notes
+    // on hand cannot cover the contract, which is reported as the balance problem it is, on
+    // either mint generation.
+    let quote = match module.receive_fee_quote(to_upstream(amount)).await {
+        Ok(quote) => quote,
+        Err(err) => {
+            let text = err.to_string();
+            let short = err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>();
+            return Err(fee_quote_failure(
+                client,
+                short,
+                &text,
+                amount,
+                "could not quote the claim fee",
+            )
+            .await);
+        }
+    };
     let fee = from_upstream(quote.total().get_bitcoin());
     let net_credit = amount.checked_sub(fee).ok_or_else(|| {
         Error::new(

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -1,26 +1,38 @@
 //! The v1 lightning module (`ln`): mappings, subscriptions, and the facade operations.
 
-use std::sync::Weak;
+use std::sync::{Arc, Weak};
 
 use fedimint_client::Client;
 use fedimint_client_module::ClientModuleInstance;
 use fedimint_core::core::OperationId;
-use fedimint_core::db::Database;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::util::BoxStream;
 use fedimint_ln_client::LnReceiveState as UpstreamReceiveState;
+use fedimint_ln_client::db::PaymentResultKey;
 use fedimint_ln_client::receive::LightningReceiveError;
-use fedimint_ln_client::{InternalPayState, LightningClientModule, LnPayState};
+use fedimint_ln_client::{
+    InternalPayState, LightningClientModule, LightningOperationMeta, LightningOperationMetaVariant,
+    LnPayState, OutgoingLightningPayment, PayBolt11InvoiceError, PayType,
+};
+use fedimint_ln_common::LightningGateway;
+use fedimint_ln_common::config::FeeToAmount;
+use fedimint_ln_common::lightning_invoice::{Bolt11InvoiceDescription, Description};
 use futures::{StreamExt, stream};
 
-use super::driver::until_final;
-use super::subscribe_error;
+use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
+use super::{
+    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, from_upstream, gateway_unavailable,
+    insufficient, internal, now, plan_of, quote_changed, quote_expired, subscribe_error,
+    to_upstream, unreachable,
+};
 use crate::federation::FederationInner;
-use crate::operation::{record_phase_in, write_details_in};
+use crate::operation::{Backfilled, Driver, kinds, record_phase_in, write_details_in};
 use crate::sdk::SdkInner;
 use crate::{
-    Amount, Error, ErrorCode, LightningRoute, LnReceiveState, LnSendDetails, LnSendState,
-    OperationState, Preimage, Result,
+    Amount, Bolt11Invoice, Error, ErrorCode, GatewayId, LightningRoute, LnReceive,
+    LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Operation, OperationState,
+    Preimage, Result, Timestamp,
 };
 
 // Upstream `LnPayState` onto `LnSendState`. The fee and the route come from the executed quote:
@@ -226,8 +238,6 @@ impl ReclaimContext {
     /// Starts the retry upstream, records which operation it runs under, and returns its
     /// stream — or the module's word that no further claim is possible.
     async fn start(&self) -> Result<ReclaimStart> {
-        use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
-
         let closed = || {
             Error::new(
                 ErrorCode::FederationClosed,
@@ -433,12 +443,330 @@ pub(super) async fn subscribe_receive(
     Ok(Box::pin(stream::unfold(follow, step)))
 }
 
-/// Rebuilds a record from the module's log entry; filled in with the facade operations.
-pub(super) fn backfill(
-    _meta: &serde_json::Value,
-    _created_at: u64,
-) -> Option<crate::operation::Backfilled> {
-    None
+/// Plans a v1 payment: refreshes the gateway list, decides the route the module will take, picks
+/// the cheapest online gateway when one is needed, and prices the funding transaction.
+pub(super) async fn plan(
+    client: &Client,
+    module: &LightningClientModule,
+    invoice: &Bolt11Invoice,
+    amount: Amount,
+) -> Result<Plan> {
+    module
+        .update_gateway_cache()
+        .await
+        .map_err(|err| unreachable(format!("could not refresh the gateway list: {err}")))?;
+    let gateway = if is_internal(client, module, invoice).await? {
+        None
+    } else {
+        Some(Box::new(
+            module
+                .select_available_gateway(None, Some(invoice.inner().clone()))
+                .await
+                .map_err(gateway_unavailable)?,
+        ))
+    };
+    terms_for(module, invoice, amount, gateway).await
+}
+
+/// Whether the module will settle this invoice inside the federation: the same two tests
+/// `pay_bolt11_invoice` runs (`fedimint-ln-client/src/lib.rs:1409-1418`), so the quote's route is
+/// the route the payment takes. Both look at the last hop of the invoice's first route hint.
+async fn is_internal(
+    client: &Client,
+    module: &LightningClientModule,
+    invoice: &Bolt11Invoice,
+) -> Result<bool> {
+    let last_hop = invoice.inner().route_hints().first().and_then(|hint| {
+        hint.0
+            .last()
+            .map(|hop| (hop.src_node_id, hop.short_channel_id))
+    });
+    let Some(last_hop) = last_hop else {
+        return Ok(false);
+    };
+    let markers = client
+        .get_internal_payment_markers()
+        .map_err(|err| internal(format!("no internal payment markers: {err}")))?;
+    if last_hop == markers {
+        return Ok(true);
+    }
+    Ok(module
+        .list_gateways()
+        .await
+        .into_iter()
+        .any(|gateway| last_hop == (gateway.info.node_pub_key, gateway.info.federation_index)))
+}
+
+/// Prices a payment through `gateway` (or internally for `None`): the gateway's charge from its
+/// fee schedule, the module's own output fee, and the shared quote for funding the contract.
+///
+/// The gateway is boxed as `Terms::V1` holds it: a `LightningGateway` is a few hundred bytes and
+/// clippy's `large_enum_variant` refuses it inline.
+async fn terms_for(
+    module: &LightningClientModule,
+    invoice: &Bolt11Invoice,
+    amount: Amount,
+    gateway: Option<Box<LightningGateway>>,
+) -> Result<Plan> {
+    // The contract is funded for the invoice amount plus the gateway's fee
+    // (`fedimint-ln-client/src/lib.rs:866-867`); an internal payment funds exactly the amount.
+    let gateway_fee = gateway.as_ref().map_or(Amount::from_msats(0), |gateway| {
+        from_upstream(gateway.fees.to_amount(&to_upstream(amount)))
+    });
+    let contract_amount = add(amount, gateway_fee)?;
+    let quote = module
+        .send_fee_quote(to_upstream(contract_amount))
+        .await
+        .map_err(|err| internal(format!("could not quote the funding fee: {err}")))?;
+    let lightning_module = from_upstream(module.cfg.fee_consensus.contract_output);
+    let route = match &gateway {
+        None => LightningRoute::Internal,
+        Some(gateway) => LightningRoute::Gateway {
+            gateway_id: GatewayId::from_upstream(gateway.gateway_id),
+        },
+    };
+    plan_of(
+        gateway_fee,
+        lightning_module,
+        &quote,
+        amount,
+        route,
+        Terms::V1 { gateway },
+    )
+}
+
+/// Executes a v1 quote: re-reads every bound input, refuses on drift, funds, records.
+pub(super) async fn send(
+    federation: &Arc<FederationInner>,
+    module: &ClientModuleInstance<'_, LightningClientModule>,
+    quote: &LnQuoteInner,
+    gateway: Option<Box<LightningGateway>>,
+) -> Result<Operation<LnSendState>> {
+    // The gateway may have withdrawn or changed its fees since the quote; the cache is what the
+    // module pays through, so it is what is checked.
+    let gateway = match gateway {
+        None => None,
+        Some(quoted) => {
+            let Some(current) = module.select_gateway(&quoted.gateway_id).await else {
+                return Err(Error::new(
+                    ErrorCode::QuoteChanged,
+                    "the quoted gateway is no longer registered with this federation",
+                ));
+            };
+            Some(Box::new(current))
+        }
+    };
+    let fresh = terms_for(
+        module,
+        &quote.invoice,
+        quote.invoice_amount,
+        gateway.clone(),
+    )
+    .await?;
+    if fresh.total != quote.plan.total {
+        return Err(quote_changed(quote.plan.total, fresh.total));
+    }
+    // A completed earlier payment of this invoice would be answered as if it were new
+    // (`fedimint-ln-client/src/lib.rs:1356-1358`); the module's own idempotency record says so
+    // before anything is funded.
+    let payment_hash = *quote.invoice.inner().payment_hash();
+    let already_paid = module
+        .db
+        .begin_transaction_nc()
+        .await
+        .get_value(&PaymentResultKey { payment_hash })
+        .await
+        .is_some_and(|result| result.completed_payment.is_some());
+    if already_paid {
+        return Err(quote_expired(quote.expires_at, true));
+    }
+    let payment: OutgoingLightningPayment = module
+        .pay_bolt11_invoice(
+            gateway.map(|gateway| *gateway),
+            quote.invoice.inner().clone(),
+            serde_json::Value::Null,
+        )
+        .await
+        .map_err(|err| {
+            if let Some(known) = err.downcast_ref::<PayBolt11InvoiceError>() {
+                return match known {
+                    PayBolt11InvoiceError::PreviousPaymentAttemptStillInProgress { .. }
+                    | PayBolt11InvoiceError::FundedContractAlreadyExists { .. } => {
+                        quote_expired(quote.expires_at, true)
+                    }
+                    PayBolt11InvoiceError::NoLnGatewayAvailable => {
+                        gateway_unavailable("the module found no gateway for this route")
+                    }
+                };
+            }
+            if let Some(short) =
+                err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>()
+            {
+                return insufficient(
+                    from_upstream(short.requested_amount),
+                    from_upstream(short.total_amount),
+                );
+            }
+            let text = err.to_string();
+            if text.contains("Invoice has expired") {
+                return quote_expired(quote.expires_at, false);
+            }
+            if text.contains("Insufficient balance") {
+                return Error::new(ErrorCode::InsufficientBalance, text);
+            }
+            internal(format!("the payment could not be started: {text}"))
+        })?;
+    let (id, route) = match payment.payment_type {
+        PayType::Internal(id) => (id, LightningRoute::Internal),
+        PayType::Lightning(id) => (id, quote.plan.route.clone()),
+    };
+    let details = crate::LnSendDetails {
+        invoice: quote.invoice.clone(),
+        invoice_amount: quote.invoice_amount,
+        fee: quote.plan.fee,
+        total: quote.plan.total,
+        route,
+        created_at: now(),
+    };
+    federation
+        .create_operation(
+            id,
+            kinds::LN_SEND,
+            "ln",
+            &wire::LnSendDetailsWire::from(&details),
+            Arc::new(LnSendDriver) as Arc<dyn Driver<LnSendState>>,
+        )
+        .await
+}
+
+/// Issues a v1 invoice through the cheapest online gateway and records it.
+pub(super) async fn receive(
+    federation: &Arc<FederationInner>,
+    module: &LightningClientModule,
+    amount: Amount,
+    description: &str,
+) -> Result<LnReceive> {
+    let bolt11_description = Description::new(description.to_owned()).map_err(|err| {
+        Error::new(
+            ErrorCode::InvalidInput,
+            format!("the description cannot be carried by an invoice: {err}"),
+        )
+    })?;
+    module
+        .update_gateway_cache()
+        .await
+        .map_err(|err| unreachable(format!("could not refresh the gateway list: {err}")))?;
+    let gateway = module
+        .select_available_gateway(None, None)
+        .await
+        .map_err(gateway_unavailable)?;
+    // v1 takes no gateway fee on the way in: the gateway funds the contract for the invoice's
+    // amount and the only deduction is the federation's fee for claiming it.
+    let quote = module
+        .receive_fee_quote(to_upstream(amount))
+        .await
+        .map_err(|err| internal(format!("could not quote the claim fee: {err}")))?;
+    let fee = from_upstream(quote.total().get_bitcoin());
+    let net_credit = amount.checked_sub(fee).ok_or_else(|| {
+        Error::new(
+            ErrorCode::InvalidInput,
+            "the amount does not cover the receive-side fee",
+        )
+    })?;
+    let (id, invoice, _preimage) = module
+        .create_bolt11_invoice(
+            to_upstream(amount),
+            Bolt11InvoiceDescription::Direct(bolt11_description),
+            Some(u64::from(INVOICE_EXPIRY_SECS)),
+            serde_json::Value::Null,
+            Some(gateway.clone()),
+        )
+        .await
+        .map_err(|err| unreachable(format!("the invoice could not be registered: {err}")))?;
+    let invoice = Bolt11Invoice::from_upstream(invoice);
+    let details = LnReceiveDetails {
+        invoice: invoice.clone(),
+        description: description.to_owned(),
+        requested_amount: amount,
+        invoice_amount: amount,
+        fee,
+        net_credit,
+        gateway_id: Some(GatewayId::from_upstream(gateway.gateway_id)),
+        expires_at: invoice.expires_at(),
+        created_at: now(),
+    };
+    let operation = federation
+        .create_operation(
+            id,
+            kinds::LN_RECEIVE,
+            "ln",
+            &wire::LnReceiveDetailsWire::from(&details),
+            Arc::new(LnReceiveDriver) as Arc<dyn Driver<LnReceiveState>>,
+        )
+        .await?;
+    Ok(LnReceive { invoice, operation })
+}
+
+/// Rebuilds a record from a v1 log entry. Best effort by nature: the entry carries the gateway's
+/// fee but not the federation's, so a rebuilt send's total is a floor and a rebuilt receive
+/// reports no fee at all.
+pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Backfilled> {
+    let meta: LightningOperationMeta = serde_json::from_value(meta.clone()).ok()?;
+    let created_at = Timestamp::from_epoch_millis(created_at);
+    match meta.variant {
+        LightningOperationMetaVariant::Pay(pay) => {
+            let invoice = Bolt11Invoice::from_upstream(pay.invoice);
+            let invoice_amount = invoice.amount()?;
+            let fee = from_upstream(pay.fee);
+            let route = if pay.is_internal_payment {
+                LightningRoute::Internal
+            } else {
+                LightningRoute::Gateway {
+                    gateway_id: GatewayId::from_upstream(pay.gateway_id?),
+                }
+            };
+            let details = crate::LnSendDetails {
+                invoice,
+                invoice_amount,
+                fee,
+                total: invoice_amount.checked_add(fee)?,
+                route,
+                created_at,
+            };
+            Some(Backfilled {
+                kind: kinds::LN_SEND,
+                details: serde_json::to_string(&wire::LnSendDetailsWire::from(&details)).ok()?,
+                phase: None,
+            })
+        }
+        LightningOperationMetaVariant::Receive {
+            invoice,
+            gateway_id,
+            ..
+        } => {
+            let invoice = Bolt11Invoice::from_upstream(invoice);
+            let amount = invoice.amount()?;
+            let details = LnReceiveDetails {
+                description: invoice.description(),
+                requested_amount: amount,
+                invoice_amount: amount,
+                fee: Amount::from_msats(0),
+                net_credit: amount,
+                gateway_id: gateway_id.map(GatewayId::from_upstream),
+                expires_at: invoice.expires_at(),
+                created_at,
+                invoice,
+            };
+            Some(Backfilled {
+                kind: kinds::LN_RECEIVE,
+                details: serde_json::to_string(&wire::LnReceiveDetailsWire::from(&details)).ok()?,
+                phase: None,
+            })
+        }
+        // A retried claim runs under the original receive's record; the deprecated claim path
+        // and recurring payments are not operations this SDK creates.
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -448,15 +776,16 @@ mod tests {
     use super::*;
     use crate::Amount;
 
+    const GATEWAY_ID: &str = "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
+    const REGTEST_INVOICE: &str = "lnbcrt1u1pj48ugqdq2vdhkven9v5pp5g3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqsp5242424242424242424242424242424242424242424242424242s9qrsgqcqzys2reg4wsryjt5w8z33ugydecgfmgyvtttwa7e0yzlm803z203j9hqspa4lr6m09cd808xkw9uh4sxc8wf3w6k0gaf5zrqm7zhcxug0vqqpdkpja";
+
     fn fee() -> Amount {
         Amount::from_msats(1_050)
     }
 
     fn gateway_route() -> LightningRoute {
         LightningRoute::Gateway {
-            gateway_id: "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166"
-                .parse()
-                .expect("a gateway id"),
+            gateway_id: GATEWAY_ID.parse().expect("a gateway id"),
         }
     }
 
@@ -706,5 +1035,65 @@ mod tests {
         let text = classify_reclaim_refusal("Operation is not a reclaimable lightning receive")
             .expect("a refusal that is not the race is definitive");
         assert_eq!(text, "Operation is not a reclaimable lightning receive");
+    }
+
+    #[test]
+    fn a_pay_log_entry_backfills_a_send_record() {
+        let meta = serde_json::json!({
+            "variant": {
+                "pay": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "fee": 1000,
+                    "change": [],
+                    "is_internal_payment": false,
+                    "contract_id": "11".repeat(32),
+                    "gateway_id": GATEWAY_ID,
+                }
+            },
+            "extra_meta": null,
+        });
+        let claimed = backfill(&meta, 1_700_000_000_000).expect("claimed");
+        assert_eq!(claimed.kind, crate::operation::kinds::LN_SEND);
+        assert_eq!(claimed.phase, None);
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        assert_eq!(details.invoice_amount, Amount::from_msats(100_000));
+        assert_eq!(details.fee, Amount::from_msats(1_000));
+        assert_eq!(details.total, Amount::from_msats(101_000));
+        assert_eq!(details.route, gateway_route());
+        assert_eq!(details.created_at.epoch_millis(), 1_700_000_000_000);
+    }
+
+    #[test]
+    fn a_receive_log_entry_backfills_a_receive_record() {
+        let meta = serde_json::json!({
+            "variant": {
+                "receive": {
+                    "out_point": { "txid": "00".repeat(32), "out_idx": 0 },
+                    "invoice": REGTEST_INVOICE,
+                    "gateway_id": GATEWAY_ID,
+                }
+            },
+            "extra_meta": null,
+        });
+        let claimed = backfill(&meta, 7).expect("claimed");
+        assert_eq!(claimed.kind, crate::operation::kinds::LN_RECEIVE);
+        let details = wire::decode_receive_details(&claimed.details).expect("decodes");
+        assert_eq!(details.invoice_amount, Amount::from_msats(100_000));
+        assert_eq!(details.requested_amount, Amount::from_msats(100_000));
+        // The fee is not in the log entry; a rebuilt record reports none.
+        assert_eq!(details.fee, Amount::from_msats(0));
+        assert_eq!(details.net_credit, Amount::from_msats(100_000));
+        assert_eq!(details.gateway_id, Some(GATEWAY_ID.parse().expect("id")));
+    }
+
+    #[test]
+    fn other_v1_log_entries_are_not_claimed() {
+        let meta = serde_json::json!({
+            "variant": { "claim": { "out_points": [] } },
+            "extra_meta": null,
+        });
+        assert!(backfill(&meta, 0).is_none());
+        assert!(backfill(&serde_json::Value::Null, 0).is_none());
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Weak};
 
 use fedimint_client::Client;
 use fedimint_client_module::ClientModuleInstance;
+use fedimint_core::bitcoin::hashes::{Hash, sha256};
 use fedimint_core::core::OperationId;
 use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
 use fedimint_core::util::BoxStream;
@@ -554,6 +555,31 @@ pub(super) async fn send(
     quote: &LnQuoteInner,
     gateway: Option<Box<LightningGateway>>,
 ) -> Result<Operation<LnSendState>> {
+    // Whether the module has already completed a payment for this invoice, or is still running
+    // one, is decided before anything else. Paying a quote moves the note inventory, so a second
+    // quote for the same invoice re-prices to a different federation fee once the first is
+    // funded, and the terms re-check below would otherwise report that as a moved quote instead
+    // of the truth: the invoice is already paid. `pay_bolt11_invoice` itself runs these same two
+    // idempotency checks first, ahead of anything else it does
+    // (`fedimint-ln-client/src/lib.rs:1356-1368`).
+    let payment_hash = *quote.invoice.inner().payment_hash();
+    let record = module
+        .db
+        .begin_transaction_nc()
+        .await
+        .get_value(&PaymentResultKey { payment_hash })
+        .await;
+    if let Some(record) = record {
+        if record.completed_payment.is_some() {
+            return Err(quote_expired(quote.expires_at, true));
+        }
+        if client
+            .has_active_states(v1_payment_operation_id(&payment_hash, record.index))
+            .await
+        {
+            return Err(quote_expired(quote.expires_at, true));
+        }
+    }
     // `pay_bolt11_invoice` decides internal-vs-gateway for itself, from the invoice and the
     // gateway cache as they stand when it is called (`fedimint-ln-client/src/lib.rs:1405-1418`).
     // That cache is shared and can move between the quote and this call, so the same decision is
@@ -589,20 +615,6 @@ pub(super) async fn send(
     .await?;
     if fresh.total != quote.plan.total {
         return Err(quote_changed(quote.plan.total, fresh.total));
-    }
-    // A completed earlier payment of this invoice would be answered as if it were new
-    // (`fedimint-ln-client/src/lib.rs:1356-1358`); the module's own idempotency record says so
-    // before anything is funded.
-    let payment_hash = *quote.invoice.inner().payment_hash();
-    let already_paid = module
-        .db
-        .begin_transaction_nc()
-        .await
-        .get_value(&PaymentResultKey { payment_hash })
-        .await
-        .is_some_and(|result| result.completed_payment.is_some());
-    if already_paid {
-        return Err(quote_expired(quote.expires_at, true));
     }
     let payment: OutgoingLightningPayment = module
         .pay_bolt11_invoice(
@@ -692,6 +704,19 @@ pub(super) async fn send(
             Arc::new(LnSendDriver) as Arc<dyn Driver<LnSendState>>,
         )
         .await
+}
+
+// Reproduces `LightningClientModule::get_payment_operation_id`, upstream's private helper
+// (`fedimint-ln-client/src/lib.rs:798-806`) that derives the operation id of one payment
+// attempt from the invoice's payment hash and the attempt's index: a sha256 hash over the 32
+// payment-hash bytes followed by the 2-byte little-endian index. This id is a storage format
+// upstream, not an implementation detail: it is the operation id under which every v1 payment
+// attempt is, and always has been, recorded, so it is as stable as the log itself.
+fn v1_payment_operation_id(payment_hash: &sha256::Hash, index: u16) -> OperationId {
+    let mut bytes = [0u8; 34];
+    bytes[0..32].copy_from_slice(&payment_hash.to_byte_array());
+    bytes[32..34].copy_from_slice(&index.to_le_bytes());
+    OperationId(sha256::Hash::hash(&bytes).to_byte_array())
 }
 
 /// Issues a v1 invoice through the cheapest online gateway and records it.
@@ -853,6 +878,16 @@ mod tests {
         LightningRoute::Gateway {
             gateway_id: GATEWAY_ID.parse().expect("a gateway id"),
         }
+    }
+
+    #[test]
+    fn v1_payment_operation_id_hashes_the_payment_hash_and_the_little_endian_index() {
+        let payment_hash = sha256::Hash::from_byte_array([0xab; 32]);
+        let mut expected_bytes = [0u8; 34];
+        expected_bytes[0..32].copy_from_slice(&payment_hash.to_byte_array());
+        expected_bytes[32..34].copy_from_slice(&1u16.to_le_bytes());
+        let expected = OperationId(sha256::Hash::hash(&expected_bytes).to_byte_array());
+        assert_eq!(v1_payment_operation_id(&payment_hash, 1), expected);
     }
 
     #[test]

--- a/rust/fedimint-sdk/src/lightning/v1.rs
+++ b/rust/fedimint-sdk/src/lightning/v1.rs
@@ -1,17 +1,26 @@
 //! The v1 lightning module (`ln`): mappings, subscriptions, and the facade operations.
 
+use std::sync::Weak;
+
 use fedimint_client::Client;
 use fedimint_client_module::ClientModuleInstance;
 use fedimint_core::core::OperationId;
+use fedimint_core::db::Database;
 use fedimint_core::util::BoxStream;
+use fedimint_ln_client::LnReceiveState as UpstreamReceiveState;
+use fedimint_ln_client::receive::LightningReceiveError;
 use fedimint_ln_client::{InternalPayState, LightningClientModule, LnPayState};
-use futures::StreamExt;
+use futures::{StreamExt, stream};
 
 use super::driver::until_final;
 use super::subscribe_error;
+use super::wire::{self, PHASE_FUNDED};
 use crate::federation::FederationInner;
+use crate::operation::{record_phase_in, write_details_in};
+use crate::sdk::SdkInner;
 use crate::{
-    Amount, Error, ErrorCode, LightningRoute, LnSendDetails, LnSendState, Preimage, Result,
+    Amount, Error, ErrorCode, LightningRoute, LnReceiveState, LnSendDetails, LnSendState,
+    OperationState, Preimage, Result,
 };
 
 // Upstream `LnPayState` onto `LnSendState`. The fee and the route come from the executed quote:
@@ -135,6 +144,215 @@ pub(super) async fn subscribe_send(
         }
     };
     Ok(until_final(stream))
+}
+
+/// What the original receive's next upstream state means: a state to hand out, or the signal to
+/// retry the claim.
+pub(super) enum ReceiveStep {
+    State(LnReceiveState),
+    Reclaim,
+}
+
+// Upstream v1 `LnReceiveState` onto `LnReceiveState`, keyed on whether the receive was ever seen
+// funded. `Rejected` means two things: the invoice-registration transaction refused (before any
+// funding, so `Canceled`), or the claim's primary outputs failing after a confirmed payment (at
+// or after funding, so `Failed`). `ClaimRejected` and `InvalidPreimage` presuppose a funded
+// contract and are not phase-keyed.
+//
+// | upstream                       | phase reached        | here                   |
+// | ------------------------------ | -------------------- | ---------------------- |
+// | `Created`                      | any                  | `Created`              |
+// | `WaitingForPayment`            | any                  | `WaitingForPayment`    |
+// | `Funded`, `AwaitingFunds`      | any                  | `Funded`               |
+// | `Claimed`                      | any                  | `Claimed`              |
+// | `Canceled { Timeout }`         | any                  | `Expired`              |
+// | `Canceled { ClaimRejected }`   | any                  | `Funded`, then reclaim |
+// | `Canceled { InvalidPreimage }` | any                  | `Failed`               |
+// | `Canceled { Rejected }`        | before `Funded`      | `Canceled`             |
+// | `Canceled { Rejected }`        | at or after `Funded` | `Failed`               |
+pub(super) fn map_receive(state: &UpstreamReceiveState, funded_before: bool) -> ReceiveStep {
+    ReceiveStep::State(match state {
+        UpstreamReceiveState::Created => LnReceiveState::Created,
+        UpstreamReceiveState::WaitingForPayment { .. } => LnReceiveState::WaitingForPayment,
+        UpstreamReceiveState::Funded | UpstreamReceiveState::AwaitingFunds => {
+            LnReceiveState::Funded
+        }
+        UpstreamReceiveState::Claimed => LnReceiveState::Claimed,
+        UpstreamReceiveState::Canceled { reason } => match reason {
+            LightningReceiveError::Timeout => LnReceiveState::Expired,
+            LightningReceiveError::ClaimRejected => return ReceiveStep::Reclaim,
+            LightningReceiveError::InvalidPreimage => LnReceiveState::Failed,
+            LightningReceiveError::Rejected if funded_before => LnReceiveState::Failed,
+            LightningReceiveError::Rejected => LnReceiveState::Canceled {
+                reason: reason.to_string(),
+            },
+        },
+    })
+}
+
+// A retried claim runs as its own upstream operation, started in the confirmed-invoice state:
+// the money is in the contract, so everything short of the end is `Funded`, and any cancellation
+// of the retry is the end of the road.
+pub(super) fn map_reclaim(state: &UpstreamReceiveState) -> LnReceiveState {
+    match state {
+        UpstreamReceiveState::Claimed => LnReceiveState::Claimed,
+        UpstreamReceiveState::Canceled { .. } => LnReceiveState::Failed,
+        UpstreamReceiveState::Created
+        | UpstreamReceiveState::WaitingForPayment { .. }
+        | UpstreamReceiveState::Funded
+        | UpstreamReceiveState::AwaitingFunds => LnReceiveState::Funded,
+    }
+}
+
+/// What a receive subscription needs to retry a rejected claim from inside its own stream.
+///
+/// A stream outlives the borrow it was made from, so it cannot hold a client guard; it holds the
+/// instance and the federation id instead and takes a guard again when the retry happens.
+struct ReclaimContext {
+    sdk: Weak<SdkInner>,
+    federation_id: fedimint_core::config::FederationId,
+    db: Database,
+    id: OperationId,
+    details_json: String,
+}
+
+impl ReclaimContext {
+    /// Starts the retry upstream, records which operation it runs under, and returns its stream.
+    async fn start(&self) -> Result<BoxStream<'static, UpstreamReceiveState>> {
+        let closed = || {
+            Error::new(
+                ErrorCode::FederationClosed,
+                "this federation stopped running",
+            )
+        };
+        let sdk = self.sdk.upgrade().ok_or_else(closed)?;
+        let federation = sdk
+            .federation_inner(&self.federation_id)
+            .ok_or_else(closed)?;
+        let client = federation.client(false).await?;
+        let module = module_of(&client)?;
+        let reclaim_id = module.reclaim_ln_receive(self.id).await.map_err(|err| {
+            Error::new(
+                ErrorCode::Internal,
+                format!("the rejected claim could not be retried: {err}"),
+            )
+        })?;
+        // Persisted before it is followed: after a restart the record is the only thing that
+        // says which upstream operation to follow.
+        let mut details = wire::decode_receive_wire(&self.details_json)?;
+        details.reclaim_operation_id =
+            Some(crate::OperationId::from_upstream(reclaim_id).to_string());
+        write_details_in(&self.db, self.id, wire::encode_receive_wire(&details)?).await?;
+        Ok(module
+            .subscribe_ln_receive(reclaim_id)
+            .await
+            .map_err(subscribe_error)?
+            .into_stream())
+    }
+}
+
+/// Which upstream operation a receive subscription is following.
+enum Following {
+    Original,
+    Reclaim,
+}
+
+/// The per-subscription cursor of a v1 receive.
+struct Follow {
+    upstream: BoxStream<'static, UpstreamReceiveState>,
+    following: Following,
+    phase: u32,
+    done: bool,
+    context: ReclaimContext,
+}
+
+/// One step of the receive stream: the next mapped state, having persisted the phase it proves
+/// and switched to the retried claim if one was needed.
+async fn step(mut follow: Follow) -> Option<(Result<LnReceiveState>, Follow)> {
+    if follow.done {
+        return None;
+    }
+    let state = follow.upstream.next().await?;
+    let mapped = match follow.following {
+        Following::Reclaim => map_reclaim(&state),
+        Following::Original => match map_receive(&state, follow.phase >= PHASE_FUNDED) {
+            ReceiveStep::State(state) => state,
+            // `ClaimRejected` is not final here: the claim is retried under the same SDK
+            // operation, and only a retry that cannot be started is the end.
+            ReceiveStep::Reclaim => match follow.context.start().await {
+                Ok(upstream) => {
+                    follow.upstream = upstream;
+                    follow.following = Following::Reclaim;
+                    LnReceiveState::Funded
+                }
+                Err(_) => LnReceiveState::Failed,
+            },
+        },
+    };
+    if matches!(mapped, LnReceiveState::Funded) && follow.phase < PHASE_FUNDED {
+        follow.phase = PHASE_FUNDED;
+        if let Err(err) = record_phase_in(&follow.context.db, follow.context.id, PHASE_FUNDED).await
+        {
+            follow.done = true;
+            return Some((Err(err), follow));
+        }
+    }
+    follow.done = mapped.is_final();
+    Some((Ok(mapped), follow))
+}
+
+/// A fresh stream over a v1 receive, following the retried claim instead of the original when
+/// the record says one was started.
+pub(super) async fn subscribe_receive(
+    federation: &FederationInner,
+    id: OperationId,
+    phase: u32,
+    details_json: &str,
+) -> Result<BoxStream<'static, Result<LnReceiveState>>> {
+    let details = wire::decode_receive_wire(details_json)?;
+    let client = federation.client(false).await?;
+    let module = module_of(&client)?;
+    let (upstream, following) = match details.reclaim_operation_id.as_deref() {
+        Some(reclaim) => {
+            let reclaim_id = reclaim
+                .parse::<crate::OperationId>()
+                .map_err(|err| {
+                    Error::new(
+                        ErrorCode::Internal,
+                        format!("a stored operation id does not parse: {err}"),
+                    )
+                })?
+                .upstream();
+            let upstream = module
+                .subscribe_ln_receive(reclaim_id)
+                .await
+                .map_err(subscribe_error)?
+                .into_stream();
+            (upstream, Following::Reclaim)
+        }
+        None => {
+            let upstream = module
+                .subscribe_ln_receive(id)
+                .await
+                .map_err(subscribe_error)?
+                .into_stream();
+            (upstream, Following::Original)
+        }
+    };
+    let follow = Follow {
+        upstream,
+        following,
+        phase,
+        done: false,
+        context: ReclaimContext {
+            sdk: federation.sdk.clone(),
+            federation_id: federation.id,
+            db: federation.db(),
+            id,
+            details_json: details_json.to_owned(),
+        },
+    };
+    Ok(Box::pin(stream::unfold(follow, step)))
 }
 
 #[cfg(test)]
@@ -277,6 +495,115 @@ mod tests {
                 map_internal_pay(&upstream, fee(), &LightningRoute::Internal),
                 expected,
                 "{upstream:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn receive_states_fold_onto_the_receive_lifecycle() {
+        use fedimint_ln_client::receive::LightningReceiveError;
+
+        let waiting = UpstreamReceiveState::WaitingForPayment {
+            invoice: String::new(),
+            timeout: core::time::Duration::from_secs(1),
+        };
+        let cases = [
+            (
+                UpstreamReceiveState::Created,
+                false,
+                LnReceiveState::Created,
+            ),
+            (waiting, false, LnReceiveState::WaitingForPayment),
+            (UpstreamReceiveState::Funded, false, LnReceiveState::Funded),
+            (
+                UpstreamReceiveState::AwaitingFunds,
+                true,
+                LnReceiveState::Funded,
+            ),
+            (UpstreamReceiveState::Claimed, true, LnReceiveState::Claimed),
+            (
+                UpstreamReceiveState::Canceled {
+                    reason: LightningReceiveError::Timeout,
+                },
+                true,
+                LnReceiveState::Expired,
+            ),
+            (
+                UpstreamReceiveState::Canceled {
+                    reason: LightningReceiveError::InvalidPreimage,
+                },
+                false,
+                LnReceiveState::Failed,
+            ),
+            (
+                UpstreamReceiveState::Canceled {
+                    reason: LightningReceiveError::Rejected,
+                },
+                false,
+                LnReceiveState::Canceled {
+                    reason: LightningReceiveError::Rejected.to_string(),
+                },
+            ),
+            (
+                UpstreamReceiveState::Canceled {
+                    reason: LightningReceiveError::Rejected,
+                },
+                true,
+                LnReceiveState::Failed,
+            ),
+        ];
+        for (upstream, funded_before, expected) in cases {
+            match map_receive(&upstream, funded_before) {
+                ReceiveStep::State(state) => assert_eq!(state, expected, "{upstream:?}"),
+                ReceiveStep::Reclaim => panic!("{upstream:?} must not ask for a reclaim"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_rejected_claim_asks_for_a_retry_whatever_the_phase() {
+        use fedimint_ln_client::receive::LightningReceiveError;
+
+        for funded_before in [false, true] {
+            let step = map_receive(
+                &UpstreamReceiveState::Canceled {
+                    reason: LightningReceiveError::ClaimRejected,
+                },
+                funded_before,
+            );
+            assert!(matches!(step, ReceiveStep::Reclaim));
+        }
+    }
+
+    #[test]
+    fn a_retried_claim_is_funded_until_it_is_claimed_or_fails() {
+        use fedimint_ln_client::receive::LightningReceiveError;
+
+        assert_eq!(
+            map_reclaim(&UpstreamReceiveState::Created),
+            LnReceiveState::Funded
+        );
+        assert_eq!(
+            map_reclaim(&UpstreamReceiveState::Funded),
+            LnReceiveState::Funded
+        );
+        assert_eq!(
+            map_reclaim(&UpstreamReceiveState::AwaitingFunds),
+            LnReceiveState::Funded
+        );
+        assert_eq!(
+            map_reclaim(&UpstreamReceiveState::Claimed),
+            LnReceiveState::Claimed
+        );
+        for reason in [
+            LightningReceiveError::Rejected,
+            LightningReceiveError::Timeout,
+            LightningReceiveError::ClaimRejected,
+            LightningReceiveError::InvalidPreimage,
+        ] {
+            assert_eq!(
+                map_reclaim(&UpstreamReceiveState::Canceled { reason }),
+                LnReceiveState::Failed
             );
         }
     }

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -354,7 +354,10 @@ pub(super) async fn send(
     // operation's own log entry, is the only place that says what was actually funded, so it
     // corrects the record's fee and total after the fact. A read or a computation that does not
     // come back clean leaves the quoted figures in place: an `Internal` error here would report a
-    // payment that was in fact started as failed, which is worse than an inexact record.
+    // payment that was in fact started as failed, which is worse than an inexact record. The
+    // metadata copy already handed to the module above still keeps the quoted figures, since it
+    // was built before this correction; only this SDK's own record ends up with the corrected
+    // ones.
     if let Some(committed) = committed_contract_amount(federation, id).await
         && let Ok((fee, total)) = committed_fee(quote, committed)
     {
@@ -586,15 +589,21 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
             let invoice = Bolt11Invoice::from_upstream(invoice);
             let invoice_amount = invoice.amount()?;
             // Trusted only when it names this exact invoice: an entry created by something
-            // other than this SDK could carry anything under the same metadata key.
+            // other than this SDK could carry anything under the same metadata key. A copy that
+            // passes that check but whose route does not parse (a gateway id from a build this
+            // one cannot read) is no more trustworthy than no copy at all, so it falls back to
+            // the same upstream-derived estimate as a missing copy.
             let copy = wire::from_custom_meta::<wire::LnSendDetailsWire>(&custom_meta)
-                .filter(|copy| copy.invoice == invoice.to_string());
+                .filter(|copy| copy.invoice == invoice.to_string())
+                .and_then(|copy| {
+                    Some((
+                        Amount::from_msats(copy.fee_msats),
+                        Amount::from_msats(copy.total_msats),
+                        LightningRoute::try_from(copy.route).ok()?,
+                    ))
+                });
             let (fee, total, route) = match copy {
-                Some(copy) => (
-                    Amount::from_msats(copy.fee_msats),
-                    Amount::from_msats(copy.total_msats),
-                    LightningRoute::try_from(copy.route).ok()?,
-                ),
+                Some(values) => values,
                 None => {
                     let total = from_upstream(contract.amount);
                     let fee = total.checked_sub(invoice_amount)?;

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -24,9 +24,9 @@ use super::{
 use crate::federation::FederationInner;
 use crate::operation::{Backfilled, Driver, kinds, record_phase_in};
 use crate::{
-    Amount, Bolt11Invoice, Error, ErrorCode, GatewayId, LightningRoute, LnReceive,
-    LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Operation, Preimage, Result,
-    Timestamp,
+    Amount, Bolt11Invoice, Error, ErrorCode, ErrorDetails, GatewayId, LightningRoute, LnReceive,
+    LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Network, Operation, Preimage,
+    Result, Timestamp,
 };
 
 // lnv2 `SendOperationState` onto `LnSendState`. `Failure` means two things: the funding
@@ -311,7 +311,7 @@ pub(super) async fn send(
             serde_json::Value::Null,
         )
         .await
-        .map_err(|err| send_error(err, quote))?;
+        .map_err(|err| send_error(err, quote, federation.record().network.into()))?;
     let details = crate::LnSendDetails {
         invoice: quote.invoice.clone(),
         invoice_amount: quote.invoice_amount,
@@ -340,7 +340,7 @@ fn select_error(err: SelectGatewayError) -> Error {
     }
 }
 
-fn send_error(err: SendPaymentError, quote: &LnQuoteInner) -> Error {
+fn send_error(err: SendPaymentError, quote: &LnQuoteInner, expected: Network) -> Error {
     match err {
         SendPaymentError::InvoiceMissingAmount => Error::new(
             ErrorCode::AmountlessInvoice,
@@ -360,10 +360,21 @@ fn send_error(err: SendPaymentError, quote: &LnQuoteInner) -> Error {
         SendPaymentError::FailedToFundPayment(cause) => {
             internal(format!("the payment could not be funded: {cause}"))
         }
-        // Unreachable: `preflight` already refused a foreign-network invoice with full details.
-        SendPaymentError::WrongCurrency { .. } => Error::new(
+        // Reachable on a testnet4 federation: lnv2 compares the invoice's currency to the
+        // configured network strictly (`self.cfg.network != invoice.currency().into()`,
+        // fedimint-lnv2-client/src/lib.rs:560-565), but BOLT11 spells testnet3 and testnet4
+        // the same way (`tb`), so a `tb` invoice this SDK's own `check_network` accepts is
+        // still refused by the module. This is an upstream limitation of lnv2 (v1 compares by
+        // currency class instead); the SDK reports it with the same detail `check_network`
+        // would have produced rather than trying to work around it.
+        SendPaymentError::WrongCurrency { .. } => Error::with_details(
             ErrorCode::NetworkMismatch,
-            "the invoice is for another network",
+            "the lnv2 module refused the invoice's network",
+            ErrorDetails::NetworkMismatch {
+                expected,
+                compatible: super::compatible_networks(quote.invoice.network()),
+                observed_prefix: quote.invoice.observed_prefix(),
+            },
         ),
     }
 }
@@ -647,5 +658,54 @@ mod tests {
     fn a_contract_below_the_invoice_amount_is_not_claimed() {
         assert!(backfill(&outgoing_meta(1), 0).is_none());
         assert!(backfill(&serde_json::Value::Null, 0).is_none());
+    }
+
+    fn a_quote() -> LnQuoteInner {
+        LnQuoteInner {
+            federation_id: fedimint_core::config::FederationId::dummy(),
+            invoice: REGTEST_INVOICE.parse().expect("a valid regtest invoice"),
+            invoice_amount: Amount::from_msats(100_000),
+            plan: Plan {
+                breakdown: crate::LnFeeBreakdown {
+                    gateway: Amount::from_msats(0),
+                    lightning_module: Amount::from_msats(0),
+                    primary_module: Amount::from_msats(0),
+                    dust: Amount::from_msats(0),
+                },
+                fee: Amount::from_msats(0),
+                total: Amount::from_msats(100_000),
+                route: route(),
+                terms: Terms::V1 { gateway: None },
+            },
+            expires_at: Timestamp::from_epoch_millis(0),
+        }
+    }
+
+    #[test]
+    fn a_wrong_currency_refusal_on_testnet4_carries_the_regtest_invoices_networks() {
+        use fedimint_ln_common::lightning_invoice::Currency;
+
+        let quote = a_quote();
+        let err = send_error(
+            SendPaymentError::WrongCurrency {
+                invoice_currency: Currency::BitcoinTestnet,
+                federation_currency: Currency::BitcoinTestnet,
+            },
+            &quote,
+            Network::Testnet4,
+        );
+        assert_eq!(err.code, ErrorCode::NetworkMismatch);
+        match err.detail() {
+            Some(ErrorDetails::NetworkMismatch {
+                expected,
+                compatible,
+                observed_prefix,
+            }) => {
+                assert_eq!(*expected, Network::Testnet4);
+                assert_eq!(compatible, &vec![Network::Regtest]);
+                assert_eq!(observed_prefix, "bcrt");
+            }
+            other => panic!("expected NetworkMismatch details, got {other:?}"),
+        }
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -328,14 +328,6 @@ pub(super) async fn send(
     if current != (send_fee, expiration_delta) || fresh.total != quote.plan.total {
         return Err(quote_changed(quote.plan.total, fresh.total));
     }
-    let id = module
-        .send(
-            quote.invoice.inner().clone(),
-            Some(gateway),
-            serde_json::Value::Null,
-        )
-        .await
-        .map_err(|err| send_error(err, quote, federation.record().network.into()))?;
     let details = crate::LnSendDetails {
         invoice: quote.invoice.clone(),
         invoice_amount: quote.invoice_amount,
@@ -344,6 +336,17 @@ pub(super) async fn send(
         route: quote.plan.route.clone(),
         created_at: now(),
     };
+    // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
+    // between upstream's commit and the SDK's write (`federation.create_operation` below) has
+    // the exact quoted terms, not just the contract amount the log entry gives on its own.
+    let id = module
+        .send(
+            quote.invoice.inner().clone(),
+            Some(gateway),
+            wire::custom_meta(&wire::LnSendDetailsWire::from(&details))?,
+        )
+        .await
+        .map_err(|err| send_error(err, quote, federation.record().network.into()))?;
     federation
         .create_operation(
             id,
@@ -441,13 +444,30 @@ pub(super) async fn receive(
             "the amount does not cover the receive-side fee",
         )
     })?;
+    // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
+    // between upstream's commit and the SDK's write (`federation.create_operation` below) has
+    // the exact quoted terms, not just the gateway's share of the fee the log entry gives on its
+    // own. The invoice is not known until the call returns, so the copy carries a placeholder
+    // for it and `expires_at`; the backfiller takes both from upstream's own meta instead.
+    let created_at = now();
     let (invoice, id) = module
         .receive(
             to_upstream(amount),
             INVOICE_EXPIRY_SECS,
             Bolt11InvoiceDescription::Direct(description.to_owned()),
             Some(gateway),
-            serde_json::Value::Null,
+            wire::custom_meta(&wire::LnReceiveDetailsWire {
+                invoice: String::new(),
+                description: description.to_owned(),
+                requested_amount_msats: amount.msats(),
+                invoice_amount_msats: amount.msats(),
+                fee_msats: fee.msats(),
+                net_credit_msats: net_credit.msats(),
+                gateway_id: Some(GatewayId::from_upstream(routing.module_public_key).to_string()),
+                expires_at: 0,
+                created_at: created_at.epoch_millis(),
+                reclaim_operation_id: None,
+            })?,
         )
         .await
         .map_err(receive_error)?;
@@ -461,7 +481,7 @@ pub(super) async fn receive(
         net_credit,
         gateway_id: Some(GatewayId::from_upstream(routing.module_public_key)),
         expires_at: invoice.expires_at(),
-        created_at: now(),
+        created_at,
     };
     let operation = federation
         .create_operation(
@@ -492,9 +512,10 @@ fn receive_error(err: ReceiveError) -> Error {
     }
 }
 
-/// Rebuilds a record from an lnv2 log entry. The contract carries the gateway's key and the
-/// gateway's fee (the contract amount less the invoice amount) but not the federation's, so a
-/// rebuilt send's total is a floor and a rebuilt receive's fee is the gateway's share only.
+/// Rebuilds a record from an lnv2 log entry: exact for an operation this SDK created, whose
+/// custom metadata carries the quoted terms verbatim; an estimate — the contract's own amount
+/// only, a send's total a floor and a receive's fee the gateway's share only — for an entry the
+/// log holds that this SDK did not create.
 pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Backfilled> {
     let meta: LightningOperationMeta = serde_json::from_value(meta.clone()).ok()?;
     let created_at = Timestamp::from_epoch_millis(created_at);
@@ -502,20 +523,36 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
         LightningOperationMeta::Send(SendOperationMeta {
             contract,
             invoice: LightningInvoice::Bolt11(invoice),
+            custom_meta,
             ..
         }) => {
             let invoice = Bolt11Invoice::from_upstream(invoice);
             let invoice_amount = invoice.amount()?;
-            let total = from_upstream(contract.amount);
-            let fee = total.checked_sub(invoice_amount)?;
+            // Trusted only when it names this exact invoice: an entry created by something
+            // other than this SDK could carry anything under the same metadata key.
+            let copy = wire::from_custom_meta::<wire::LnSendDetailsWire>(&custom_meta)
+                .filter(|copy| copy.invoice == invoice.to_string());
+            let (fee, total, route) = match copy {
+                Some(copy) => (
+                    Amount::from_msats(copy.fee_msats),
+                    Amount::from_msats(copy.total_msats),
+                    LightningRoute::try_from(copy.route).ok()?,
+                ),
+                None => {
+                    let total = from_upstream(contract.amount);
+                    let fee = total.checked_sub(invoice_amount)?;
+                    let route = LightningRoute::Gateway {
+                        gateway_id: GatewayId::from_upstream(contract.claim_pk),
+                    };
+                    (fee, total, route)
+                }
+            };
             let details = crate::LnSendDetails {
                 invoice,
                 invoice_amount,
                 fee,
                 total,
-                route: LightningRoute::Gateway {
-                    gateway_id: GatewayId::from_upstream(contract.claim_pk),
-                },
+                route,
                 created_at,
             };
             Some(Backfilled {
@@ -528,18 +565,31 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
             let LightningInvoice::Bolt11(invoice) = meta.invoice;
             let invoice = Bolt11Invoice::from_upstream(invoice);
             let amount = invoice.amount()?;
-            let net_credit = from_upstream(meta.contract.commitment.amount);
-            let fee = amount.checked_sub(net_credit)?;
+            let copy = wire::from_custom_meta::<wire::LnReceiveDetailsWire>(&meta.custom_meta);
+            let (description, requested_amount, fee, net_credit, created_at) = match &copy {
+                Some(copy) => (
+                    copy.description.clone(),
+                    Amount::from_msats(copy.requested_amount_msats),
+                    Amount::from_msats(copy.fee_msats),
+                    Amount::from_msats(copy.net_credit_msats),
+                    Timestamp::from_epoch_millis(copy.created_at),
+                ),
+                None => {
+                    let net_credit = from_upstream(meta.contract.commitment.amount);
+                    let fee = amount.checked_sub(net_credit)?;
+                    (invoice.description(), amount, fee, net_credit, created_at)
+                }
+            };
             let details = LnReceiveDetails {
-                description: invoice.description(),
-                requested_amount: amount,
+                invoice: invoice.clone(),
+                description,
+                requested_amount,
                 invoice_amount: amount,
                 fee,
                 net_credit,
                 gateway_id: Some(GatewayId::from_upstream(meta.contract.commitment.refund_pk)),
                 expires_at: invoice.expires_at(),
                 created_at,
-                invoice,
             };
             Some(Backfilled {
                 kind: kinds::LN_RECEIVE,
@@ -640,7 +690,7 @@ mod tests {
     const GATEWAY_ID: &str = "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
     const REGTEST_INVOICE: &str = "lnbcrt1u1pj48ugqdq2vdhkven9v5pp5g3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqsp5242424242424242424242424242424242424242424242424242s9qrsgqcqzys2reg4wsryjt5w8z33ugydecgfmgyvtttwa7e0yzlm803z203j9hqspa4lr6m09cd808xkw9uh4sxc8wf3w6k0gaf5zrqm7zhcxug0vqqpdkpja";
 
-    fn outgoing_meta(contract_msats: u64) -> serde_json::Value {
+    fn outgoing_meta(contract_msats: u64, custom_meta: serde_json::Value) -> serde_json::Value {
         // `all_zeros` is the `bitcoin::hashes::Hash` trait's; `TransactionId` is a hash newtype.
         use fedimint_core::bitcoin::hashes::Hash;
         use fedimint_lnv2_common::contracts::{OutgoingContract, PaymentImage};
@@ -665,14 +715,48 @@ mod tests {
             gateway: SafeUrl::parse("http://127.0.0.1:1/").expect("a url"),
             contract,
             invoice: fedimint_lnv2_common::LightningInvoice::Bolt11(invoice),
-            custom_meta: serde_json::Value::Null,
+            custom_meta,
         }))
         .expect("serialises")
     }
 
+    /// A v2 receive log entry, `commitment.amount` set to `net_credit_msats` and `refund_pk` to
+    /// `GATEWAY_ID`. The payment image and ciphertext are opaque to `backfill` (nothing here
+    /// ever checks or decrypts them), so they are fixed, syntactically valid values rather than
+    /// a fresh encryption.
+    fn incoming_meta(net_credit_msats: u64, custom_meta: serde_json::Value) -> serde_json::Value {
+        const PAYMENT_HASH: &str =
+            "107661134f21fc7c02223d50ab9eb3600bc3ffc3712423a1e47bb1f9a9dbf55f";
+        const CIPHERTEXT_PK: &str = "b2d3ced866057f6caf291f81630301571816663a5189aab23d06d0a1140e86f12232b0c2200513f942db0978a50f09d3";
+        const CIPHERTEXT_SIGNATURE: &str = "abcc29588c6342a99d036733ae838445eb78154452a6eea4492f63a5f512182a2ac9840f779b696b19117a204149216d0e58ad3a0f3d01f404bd0697c27c8aa7aee02a84de30c9f9d90e2eb714f5922efb2768f18a31961108a757afc88089ed";
+        serde_json::json!({
+            "Receive": {
+                "gateway": "http://127.0.0.1:1/",
+                "contract": {
+                    "commitment": {
+                        "payment_image": { "Hash": PAYMENT_HASH },
+                        "amount": net_credit_msats,
+                        "expiration": 2_000_000_000u64,
+                        "claim_pk": GATEWAY_ID,
+                        "refund_pk": GATEWAY_ID,
+                        "ephemeral_pk": GATEWAY_ID,
+                    },
+                    "ciphertext": {
+                        "encrypted_preimage": vec![0u8; 32],
+                        "pk": CIPHERTEXT_PK,
+                        "signature": CIPHERTEXT_SIGNATURE,
+                    },
+                },
+                "invoice": { "Bolt11": REGTEST_INVOICE },
+                "custom_meta": custom_meta,
+            }
+        })
+    }
+
     #[test]
     fn a_send_log_entry_backfills_a_send_record() {
-        let claimed = backfill(&outgoing_meta(101_000), 9).expect("claimed");
+        let claimed =
+            backfill(&outgoing_meta(101_000, serde_json::Value::Null), 9).expect("claimed");
         assert_eq!(claimed.kind, crate::operation::kinds::LN_SEND);
         let details = wire::decode_send_details(&claimed.details).expect("decodes");
         assert_eq!(details.invoice_amount, Amount::from_msats(100_000));
@@ -684,8 +768,55 @@ mod tests {
 
     #[test]
     fn a_contract_below_the_invoice_amount_is_not_claimed() {
-        assert!(backfill(&outgoing_meta(1), 0).is_none());
+        assert!(backfill(&outgoing_meta(1, serde_json::Value::Null), 0).is_none());
         assert!(backfill(&serde_json::Value::Null, 0).is_none());
+    }
+
+    #[test]
+    fn a_send_log_entry_with_an_sdk_copy_uses_the_copys_fee_and_total() {
+        let copy = wire::LnSendDetailsWire {
+            invoice: REGTEST_INVOICE.to_owned(),
+            invoice_amount_msats: 100_000,
+            fee_msats: 1_500,
+            total_msats: 101_500,
+            route: wire::RouteWire::Gateway {
+                gateway_id: GATEWAY_ID.to_owned(),
+            },
+            created_at: 1_650_000_000_000,
+        };
+        let meta = outgoing_meta(101_000, wire::custom_meta(&copy).expect("encode"));
+        let claimed = backfill(&meta, 9).expect("claimed");
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        // The copy's figures, not the contract-derived estimate (1_000 / 101_000) the log entry
+        // alone would give.
+        assert_eq!(details.fee, Amount::from_msats(1_500));
+        assert_eq!(details.total, Amount::from_msats(101_500));
+    }
+
+    #[test]
+    fn a_receive_log_entry_with_an_sdk_copy_uses_the_copys_fee_and_net_credit() {
+        let copy = wire::LnReceiveDetailsWire {
+            invoice: String::new(),
+            description: "coffee".to_owned(),
+            requested_amount_msats: 100_000,
+            invoice_amount_msats: 100_000,
+            fee_msats: 750,
+            net_credit_msats: 99_250,
+            gateway_id: None,
+            expires_at: 0,
+            created_at: 1_650_000_000_000,
+            reclaim_operation_id: None,
+        };
+        let meta = incoming_meta(99_500, wire::custom_meta(&copy).expect("encode"));
+        let claimed = backfill(&meta, 9).expect("claimed");
+        let details = wire::decode_receive_details(&claimed.details).expect("decodes");
+        // The copy's figures, not the contract-derived estimate (fee 500, net credit 99_500)
+        // the log entry alone would give.
+        assert_eq!(details.fee, Amount::from_msats(750));
+        assert_eq!(details.net_credit, Amount::from_msats(99_250));
+        assert_eq!(details.description, "coffee");
+        // The gateway id still comes from upstream's own meta, not the copy's placeholder.
+        assert_eq!(details.gateway_id, Some(GATEWAY_ID.parse().expect("id")));
     }
 
     fn a_quote() -> LnQuoteInner {

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -328,7 +328,7 @@ pub(super) async fn send(
     if current != (send_fee, expiration_delta) || fresh.total != quote.plan.total {
         return Err(quote_changed(quote.plan.total, fresh.total));
     }
-    let details = crate::LnSendDetails {
+    let mut details = crate::LnSendDetails {
         invoice: quote.invoice.clone(),
         invoice_amount: quote.invoice_amount,
         fee: quote.plan.fee,
@@ -347,6 +347,20 @@ pub(super) async fn send(
         )
         .await
         .map_err(|err| send_error(err, quote, federation.record().network.into()))?;
+    // Upstream re-derives the gateway's terms itself inside `send` and funds the contract at
+    // whatever it reads there; nothing binds that read to the `routing_info` re-check above, so a
+    // gateway that changes its fee in the instant between the two funds a different contract than
+    // the one this record is about to describe. The committed contract, read back from the
+    // operation's own log entry, is the only place that says what was actually funded, so it
+    // corrects the record's fee and total after the fact. A read or a computation that does not
+    // come back clean leaves the quoted figures in place: an `Internal` error here would report a
+    // payment that was in fact started as failed, which is worse than an inexact record.
+    if let Some(committed) = committed_contract_amount(federation, id).await
+        && let Ok((fee, total)) = committed_fee(quote, committed)
+    {
+        details.fee = fee;
+        details.total = total;
+    }
     federation
         .create_operation(
             id,
@@ -356,6 +370,49 @@ pub(super) async fn send(
             Arc::new(LnSendDriver) as Arc<dyn Driver<LnSendState>>,
         )
         .await
+}
+
+/// The amount of the contract upstream actually funded for `id`'s send, read back from the
+/// operation's own log entry. `None` when the entry is not there, or its meta does not decode as
+/// an `lnv2` send: both are read failures the caller treats as "unknown", never as proof that
+/// nothing was funded.
+async fn committed_contract_amount(
+    federation: &FederationInner,
+    id: OperationId,
+) -> Option<Amount> {
+    let entry = fedimint_client::oplog::OperationLog::new(federation.db())
+        .get_operation(id)
+        .await?;
+    let LightningOperationMeta::Send(SendOperationMeta { contract, .. }) =
+        entry.try_meta::<LightningOperationMeta>().ok()?
+    else {
+        return None;
+    };
+    Some(from_upstream(contract.amount))
+}
+
+/// The fee and total to record for a send once the contract upstream actually committed is
+/// known. Equal to what the quote itself would have funded (`invoice_amount` plus the quoted
+/// gateway fee), the quote's own figures come back unchanged. Otherwise the difference between
+/// the committed and the quoted gateway fee is folded into both: `fee` moves by exactly that much
+/// and `total` follows it, since `total` is always `invoice_amount` plus `fee`. Errors only if
+/// `committed_contract` funds less than the invoice amount, which upstream never actually does;
+/// the caller keeps the quoted figures rather than surface that as a payment failure.
+fn committed_fee(quote: &LnQuoteInner, committed_contract: Amount) -> Result<(Amount, Amount)> {
+    let quoted_contract = add(quote.invoice_amount, quote.plan.breakdown.gateway)?;
+    if committed_contract == quoted_contract {
+        return Ok((quote.plan.fee, quote.plan.total));
+    }
+    let committed_gateway_fee = committed_contract
+        .checked_sub(quote.invoice_amount)
+        .ok_or_else(|| internal("the committed contract funds less than the invoice amount"))?;
+    let fee = quote
+        .plan
+        .fee
+        .checked_sub(quote.plan.breakdown.gateway)
+        .and_then(|fee| fee.checked_add(committed_gateway_fee))
+        .ok_or_else(|| internal("an amount overflowed"))?;
+    Ok((fee, add(quote.invoice_amount, fee)?))
 }
 
 fn select_error(err: SelectGatewayError) -> Error {
@@ -866,5 +923,53 @@ mod tests {
             }
             other => panic!("expected NetworkMismatch details, got {other:?}"),
         }
+    }
+
+    /// A quote with a nonzero gateway fee, so `committed_fee`'s folding of the difference
+    /// between the quoted and the committed gateway fee is actually exercised rather than
+    /// collapsing on a zero.
+    fn quote_with_gateway_fee(gateway_fee_msats: u64) -> LnQuoteInner {
+        let mut quote = a_quote();
+        quote.plan.breakdown.gateway = Amount::from_msats(gateway_fee_msats);
+        quote.plan.breakdown.lightning_module = Amount::from_msats(50);
+        quote.plan.fee = Amount::from_msats(gateway_fee_msats + 50);
+        quote.plan.total =
+            Amount::from_msats(quote.invoice_amount.msats() + gateway_fee_msats + 50);
+        quote
+    }
+
+    #[test]
+    fn committed_fee_keeps_the_quoted_figures_when_the_contract_matches_the_quote() {
+        let quote = quote_with_gateway_fee(1_000);
+        let committed = Amount::from_msats(101_000); // invoice (100_000) + quoted gateway fee.
+        let (fee, total) = committed_fee(&quote, committed).expect("committed fee");
+        assert_eq!(fee, quote.plan.fee);
+        assert_eq!(total, quote.plan.total);
+    }
+
+    #[test]
+    fn committed_fee_raises_both_by_the_gateways_increase() {
+        let quote = quote_with_gateway_fee(1_000);
+        let committed = Amount::from_msats(102_000); // gateway actually took 2_000, not 1_000.
+        let (fee, total) = committed_fee(&quote, committed).expect("committed fee");
+        assert_eq!(fee, Amount::from_msats(2_050));
+        assert_eq!(total, Amount::from_msats(102_050));
+    }
+
+    #[test]
+    fn committed_fee_lowers_both_by_the_gateways_decrease() {
+        let quote = quote_with_gateway_fee(1_000);
+        let committed = Amount::from_msats(100_500); // gateway actually took 500, not 1_000.
+        let (fee, total) = committed_fee(&quote, committed).expect("committed fee");
+        assert_eq!(fee, Amount::from_msats(550));
+        assert_eq!(total, Amount::from_msats(100_550));
+    }
+
+    #[test]
+    fn committed_fee_refuses_a_contract_below_the_invoice_amount() {
+        let quote = quote_with_gateway_fee(1_000);
+        let committed = Amount::from_msats(99_000); // less than the invoice's own 100_000.
+        let err = committed_fee(&quote, committed).expect_err("below the invoice amount");
+        assert_eq!(err.code, ErrorCode::Internal);
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -167,6 +167,14 @@ pub(super) async fn subscribe_receive(
     Ok(until_final(stream))
 }
 
+/// Rebuilds a record from the module's log entry; filled in with the facade operations.
+pub(super) fn backfill(
+    _meta: &serde_json::Value,
+    _created_at: u64,
+) -> Option<crate::operation::Backfilled> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -300,7 +300,11 @@ pub(super) async fn send(
     // re-quoted below: the balance can drop between a quote and this call, and it must be asked
     // whether the invoice was already paid before it is asked whether the balance still covers
     // it, or a second quote for an already-paid invoice is misreported as a shortfall instead of
-    // the truth.
+    // the truth. Upstream's `send_with_terms` below binds the gateway's terms, but the funding
+    // notes are still selected inside it: the mint's fees and the dust the re-quote computes are
+    // therefore only the figures for the balance at this moment, and a wallet whose notes change
+    // in the same instant can still fund at a different figure. That remainder is tracked as
+    // fedimint/fedimint#9124.
     let available = balance_of(client).await?;
     if available < quote.plan.total {
         return Err(insufficient(quote.plan.total, available));
@@ -873,6 +877,7 @@ mod tests {
                 gateway_id: GATEWAY_ID.to_owned(),
             },
             created_at: 1_650_000_000_000,
+            gateway_fee_msats: None,
         };
         let meta = outgoing_meta(101_000, wire::custom_meta(&copy).expect("encode"));
         let claimed = backfill(&meta, 9).expect("claimed");

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -18,13 +18,13 @@ use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
 use super::{
     INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, balance_of, fee_quote_failure,
-    from_upstream, gateway_unavailable, insufficient, internal, now, plan_of, quote_changed,
-    quote_expired, subscribe_error, to_upstream, unreachable,
+    from_upstream, gateway_unavailable, insufficient, internal, network_refusal, now, plan_of,
+    quote_changed, quote_expired, subscribe_error, to_upstream, unreachable,
 };
 use crate::federation::FederationInner;
 use crate::operation::{Backfilled, Driver, kinds, record_phase_in};
 use crate::{
-    Amount, Bolt11Invoice, Error, ErrorCode, ErrorDetails, GatewayId, LightningRoute, LnReceive,
+    Amount, Bolt11Invoice, Error, ErrorCode, GatewayId, LightningRoute, LnReceive,
     LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Network, Operation, Preimage,
     Result, Timestamp,
 };
@@ -393,18 +393,13 @@ fn send_error(err: SendPaymentError, quote: &LnQuoteInner, expected: Network) ->
         // configured network strictly (`self.cfg.network != invoice.currency().into()`,
         // fedimint-lnv2-client/src/lib.rs:560-565), but BOLT11 spells testnet3 and testnet4
         // the same way (`tb`), so a `tb` invoice this SDK's own `check_network` accepts is
-        // still refused by the module. This is an upstream limitation of lnv2 (v1 compares by
-        // currency class instead); the SDK reports it with the same detail `check_network`
-        // would have produced rather than trying to work around it.
-        SendPaymentError::WrongCurrency { .. } => Error::with_details(
-            ErrorCode::NetworkMismatch,
-            "the lnv2 module refused the invoice's network",
-            ErrorDetails::NetworkMismatch {
-                expected,
-                compatible: super::compatible_networks(quote.invoice.network()),
-                observed_prefix: quote.invoice.observed_prefix(),
-            },
-        ),
+        // still refused by the module. Both generations are affected, not lnv2 alone: v1
+        // converts the configured network through lightning-invoice's
+        // `From<bitcoin::Network> for Currency` (lightning-invoice-0.33.3/src/lib.rs:451-463),
+        // which has no `Testnet4` arm either. Tracked upstream as fedimint/fedimint#9100; the
+        // SDK reports this with the same detail `check_network` would have produced, rather
+        // than trying to work around it.
+        SendPaymentError::WrongCurrency { .. } => network_refusal(quote, expected),
     }
 }
 
@@ -560,7 +555,7 @@ pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Back
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Amount;
+    use crate::{Amount, ErrorDetails};
 
     fn fee() -> Amount {
         Amount::from_msats(1_050)

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -1,0 +1,181 @@
+//! The lnv2 lightning module: mappings, subscriptions, and the facade operations.
+
+use fedimint_client::Client;
+use fedimint_client_module::ClientModuleInstance;
+use fedimint_core::core::OperationId;
+use fedimint_core::util::BoxStream;
+use fedimint_lnv2_client::{LightningClientModule, SendOperationState};
+use futures::StreamExt;
+
+use super::driver::until_final;
+use super::subscribe_error;
+use super::wire::PHASE_FUNDED;
+use crate::federation::FederationInner;
+use crate::operation::record_phase_in;
+use crate::{
+    Amount, Error, ErrorCode, LightningRoute, LnSendDetails, LnSendState, Preimage, Result,
+};
+
+// lnv2 `SendOperationState` onto `LnSendState`. `Failure` means two things: the funding
+// transaction was refused (before `Funded`, nothing debited, so `Refunded`) or the refund of a
+// funded contract failed (after it, so `Failed`). After a restart the persisted phase is what
+// tells them apart. `Refunding` is in progress, not final.
+//
+// | upstream        | phase reached   | here       |
+// | --------------- | --------------- | ---------- |
+// | `Funding`       | any             | `Created`  |
+// | `Funded`        | any             | `Funded`   |
+// | `Refunding`     | any             | `Funded`   |
+// | `Success`       | any             | `Success`  |
+// | `Refunded`      | any             | `Refunded` |
+// | `Failure`       | before `Funded` | `Refunded` |
+// | `Failure`       | at/after        | `Failed`   |
+pub(super) fn map_send(
+    state: &SendOperationState,
+    funded_before: bool,
+    fee: Amount,
+    route: &LightningRoute,
+) -> LnSendState {
+    match state {
+        SendOperationState::Funding => LnSendState::Created,
+        SendOperationState::Funded | SendOperationState::Refunding => LnSendState::Funded,
+        SendOperationState::Success(preimage) => LnSendState::Success {
+            preimage: Preimage::from_bytes(*preimage),
+            fee,
+            route: route.clone(),
+        },
+        SendOperationState::Refunded => LnSendState::Refunded,
+        SendOperationState::Failure if funded_before => LnSendState::Failed {
+            reason: "the payment's contract could not be refunded".to_owned(),
+        },
+        SendOperationState::Failure => LnSendState::Refunded,
+    }
+}
+
+/// The phase an upstream state proves was reached.
+pub(super) fn send_phase(state: &SendOperationState) -> u32 {
+    match state {
+        SendOperationState::Funded
+        | SendOperationState::Refunding
+        | SendOperationState::Success(_)
+        | SendOperationState::Refunded => PHASE_FUNDED,
+        SendOperationState::Funding | SendOperationState::Failure => 0,
+    }
+}
+
+/// The lnv2 module on a live client, or `NotSupported` when the federation dropped it.
+pub(super) fn module_of(
+    client: &Client,
+) -> Result<ClientModuleInstance<'_, LightningClientModule>> {
+    client
+        .get_first_module::<LightningClientModule>()
+        .map_err(|_| {
+            Error::new(
+                ErrorCode::NotSupported,
+                "this federation no longer has an lnv2 lightning module",
+            )
+        })
+}
+
+/// A fresh stream over an lnv2 send, persisting the funded phase the moment it is seen.
+pub(super) async fn subscribe_send(
+    federation: &FederationInner,
+    id: OperationId,
+    phase: u32,
+    details: &LnSendDetails,
+) -> Result<BoxStream<'static, Result<LnSendState>>> {
+    let client = federation.client(false).await?;
+    let module = module_of(&client)?;
+    let upstream = module
+        .subscribe_send_operation_state_updates(id)
+        .await
+        .map_err(subscribe_error)?
+        .into_stream();
+    let db = federation.db();
+    let fee = details.fee;
+    let route = details.route.clone();
+    let stream = upstream.scan((phase, db), move |(phase, db), state| {
+        let reached = send_phase(&state);
+        let advance = reached > *phase;
+        if advance {
+            *phase = reached;
+        }
+        let mapped = map_send(&state, *phase >= PHASE_FUNDED, fee, &route);
+        let db = db.clone();
+        async move {
+            if advance && let Err(err) = record_phase_in(&db, id, reached).await {
+                return Some(Err(err));
+            }
+            Some(Ok(mapped))
+        }
+    });
+    Ok(until_final(stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Amount;
+
+    fn fee() -> Amount {
+        Amount::from_msats(1_050)
+    }
+
+    fn route() -> LightningRoute {
+        LightningRoute::Gateway {
+            gateway_id: "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166"
+                .parse()
+                .expect("a gateway id"),
+        }
+    }
+
+    #[test]
+    fn send_states_fold_onto_the_send_lifecycle() {
+        let cases = [
+            (SendOperationState::Funding, false, LnSendState::Created),
+            (SendOperationState::Funded, true, LnSendState::Funded),
+            (SendOperationState::Refunding, true, LnSendState::Funded),
+            (SendOperationState::Refunded, true, LnSendState::Refunded),
+            (
+                SendOperationState::Success([0x33; 32]),
+                true,
+                LnSendState::Success {
+                    preimage: Preimage::from_bytes([0x33; 32]),
+                    fee: fee(),
+                    route: route(),
+                },
+            ),
+        ];
+        for (upstream, funded_before, expected) in cases {
+            assert_eq!(
+                map_send(&upstream, funded_before, fee(), &route()),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn a_failure_before_funding_is_a_refund_and_after_it_is_a_failure() {
+        assert_eq!(
+            map_send(&SendOperationState::Failure, false, fee(), &route()),
+            LnSendState::Refunded
+        );
+        assert!(matches!(
+            map_send(&SendOperationState::Failure, true, fee(), &route()),
+            LnSendState::Failed { .. }
+        ));
+    }
+
+    #[test]
+    fn only_funding_advances_the_phase() {
+        assert_eq!(send_phase(&SendOperationState::Funding), 0);
+        assert_eq!(send_phase(&SendOperationState::Funded), PHASE_FUNDED);
+        assert_eq!(send_phase(&SendOperationState::Refunding), PHASE_FUNDED);
+        assert_eq!(
+            send_phase(&SendOperationState::Success([0; 32])),
+            PHASE_FUNDED
+        );
+        assert_eq!(send_phase(&SendOperationState::Refunded), PHASE_FUNDED);
+        assert_eq!(send_phase(&SendOperationState::Failure), 0);
+    }
+}

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -8,7 +8,8 @@ use fedimint_core::core::OperationId;
 use fedimint_core::util::{BoxStream, SafeUrl};
 use fedimint_lnv2_client::{
     LightningClientModule, LightningOperationMeta, ReceiveError, ReceiveOperationState,
-    SelectGatewayError, SendOperationMeta, SendOperationState, SendPaymentError,
+    ReceiveWithTermsError, SelectGatewayError, SendOperationMeta, SendOperationState,
+    SendPaymentError, SendWithTermsError,
 };
 use fedimint_lnv2_common::gateway_api::{PaymentFee, RoutingInfo};
 use fedimint_lnv2_common::{Bolt11InvoiceDescription, LightningInvoice};
@@ -328,7 +329,7 @@ pub(super) async fn send(
     if current != (send_fee, expiration_delta) || fresh.total != quote.plan.total {
         return Err(quote_changed(quote.plan.total, fresh.total));
     }
-    let mut details = crate::LnSendDetails {
+    let details = crate::LnSendDetails {
         invoice: quote.invoice.clone(),
         invoice_amount: quote.invoice_amount,
         fee: quote.plan.fee,
@@ -339,32 +340,45 @@ pub(super) async fn send(
     // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
     // between upstream's commit and the SDK's write (`federation.create_operation` below) has
     // the exact quoted terms, not just the contract amount the log entry gives on its own.
-    let id = module
-        .send(
+    let id = match module
+        .send_with_terms(
             quote.invoice.inner().clone(),
-            Some(gateway),
+            gateway.clone(),
+            send_fee,
+            expiration_delta,
             wire::custom_meta(&wire::LnSendDetailsWire::from(&details))?,
         )
         .await
-        .map_err(|err| send_error(err, quote, federation.record().network.into()))?;
-    // Upstream re-derives the gateway's terms itself inside `send` and funds the contract at
-    // whatever it reads there; nothing binds that read to the `routing_info` re-check above, so a
-    // gateway that changes its fee in the instant between the two funds a different contract than
-    // the one this record is about to describe (an API that takes the checked terms is requested
-    // as fedimint/fedimint#9124). The committed contract, read back from the
-    // operation's own log entry, is the only place that says what was actually funded, so it
-    // corrects the record's fee and total after the fact. A read or a computation that does not
-    // come back clean leaves the quoted figures in place: an `Internal` error here would report a
-    // payment that was in fact started as failed, which is worse than an inexact record. The
-    // metadata copy already handed to the module above still keeps the quoted figures, since it
-    // was built before this correction; only this SDK's own record ends up with the corrected
-    // ones.
-    if let Some(committed) = committed_contract_amount(federation, id).await
-        && let Ok((fee, total)) = committed_fee(quote, committed)
     {
-        details.fee = fee;
-        details.total = total;
-    }
+        Ok(id) => id,
+        Err(SendWithTermsError::Send(inner)) => {
+            return Err(send_error(inner, quote, federation.record().network.into()));
+        }
+        // Upstream re-checked the gateway's terms itself, right before funding, and found them
+        // different from the ones just passed: the same drift the `routing_info` re-check above
+        // guards against, just caught a moment later. Reported the same way, at the terms
+        // upstream says are current now.
+        Err(SendWithTermsError::TermsChanged {
+            send_fee,
+            expiration_delta,
+        }) => {
+            let actual = terms_for(
+                client,
+                module,
+                quote.invoice_amount,
+                gateway.clone(),
+                &routing,
+                send_fee,
+                expiration_delta,
+            )
+            .await?;
+            return Err(quote_changed(quote.plan.total, actual.total));
+        }
+        // `SendWithTermsError` is `#[non_exhaustive]`; a variant added upstream after this was
+        // written carries no case this SDK can act on, so it is reported as unexpected rather
+        // than silently folded into one of the arms above.
+        Err(other) => return Err(internal(other)),
+    };
     federation
         .create_operation(
             id,
@@ -374,49 +388,6 @@ pub(super) async fn send(
             Arc::new(LnSendDriver) as Arc<dyn Driver<LnSendState>>,
         )
         .await
-}
-
-/// The amount of the contract upstream actually funded for `id`'s send, read back from the
-/// operation's own log entry. `None` when the entry is not there, or its meta does not decode as
-/// an `lnv2` send: both are read failures the caller treats as "unknown", never as proof that
-/// nothing was funded.
-async fn committed_contract_amount(
-    federation: &FederationInner,
-    id: OperationId,
-) -> Option<Amount> {
-    let entry = fedimint_client::oplog::OperationLog::new(federation.db())
-        .get_operation(id)
-        .await?;
-    let LightningOperationMeta::Send(SendOperationMeta { contract, .. }) =
-        entry.try_meta::<LightningOperationMeta>().ok()?
-    else {
-        return None;
-    };
-    Some(from_upstream(contract.amount))
-}
-
-/// The fee and total to record for a send once the contract upstream actually committed is
-/// known. Equal to what the quote itself would have funded (`invoice_amount` plus the quoted
-/// gateway fee), the quote's own figures come back unchanged. Otherwise the difference between
-/// the committed and the quoted gateway fee is folded into both: `fee` moves by exactly that much
-/// and `total` follows it, since `total` is always `invoice_amount` plus `fee`. Errors only if
-/// `committed_contract` funds less than the invoice amount, which upstream never actually does;
-/// the caller keeps the quoted figures rather than surface that as a payment failure.
-fn committed_fee(quote: &LnQuoteInner, committed_contract: Amount) -> Result<(Amount, Amount)> {
-    let quoted_contract = add(quote.invoice_amount, quote.plan.breakdown.gateway)?;
-    if committed_contract == quoted_contract {
-        return Ok((quote.plan.fee, quote.plan.total));
-    }
-    let committed_gateway_fee = committed_contract
-        .checked_sub(quote.invoice_amount)
-        .ok_or_else(|| internal("the committed contract funds less than the invoice amount"))?;
-    let fee = quote
-        .plan
-        .fee
-        .checked_sub(quote.plan.breakdown.gateway)
-        .and_then(|fee| fee.checked_add(committed_gateway_fee))
-        .ok_or_else(|| internal("an amount overflowed"))?;
-    Ok((fee, add(quote.invoice_amount, fee)?))
 }
 
 fn select_error(err: SelectGatewayError) -> Error {
@@ -477,61 +448,60 @@ pub(super) async fn receive(
     description: &str,
 ) -> Result<LnReceive> {
     let (gateway, routing) = module.select_gateway(None).await.map_err(select_error)?;
-    // The contract the gateway funds is the invoice amount less its fee
-    // (`fedimint-lnv2-client/src/lib.rs:1064`); the federation's claim fee comes off that.
-    let contract_amount = from_upstream(routing.receive_fee.subtract_from(amount.msats()));
-    let gateway_fee = amount.checked_sub(contract_amount).ok_or_else(|| {
-        internal("the gateway's fee schedule produced a contract above the amount")
-    })?;
-    let quote = match module.receive_fee_quote(to_upstream(contract_amount)).await {
-        Ok(quote) => quote,
-        Err(err) => {
-            let text = err.to_string();
-            let short = err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>();
-            return Err(fee_quote_failure(
-                client,
-                short,
-                &text,
-                contract_amount,
-                "could not quote the claim fee",
+    let mut receive_fee = routing.receive_fee;
+    let (mut fee, mut net_credit) = receive_terms(client, module, amount, receive_fee).await?;
+    let created_at = now();
+    let mut retried = false;
+    let (invoice, id) = loop {
+        // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
+        // between upstream's commit and the SDK's write (`federation.create_operation` below)
+        // has the exact quoted terms, not just the gateway's share of the fee the log entry
+        // gives on its own. The invoice is not known until the call returns, so the copy
+        // carries a placeholder for it and `expires_at`; the backfiller takes both from
+        // upstream's own meta instead.
+        let copy = wire::custom_meta(&wire::LnReceiveDetailsWire {
+            invoice: String::new(),
+            description: description.to_owned(),
+            requested_amount_msats: amount.msats(),
+            invoice_amount_msats: amount.msats(),
+            fee_msats: fee.msats(),
+            net_credit_msats: net_credit.msats(),
+            gateway_id: Some(GatewayId::from_upstream(routing.module_public_key).to_string()),
+            expires_at: 0,
+            created_at: created_at.epoch_millis(),
+            reclaim_operation_id: None,
+        })?;
+        match module
+            .receive_with_terms(
+                to_upstream(amount),
+                INVOICE_EXPIRY_SECS,
+                Bolt11InvoiceDescription::Direct(description.to_owned()),
+                gateway.clone(),
+                receive_fee,
+                copy,
             )
-            .await);
+            .await
+        {
+            Ok(issued) => break issued,
+            Err(ReceiveWithTermsError::Receive(inner)) => return Err(receive_error(inner)),
+            // One read apart, a changed fee is the gateway moving under us, so one retry at the
+            // fresh fee is fair; a second refusal means the gateway is not usable right now.
+            Err(ReceiveWithTermsError::TermsChanged { receive_fee: fresh }) if !retried => {
+                retried = true;
+                receive_fee = fresh;
+                (fee, net_credit) = receive_terms(client, module, amount, receive_fee).await?;
+            }
+            Err(ReceiveWithTermsError::TermsChanged { .. }) => {
+                return Err(gateway_unavailable(
+                    "the gateway's receive fee keeps changing",
+                ));
+            }
+            // `ReceiveWithTermsError` is `#[non_exhaustive]`; a variant added upstream after
+            // this was written carries no case this SDK can act on, so it is reported as
+            // unexpected rather than silently folded into an arm above.
+            Err(other) => return Err(internal(other)),
         }
     };
-    let fee = add(gateway_fee, from_upstream(quote.total().get_bitcoin()))?;
-    let net_credit = amount.checked_sub(fee).ok_or_else(|| {
-        Error::new(
-            ErrorCode::InvalidInput,
-            "the amount does not cover the receive-side fee",
-        )
-    })?;
-    // Carried inside upstream's own metadata so a record rebuilt from the log after a crash
-    // between upstream's commit and the SDK's write (`federation.create_operation` below) has
-    // the exact quoted terms, not just the gateway's share of the fee the log entry gives on its
-    // own. The invoice is not known until the call returns, so the copy carries a placeholder
-    // for it and `expires_at`; the backfiller takes both from upstream's own meta instead.
-    let created_at = now();
-    let (invoice, id) = module
-        .receive(
-            to_upstream(amount),
-            INVOICE_EXPIRY_SECS,
-            Bolt11InvoiceDescription::Direct(description.to_owned()),
-            Some(gateway),
-            wire::custom_meta(&wire::LnReceiveDetailsWire {
-                invoice: String::new(),
-                description: description.to_owned(),
-                requested_amount_msats: amount.msats(),
-                invoice_amount_msats: amount.msats(),
-                fee_msats: fee.msats(),
-                net_credit_msats: net_credit.msats(),
-                gateway_id: Some(GatewayId::from_upstream(routing.module_public_key).to_string()),
-                expires_at: 0,
-                created_at: created_at.epoch_millis(),
-                reclaim_operation_id: None,
-            })?,
-        )
-        .await
-        .map_err(receive_error)?;
     let invoice = Bolt11Invoice::from_upstream(invoice);
     let details = LnReceiveDetails {
         invoice: invoice.clone(),
@@ -554,6 +524,59 @@ pub(super) async fn receive(
         )
         .await?;
     Ok(LnReceive { invoice, operation })
+}
+
+/// The receive-side fee and what lands from an lnv2 receive of `amount` at `receive_fee`: the
+/// gateway's share plus the federation's claim fee, quoted by the module for the contract the
+/// gateway would fund. Shared by the first attempt and the one retry after the gateway's fee
+/// moved.
+async fn receive_terms(
+    client: &Client,
+    module: &LightningClientModule,
+    amount: Amount,
+    receive_fee: PaymentFee,
+) -> Result<(Amount, Amount)> {
+    let (contract_amount, gateway_fee) = receive_contract_and_gateway_fee(amount, receive_fee)?;
+    let quote = match module.receive_fee_quote(to_upstream(contract_amount)).await {
+        Ok(quote) => quote,
+        Err(err) => {
+            let text = err.to_string();
+            let short = err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>();
+            return Err(fee_quote_failure(
+                client,
+                short,
+                &text,
+                contract_amount,
+                "could not quote the claim fee",
+            )
+            .await);
+        }
+    };
+    let fee = add(gateway_fee, from_upstream(quote.total().get_bitcoin()))?;
+    let net_credit = amount.checked_sub(fee).ok_or_else(|| {
+        Error::new(
+            ErrorCode::InvalidInput,
+            "the amount does not cover the receive-side fee",
+        )
+    })?;
+    Ok((fee, net_credit))
+}
+
+/// The contract amount and gateway fee an lnv2 receive of `amount` would use at `receive_fee`.
+/// The contract the gateway funds is the invoice amount less its fee
+/// (`fedimint-lnv2-client/src/lib.rs:1064`); the federation's own claim fee comes off that
+/// contract separately, once the module quotes it for the returned `contract_amount`. Pure in
+/// `receive_fee` so a retry after the gateway's fee changed shares this step with the first
+/// attempt instead of duplicating it.
+fn receive_contract_and_gateway_fee(
+    amount: Amount,
+    receive_fee: PaymentFee,
+) -> Result<(Amount, Amount)> {
+    let contract_amount = from_upstream(receive_fee.subtract_from(amount.msats()));
+    let gateway_fee = amount.checked_sub(contract_amount).ok_or_else(|| {
+        internal("the gateway's fee schedule produced a contract above the amount")
+    })?;
+    Ok((contract_amount, gateway_fee))
 }
 
 fn receive_error(err: ReceiveError) -> Error {
@@ -935,51 +958,18 @@ mod tests {
         }
     }
 
-    /// A quote with a nonzero gateway fee, so `committed_fee`'s folding of the difference
-    /// between the quoted and the committed gateway fee is actually exercised rather than
-    /// collapsing on a zero.
-    fn quote_with_gateway_fee(gateway_fee_msats: u64) -> LnQuoteInner {
-        let mut quote = a_quote();
-        quote.plan.breakdown.gateway = Amount::from_msats(gateway_fee_msats);
-        quote.plan.breakdown.lightning_module = Amount::from_msats(50);
-        quote.plan.fee = Amount::from_msats(gateway_fee_msats + 50);
-        quote.plan.total =
-            Amount::from_msats(quote.invoice_amount.msats() + gateway_fee_msats + 50);
-        quote
-    }
-
     #[test]
-    fn committed_fee_keeps_the_quoted_figures_when_the_contract_matches_the_quote() {
-        let quote = quote_with_gateway_fee(1_000);
-        let committed = Amount::from_msats(101_000); // invoice (100_000) + quoted gateway fee.
-        let (fee, total) = committed_fee(&quote, committed).expect("committed fee");
-        assert_eq!(fee, quote.plan.fee);
-        assert_eq!(total, quote.plan.total);
-    }
-
-    #[test]
-    fn committed_fee_raises_both_by_the_gateways_increase() {
-        let quote = quote_with_gateway_fee(1_000);
-        let committed = Amount::from_msats(102_000); // gateway actually took 2_000, not 1_000.
-        let (fee, total) = committed_fee(&quote, committed).expect("committed fee");
-        assert_eq!(fee, Amount::from_msats(2_050));
-        assert_eq!(total, Amount::from_msats(102_050));
-    }
-
-    #[test]
-    fn committed_fee_lowers_both_by_the_gateways_decrease() {
-        let quote = quote_with_gateway_fee(1_000);
-        let committed = Amount::from_msats(100_500); // gateway actually took 500, not 1_000.
-        let (fee, total) = committed_fee(&quote, committed).expect("committed fee");
-        assert_eq!(fee, Amount::from_msats(550));
-        assert_eq!(total, Amount::from_msats(100_550));
-    }
-
-    #[test]
-    fn committed_fee_refuses_a_contract_below_the_invoice_amount() {
-        let quote = quote_with_gateway_fee(1_000);
-        let committed = Amount::from_msats(99_000); // less than the invoice's own 100_000.
-        let err = committed_fee(&quote, committed).expect_err("below the invoice amount");
-        assert_eq!(err.code, ErrorCode::Internal);
+    fn receive_contract_and_gateway_fee_takes_the_gateways_cut_off_the_amount() {
+        let receive_fee = PaymentFee {
+            base: fedimint_core::Amount::from_msats(1_000),
+            parts_per_million: 10_000,
+        };
+        let (contract_amount, gateway_fee) =
+            receive_contract_and_gateway_fee(Amount::from_msats(100_000), receive_fee)
+                .expect("a contract amount and gateway fee");
+        // Base 1_000 plus one percent of 100_000 (parts_per_million 10_000): 2_000 msat, taken
+        // off the amount to leave the contract the gateway actually funds.
+        assert_eq!(gateway_fee, Amount::from_msats(2_000));
+        assert_eq!(contract_amount, Amount::from_msats(98_000));
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -1,20 +1,32 @@
 //! The lnv2 lightning module: mappings, subscriptions, and the facade operations.
 
+use std::sync::Arc;
+
 use fedimint_client::Client;
 use fedimint_client_module::ClientModuleInstance;
 use fedimint_core::core::OperationId;
-use fedimint_core::util::BoxStream;
-use fedimint_lnv2_client::{LightningClientModule, ReceiveOperationState, SendOperationState};
+use fedimint_core::util::{BoxStream, SafeUrl};
+use fedimint_lnv2_client::{
+    LightningClientModule, LightningOperationMeta, ReceiveError, ReceiveOperationState,
+    SelectGatewayError, SendOperationMeta, SendOperationState, SendPaymentError,
+};
+use fedimint_lnv2_common::gateway_api::{PaymentFee, RoutingInfo};
+use fedimint_lnv2_common::{Bolt11InvoiceDescription, LightningInvoice};
 use futures::StreamExt;
 
-use super::driver::until_final;
-use super::subscribe_error;
-use super::wire::PHASE_FUNDED;
+use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
+use super::wire::{self, PHASE_FUNDED};
+use super::{
+    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, from_upstream, gateway_unavailable,
+    insufficient, internal, now, plan_of, quote_changed, quote_expired, subscribe_error,
+    to_upstream, unreachable,
+};
 use crate::federation::FederationInner;
-use crate::operation::record_phase_in;
+use crate::operation::{Backfilled, Driver, kinds, record_phase_in};
 use crate::{
-    Amount, Error, ErrorCode, LightningRoute, LnReceiveState, LnSendDetails, LnSendState, Preimage,
-    Result,
+    Amount, Bolt11Invoice, Error, ErrorCode, GatewayId, LightningRoute, LnReceive,
+    LnReceiveDetails, LnReceiveState, LnSendDetails, LnSendState, Operation, Preimage, Result,
+    Timestamp,
 };
 
 // lnv2 `SendOperationState` onto `LnSendState`. `Failure` means two things: the funding
@@ -167,12 +179,338 @@ pub(super) async fn subscribe_receive(
     Ok(until_final(stream))
 }
 
-/// Rebuilds a record from the module's log entry; filled in with the facade operations.
-pub(super) fn backfill(
-    _meta: &serde_json::Value,
-    _created_at: u64,
-) -> Option<crate::operation::Backfilled> {
-    None
+/// Plans an lnv2 payment: the gateway the module would pick for this invoice, its fee schedule
+/// for it, and the shared quote for funding the contract.
+pub(super) async fn plan(
+    client: &Client,
+    module: &LightningClientModule,
+    invoice: &Bolt11Invoice,
+    amount: Amount,
+) -> Result<Plan> {
+    let (gateway, routing) = module
+        .select_gateway(Some(invoice.inner().clone()))
+        .await
+        .map_err(select_error)?;
+    let (send_fee, expiration_delta) = routing.send_parameters(invoice.inner());
+    terms_for(
+        client,
+        module,
+        amount,
+        gateway,
+        &routing,
+        send_fee,
+        expiration_delta,
+    )
+    .await
+}
+
+/// Prices a payment through `gateway` on the given schedule. lnv2 has no internal route: a payee
+/// on the same gateway is a direct swap, still through the gateway.
+async fn terms_for(
+    client: &Client,
+    module: &LightningClientModule,
+    amount: Amount,
+    gateway: SafeUrl,
+    routing: &RoutingInfo,
+    send_fee: PaymentFee,
+    expiration_delta: u64,
+) -> Result<Plan> {
+    let contract_amount = from_upstream(send_fee.add_to(amount.msats()));
+    let gateway_fee = contract_amount.checked_sub(amount).ok_or_else(|| {
+        internal("the gateway's fee schedule produced a contract below the amount")
+    })?;
+    // The dry run balances the transaction against the real notes, so it fails with the mint's
+    // own insufficient-balance error when they cannot cover the contract.
+    let quote = module
+        .send_fee_quote(to_upstream(contract_amount))
+        .await
+        .map_err(|err| {
+            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
+                Some(short) => insufficient(
+                    from_upstream(short.requested_amount),
+                    from_upstream(short.total_amount),
+                ),
+                None => internal(format!("could not quote the funding fee: {err}")),
+            }
+        })?;
+    let lightning_module = from_upstream(
+        fee_consensus(client)
+            .await?
+            .fee(to_upstream(contract_amount)),
+    );
+    plan_of(
+        gateway_fee,
+        lightning_module,
+        &quote,
+        amount,
+        LightningRoute::Gateway {
+            gateway_id: GatewayId::from_upstream(routing.module_public_key),
+        },
+        Terms::V2 {
+            gateway,
+            send_fee,
+            expiration_delta,
+        },
+    )
+}
+
+/// The lnv2 module's fee consensus, from the client's decoded configuration: the module keeps
+/// its own copy private.
+async fn fee_consensus(client: &Client) -> Result<fedimint_lnv2_common::config::FeeConsensus> {
+    let config = client.config().await;
+    let (_, config) = config
+        .get_first_module_by_kind::<fedimint_lnv2_common::config::LightningClientConfig>("lnv2")
+        .map_err(|err| {
+            Error::new(
+                ErrorCode::NotSupported,
+                format!("this federation's lnv2 configuration is unreadable: {err}"),
+            )
+        })?;
+    Ok(config.fee_consensus.clone())
+}
+
+/// Executes an lnv2 quote: asks the gateway for its schedule again, refuses on drift, funds,
+/// records.
+pub(super) async fn send(
+    federation: &Arc<FederationInner>,
+    client: &Client,
+    module: &LightningClientModule,
+    quote: &LnQuoteInner,
+    gateway: SafeUrl,
+    send_fee: PaymentFee,
+    expiration_delta: u64,
+) -> Result<Operation<LnSendState>> {
+    let Some(routing) = module
+        .routing_info(&gateway)
+        .await
+        .map_err(gateway_unavailable)?
+    else {
+        return Err(Error::new(
+            ErrorCode::QuoteChanged,
+            "the quoted gateway no longer serves this federation",
+        ));
+    };
+    let current = routing.send_parameters(quote.invoice.inner());
+    let fresh = terms_for(
+        client,
+        module,
+        quote.invoice_amount,
+        gateway.clone(),
+        &routing,
+        current.0,
+        current.1,
+    )
+    .await?;
+    if current != (send_fee, expiration_delta) || fresh.total != quote.plan.total {
+        return Err(quote_changed(quote.plan.total, fresh.total));
+    }
+    let id = module
+        .send(
+            quote.invoice.inner().clone(),
+            Some(gateway),
+            serde_json::Value::Null,
+        )
+        .await
+        .map_err(|err| send_error(err, quote))?;
+    let details = crate::LnSendDetails {
+        invoice: quote.invoice.clone(),
+        invoice_amount: quote.invoice_amount,
+        fee: quote.plan.fee,
+        total: quote.plan.total,
+        route: quote.plan.route.clone(),
+        created_at: now(),
+    };
+    federation
+        .create_operation(
+            id,
+            kinds::LN_SEND,
+            "lnv2",
+            &wire::LnSendDetailsWire::from(&details),
+            Arc::new(LnSendDriver) as Arc<dyn Driver<LnSendState>>,
+        )
+        .await
+}
+
+fn select_error(err: SelectGatewayError) -> Error {
+    match err {
+        SelectGatewayError::FailedToRequestGateways(cause) => unreachable(cause),
+        SelectGatewayError::NoGatewaysAvailable | SelectGatewayError::GatewaysUnresponsive => {
+            gateway_unavailable(err)
+        }
+    }
+}
+
+fn send_error(err: SendPaymentError, quote: &LnQuoteInner) -> Error {
+    match err {
+        SendPaymentError::InvoiceMissingAmount => Error::new(
+            ErrorCode::AmountlessInvoice,
+            "this invoice names no amount and cannot be paid through fedimint",
+        ),
+        SendPaymentError::InvoiceExpired => quote_expired(quote.expires_at, false),
+        SendPaymentError::DuplicatePaymentAttempt(_) => quote_expired(quote.expires_at, true),
+        SendPaymentError::SelectGateway(inner) => select_error(inner),
+        SendPaymentError::FailedToConnectToGateway(_)
+        | SendPaymentError::FederationNotSupported
+        | SendPaymentError::GatewayFeeExceedsLimit
+        | SendPaymentError::GatewayExpirationExceedsLimit => gateway_unavailable(err),
+        SendPaymentError::FailedToRequestBlockCount(cause) => unreachable(cause),
+        SendPaymentError::FailedToFundPayment(cause) if cause.contains("Insufficient balance") => {
+            Error::new(ErrorCode::InsufficientBalance, cause)
+        }
+        SendPaymentError::FailedToFundPayment(cause) => {
+            internal(format!("the payment could not be funded: {cause}"))
+        }
+        // Unreachable: `preflight` already refused a foreign-network invoice with full details.
+        SendPaymentError::WrongCurrency { .. } => Error::new(
+            ErrorCode::NetworkMismatch,
+            "the invoice is for another network",
+        ),
+    }
+}
+
+/// Issues an lnv2 invoice through the gateway the module selects, with both the gateway's and
+/// the federation's receive-side fees taken out of what will land.
+pub(super) async fn receive(
+    federation: &Arc<FederationInner>,
+    module: &LightningClientModule,
+    amount: Amount,
+    description: &str,
+) -> Result<LnReceive> {
+    let (gateway, routing) = module.select_gateway(None).await.map_err(select_error)?;
+    // The contract the gateway funds is the invoice amount less its fee
+    // (`fedimint-lnv2-client/src/lib.rs:1064`); the federation's claim fee comes off that.
+    let contract_amount = from_upstream(routing.receive_fee.subtract_from(amount.msats()));
+    let gateway_fee = amount.checked_sub(contract_amount).ok_or_else(|| {
+        internal("the gateway's fee schedule produced a contract above the amount")
+    })?;
+    let quote = module
+        .receive_fee_quote(to_upstream(contract_amount))
+        .await
+        .map_err(|err| {
+            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
+                Some(short) => insufficient(
+                    from_upstream(short.requested_amount),
+                    from_upstream(short.total_amount),
+                ),
+                None => internal(format!("could not quote the claim fee: {err}")),
+            }
+        })?;
+    let fee = add(gateway_fee, from_upstream(quote.total().get_bitcoin()))?;
+    let net_credit = amount.checked_sub(fee).ok_or_else(|| {
+        Error::new(
+            ErrorCode::InvalidInput,
+            "the amount does not cover the receive-side fee",
+        )
+    })?;
+    let (invoice, id) = module
+        .receive(
+            to_upstream(amount),
+            INVOICE_EXPIRY_SECS,
+            Bolt11InvoiceDescription::Direct(description.to_owned()),
+            Some(gateway),
+            serde_json::Value::Null,
+        )
+        .await
+        .map_err(receive_error)?;
+    let invoice = Bolt11Invoice::from_upstream(invoice);
+    let details = LnReceiveDetails {
+        invoice: invoice.clone(),
+        description: description.to_owned(),
+        requested_amount: amount,
+        invoice_amount: amount,
+        fee,
+        net_credit,
+        gateway_id: Some(GatewayId::from_upstream(routing.module_public_key)),
+        expires_at: invoice.expires_at(),
+        created_at: now(),
+    };
+    let operation = federation
+        .create_operation(
+            id,
+            kinds::LN_RECEIVE,
+            "lnv2",
+            &wire::LnReceiveDetailsWire::from(&details),
+            Arc::new(LnReceiveDriver) as Arc<dyn Driver<LnReceiveState>>,
+        )
+        .await?;
+    Ok(LnReceive { invoice, operation })
+}
+
+fn receive_error(err: ReceiveError) -> Error {
+    match err {
+        ReceiveError::SelectGateway(inner) => select_error(inner),
+        ReceiveError::FailedToConnectToGateway(_)
+        | ReceiveError::FederationNotSupported
+        | ReceiveError::GatewayFeeExceedsLimit
+        | ReceiveError::InvalidInvoice
+        | ReceiveError::IncorrectInvoiceAmount => gateway_unavailable(err),
+        ReceiveError::AmountTooSmall => Error::new(
+            ErrorCode::InvalidInput,
+            "the amount is too small to cover the fees of claiming it",
+        ),
+        // The expiry is this facade's own constant, well under the module's cap.
+        ReceiveError::InvoiceExpiryTooLong => internal(err),
+    }
+}
+
+/// Rebuilds a record from an lnv2 log entry. The contract carries the gateway's key and the
+/// gateway's fee (the contract amount less the invoice amount) but not the federation's, so a
+/// rebuilt send's total is a floor and a rebuilt receive's fee is the gateway's share only.
+pub(super) fn backfill(meta: &serde_json::Value, created_at: u64) -> Option<Backfilled> {
+    let meta: LightningOperationMeta = serde_json::from_value(meta.clone()).ok()?;
+    let created_at = Timestamp::from_epoch_millis(created_at);
+    match meta {
+        LightningOperationMeta::Send(SendOperationMeta {
+            contract,
+            invoice: LightningInvoice::Bolt11(invoice),
+            ..
+        }) => {
+            let invoice = Bolt11Invoice::from_upstream(invoice);
+            let invoice_amount = invoice.amount()?;
+            let total = from_upstream(contract.amount);
+            let fee = total.checked_sub(invoice_amount)?;
+            let details = crate::LnSendDetails {
+                invoice,
+                invoice_amount,
+                fee,
+                total,
+                route: LightningRoute::Gateway {
+                    gateway_id: GatewayId::from_upstream(contract.claim_pk),
+                },
+                created_at,
+            };
+            Some(Backfilled {
+                kind: kinds::LN_SEND,
+                details: serde_json::to_string(&wire::LnSendDetailsWire::from(&details)).ok()?,
+                phase: None,
+            })
+        }
+        LightningOperationMeta::Receive(meta) => {
+            let LightningInvoice::Bolt11(invoice) = meta.invoice;
+            let invoice = Bolt11Invoice::from_upstream(invoice);
+            let amount = invoice.amount()?;
+            let net_credit = from_upstream(meta.contract.commitment.amount);
+            let fee = amount.checked_sub(net_credit)?;
+            let details = LnReceiveDetails {
+                description: invoice.description(),
+                requested_amount: amount,
+                invoice_amount: amount,
+                fee,
+                net_credit,
+                gateway_id: Some(GatewayId::from_upstream(meta.contract.commitment.refund_pk)),
+                expires_at: invoice.expires_at(),
+                created_at,
+                invoice,
+            };
+            Some(Backfilled {
+                kind: kinds::LN_RECEIVE,
+                details: serde_json::to_string(&wire::LnReceiveDetailsWire::from(&details)).ok()?,
+                phase: None,
+            })
+        }
+        // An lnurl receive is not an operation this SDK creates.
+        LightningOperationMeta::LnurlReceive(_) => None,
+    }
 }
 
 #[cfg(test)]
@@ -258,5 +596,56 @@ mod tests {
         for (upstream, expected) in cases {
             assert_eq!(map_receive(&upstream), expected);
         }
+    }
+
+    const GATEWAY_ID: &str = "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
+    const REGTEST_INVOICE: &str = "lnbcrt1u1pj48ugqdq2vdhkven9v5pp5g3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqsp5242424242424242424242424242424242424242424242424242s9qrsgqcqzys2reg4wsryjt5w8z33ugydecgfmgyvtttwa7e0yzlm803z203j9hqspa4lr6m09cd808xkw9uh4sxc8wf3w6k0gaf5zrqm7zhcxug0vqqpdkpja";
+
+    fn outgoing_meta(contract_msats: u64) -> serde_json::Value {
+        // `all_zeros` is the `bitcoin::hashes::Hash` trait's; `TransactionId` is a hash newtype.
+        use fedimint_core::bitcoin::hashes::Hash;
+        use fedimint_lnv2_common::contracts::{OutgoingContract, PaymentImage};
+
+        let key: fedimint_core::secp256k1::PublicKey = GATEWAY_ID.parse().expect("a key");
+        let invoice: fedimint_ln_common::lightning_invoice::Bolt11Invoice =
+            REGTEST_INVOICE.parse().expect("an invoice");
+        let contract = OutgoingContract {
+            payment_image: PaymentImage::Hash(*invoice.payment_hash()),
+            amount: fedimint_core::Amount::from_msats(contract_msats),
+            expiration: 0,
+            claim_pk: key,
+            refund_pk: key,
+            ephemeral_pk: key,
+        };
+        serde_json::to_value(LightningOperationMeta::Send(SendOperationMeta {
+            change_outpoint_range: fedimint_core::OutPointRange::new_single(
+                fedimint_core::TransactionId::all_zeros(),
+                0,
+            )
+            .expect("a range"),
+            gateway: SafeUrl::parse("http://127.0.0.1:1/").expect("a url"),
+            contract,
+            invoice: fedimint_lnv2_common::LightningInvoice::Bolt11(invoice),
+            custom_meta: serde_json::Value::Null,
+        }))
+        .expect("serialises")
+    }
+
+    #[test]
+    fn a_send_log_entry_backfills_a_send_record() {
+        let claimed = backfill(&outgoing_meta(101_000), 9).expect("claimed");
+        assert_eq!(claimed.kind, crate::operation::kinds::LN_SEND);
+        let details = wire::decode_send_details(&claimed.details).expect("decodes");
+        assert_eq!(details.invoice_amount, Amount::from_msats(100_000));
+        assert_eq!(details.fee, Amount::from_msats(1_000));
+        assert_eq!(details.total, Amount::from_msats(101_000));
+        assert_eq!(details.route, route());
+        assert_eq!(details.created_at.epoch_millis(), 9);
+    }
+
+    #[test]
+    fn a_contract_below_the_invoice_amount_is_not_claimed() {
+        assert!(backfill(&outgoing_meta(1), 0).is_none());
+        assert!(backfill(&serde_json::Value::Null, 0).is_none());
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -17,9 +17,9 @@ use futures::StreamExt;
 use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
 use super::{
-    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, fee_quote_failure, from_upstream,
-    gateway_unavailable, internal, now, plan_of, quote_changed, quote_expired, subscribe_error,
-    to_upstream, unreachable,
+    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, balance_of, fee_quote_failure,
+    from_upstream, gateway_unavailable, insufficient, internal, now, plan_of, quote_changed,
+    quote_expired, subscribe_error, to_upstream, unreachable,
 };
 use crate::federation::FederationInner;
 use crate::operation::{Backfilled, Driver, kinds, record_phase_in};
@@ -295,6 +295,15 @@ pub(super) async fn send(
     if client.operation_exists(id).await {
         return Err(quote_expired(quote.expires_at, true));
     }
+    // Checked again here, after the already-executed check above and before the gateway is
+    // re-quoted below: the balance can drop between a quote and this call, and it must be asked
+    // whether the invoice was already paid before it is asked whether the balance still covers
+    // it, or a second quote for an already-paid invoice is misreported as a shortfall instead of
+    // the truth.
+    let available = balance_of(client).await?;
+    if available < quote.plan.total {
+        return Err(insufficient(quote.plan.total, available));
+    }
     let Some(routing) = module
         .routing_info(&gateway)
         .await
@@ -369,7 +378,12 @@ fn send_error(err: SendPaymentError, quote: &LnQuoteInner, expected: Network) ->
         | SendPaymentError::GatewayFeeExceedsLimit
         | SendPaymentError::GatewayExpirationExceedsLimit => gateway_unavailable(err),
         SendPaymentError::FailedToRequestBlockCount(cause) => unreachable(cause),
-        SendPaymentError::FailedToFundPayment(cause) if cause.contains("Insufficient balance") => {
+        // The wording differs by which mint funds the contract: the v1 mint says "Insufficient
+        // balance" (`fedimint-mint-client/src/lib.rs:2917`), the v2 mint says "Insufficient
+        // funds" (`fedimint-mintv2-client/src/lib.rs:503`).
+        SendPaymentError::FailedToFundPayment(cause)
+            if cause.contains("Insufficient balance") || cause.contains("Insufficient funds") =>
+        {
             Error::new(ErrorCode::InsufficientBalance, cause)
         }
         SendPaymentError::FailedToFundPayment(cause) => {

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -17,8 +17,8 @@ use futures::StreamExt;
 use super::driver::{LnReceiveDriver, LnSendDriver, until_final};
 use super::wire::{self, PHASE_FUNDED};
 use super::{
-    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, from_upstream, gateway_unavailable,
-    insufficient, internal, now, plan_of, quote_changed, quote_expired, subscribe_error,
+    INVOICE_EXPIRY_SECS, LnQuoteInner, Plan, Terms, add, fee_quote_failure, from_upstream,
+    gateway_unavailable, internal, now, plan_of, quote_changed, quote_expired, subscribe_error,
     to_upstream, unreachable,
 };
 use crate::federation::FederationInner;
@@ -219,20 +219,24 @@ async fn terms_for(
     let gateway_fee = contract_amount.checked_sub(amount).ok_or_else(|| {
         internal("the gateway's fee schedule produced a contract below the amount")
     })?;
-    // The dry run balances the transaction against the real notes, so it fails with the mint's
-    // own insufficient-balance error when they cannot cover the contract.
-    let quote = module
-        .send_fee_quote(to_upstream(contract_amount))
-        .await
-        .map_err(|err| {
-            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
-                Some(short) => insufficient(
-                    from_upstream(short.requested_amount),
-                    from_upstream(short.total_amount),
-                ),
-                None => internal(format!("could not quote the funding fee: {err}")),
-            }
-        })?;
+    // The dry run balances the transaction against the real notes, so it fails when they
+    // cannot cover the contract; the mint reports that as either a typed error (mint v1) or a
+    // plain-text one (mint v2, `fee_quote_failure`'s doc comment says where).
+    let quote = match module.send_fee_quote(to_upstream(contract_amount)).await {
+        Ok(quote) => quote,
+        Err(err) => {
+            let text = err.to_string();
+            let short = err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>();
+            return Err(fee_quote_failure(
+                client,
+                short,
+                &text,
+                contract_amount,
+                "could not quote the funding fee",
+            )
+            .await);
+        }
+    };
     let lightning_module = from_upstream(
         fee_consensus(client)
             .await?
@@ -394,6 +398,7 @@ fn send_error(err: SendPaymentError, quote: &LnQuoteInner, expected: Network) ->
 /// the federation's receive-side fees taken out of what will land.
 pub(super) async fn receive(
     federation: &Arc<FederationInner>,
+    client: &Client,
     module: &LightningClientModule,
     amount: Amount,
     description: &str,
@@ -405,18 +410,21 @@ pub(super) async fn receive(
     let gateway_fee = amount.checked_sub(contract_amount).ok_or_else(|| {
         internal("the gateway's fee schedule produced a contract above the amount")
     })?;
-    let quote = module
-        .receive_fee_quote(to_upstream(contract_amount))
-        .await
-        .map_err(|err| {
-            match err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>() {
-                Some(short) => insufficient(
-                    from_upstream(short.requested_amount),
-                    from_upstream(short.total_amount),
-                ),
-                None => internal(format!("could not quote the claim fee: {err}")),
-            }
-        })?;
+    let quote = match module.receive_fee_quote(to_upstream(contract_amount)).await {
+        Ok(quote) => quote,
+        Err(err) => {
+            let text = err.to_string();
+            let short = err.downcast_ref::<fedimint_mint_client::InsufficientBalanceError>();
+            return Err(fee_quote_failure(
+                client,
+                short,
+                &text,
+                contract_amount,
+                "could not quote the claim fee",
+            )
+            .await);
+        }
+    };
     let fee = add(gateway_fee, from_upstream(quote.total().get_bitcoin()))?;
     let net_credit = amount.checked_sub(fee).ok_or_else(|| {
         Error::new(

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -350,7 +350,8 @@ pub(super) async fn send(
     // Upstream re-derives the gateway's terms itself inside `send` and funds the contract at
     // whatever it reads there; nothing binds that read to the `routing_info` re-check above, so a
     // gateway that changes its fee in the instant between the two funds a different contract than
-    // the one this record is about to describe. The committed contract, read back from the
+    // the one this record is about to describe (an API that takes the checked terms is requested
+    // as fedimint/fedimint#9124). The committed contract, read back from the
     // operation's own log entry, is the only place that says what was actually funded, so it
     // corrects the record's fee and total after the fact. A read or a computation that does not
     // come back clean leaves the quoted figures in place: an `Internal` error here would report a

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -4,7 +4,7 @@ use fedimint_client::Client;
 use fedimint_client_module::ClientModuleInstance;
 use fedimint_core::core::OperationId;
 use fedimint_core::util::BoxStream;
-use fedimint_lnv2_client::{LightningClientModule, SendOperationState};
+use fedimint_lnv2_client::{LightningClientModule, ReceiveOperationState, SendOperationState};
 use futures::StreamExt;
 
 use super::driver::until_final;
@@ -13,7 +13,8 @@ use super::wire::PHASE_FUNDED;
 use crate::federation::FederationInner;
 use crate::operation::record_phase_in;
 use crate::{
-    Amount, Error, ErrorCode, LightningRoute, LnSendDetails, LnSendState, Preimage, Result,
+    Amount, Error, ErrorCode, LightningRoute, LnReceiveState, LnSendDetails, LnSendState, Preimage,
+    Result,
 };
 
 // lnv2 `SendOperationState` onto `LnSendState`. `Failure` means two things: the funding
@@ -112,6 +113,60 @@ pub(super) async fn subscribe_send(
     Ok(until_final(stream))
 }
 
+// lnv2 `ReceiveOperationState` onto `LnReceiveState`. Direct: lnv2 names its stages.
+//
+// | upstream       | here                |
+// | -------------- | ------------------- |
+// | `Pending`      | `WaitingForPayment` |
+// | `Claiming`     | `Funded`            |
+// | `Claimed`      | `Claimed`           |
+// | `Expired`      | `Expired`           |
+// | `Failure`      | `Failed`            |
+// | `Uneconomical` | `Failed`            |
+pub(super) fn map_receive(state: &ReceiveOperationState) -> LnReceiveState {
+    match state {
+        ReceiveOperationState::Pending => LnReceiveState::WaitingForPayment,
+        ReceiveOperationState::Claiming => LnReceiveState::Funded,
+        ReceiveOperationState::Claimed => LnReceiveState::Claimed,
+        ReceiveOperationState::Expired => LnReceiveState::Expired,
+        ReceiveOperationState::Failure | ReceiveOperationState::Uneconomical => {
+            LnReceiveState::Failed
+        }
+    }
+}
+
+/// A fresh stream over an lnv2 receive. The funded phase is recorded for symmetry with v1, though
+/// no lnv2 receive mapping reads it.
+pub(super) async fn subscribe_receive(
+    federation: &FederationInner,
+    id: OperationId,
+    phase: u32,
+) -> Result<BoxStream<'static, Result<LnReceiveState>>> {
+    let client = federation.client(false).await?;
+    let module = module_of(&client)?;
+    let upstream = module
+        .subscribe_receive_operation_state_updates(id)
+        .await
+        .map_err(subscribe_error)?
+        .into_stream();
+    let db = federation.db();
+    let stream = upstream.scan((phase, db), move |(phase, db), state| {
+        let mapped = map_receive(&state);
+        let advance = matches!(mapped, LnReceiveState::Funded) && *phase < PHASE_FUNDED;
+        if advance {
+            *phase = PHASE_FUNDED;
+        }
+        let db = db.clone();
+        async move {
+            if advance && let Err(err) = record_phase_in(&db, id, PHASE_FUNDED).await {
+                return Some(Err(err));
+            }
+            Some(Ok(mapped))
+        }
+    });
+    Ok(until_final(stream))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,5 +232,23 @@ mod tests {
         );
         assert_eq!(send_phase(&SendOperationState::Refunded), PHASE_FUNDED);
         assert_eq!(send_phase(&SendOperationState::Failure), 0);
+    }
+
+    #[test]
+    fn receive_states_fold_onto_the_receive_lifecycle() {
+        let cases = [
+            (
+                ReceiveOperationState::Pending,
+                LnReceiveState::WaitingForPayment,
+            ),
+            (ReceiveOperationState::Claiming, LnReceiveState::Funded),
+            (ReceiveOperationState::Claimed, LnReceiveState::Claimed),
+            (ReceiveOperationState::Expired, LnReceiveState::Expired),
+            (ReceiveOperationState::Failure, LnReceiveState::Failed),
+            (ReceiveOperationState::Uneconomical, LnReceiveState::Failed),
+        ];
+        for (upstream, expected) in cases {
+            assert_eq!(map_receive(&upstream), expected);
+        }
     }
 }

--- a/rust/fedimint-sdk/src/lightning/v2.rs
+++ b/rust/fedimint-sdk/src/lightning/v2.rs
@@ -280,6 +280,17 @@ pub(super) async fn send(
     send_fee: PaymentFee,
     expiration_delta: u64,
 ) -> Result<Operation<LnSendState>> {
+    // The module derives this invoice's operation id independently of the gateway or fee
+    // schedule (`fedimint-lnv2-client/src/lib.rs:567-574`) and later refuses a duplicate
+    // attempt against it with `DuplicatePaymentAttempt`, which `send_error` below maps to the
+    // same `QuoteExpired` this reports. Checking first, before the gateway is asked to
+    // re-quote, keeps an already-paid or still-in-flight invoice from being reported as a
+    // quote whose terms moved: paying the first quote can change the fee a second quote for
+    // the same invoice would be re-priced at.
+    let id = OperationId::from_encodable(&(quote.invoice.inner().clone(), 0u64));
+    if client.operation_exists(id).await {
+        return Err(quote_expired(quote.expires_at, true));
+    }
     let Some(routing) = module
         .routing_info(&gateway)
         .await

--- a/rust/fedimint-sdk/src/lightning/wire.rs
+++ b/rust/fedimint-sdk/src/lightning/wire.rs
@@ -1,0 +1,440 @@
+//! The persisted shapes of the lightning facade: details records and final states as JSON, and
+//! the phase a phase-keyed mapping reads after a restart.
+//!
+//! These are storage format. A field added later must be `Option` with `#[serde(default)]`, and
+//! a field is never renamed or removed: every record already written reads through this file.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Amount, Error, ErrorCode, LightningRoute, LnReceiveDetails, LnReceiveState, LnSendDetails,
+    LnSendState, Preimage, Result, Timestamp,
+};
+
+/// The operation reached the funded stage: upstream accepted the payment's funding, or the
+/// incoming contract was confirmed paid. The only phase a lightning record ever carries.
+pub(super) const PHASE_FUNDED: u32 = 1;
+
+/// [`LightningRoute`] as stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(super) enum RouteWire {
+    Internal,
+    Gateway { gateway_id: String },
+}
+
+impl From<&LightningRoute> for RouteWire {
+    fn from(route: &LightningRoute) -> RouteWire {
+        match route {
+            LightningRoute::Internal => RouteWire::Internal,
+            LightningRoute::Gateway { gateway_id } => RouteWire::Gateway {
+                gateway_id: gateway_id.to_string(),
+            },
+        }
+    }
+}
+
+impl TryFrom<RouteWire> for LightningRoute {
+    type Error = Error;
+
+    fn try_from(wire: RouteWire) -> Result<LightningRoute> {
+        Ok(match wire {
+            RouteWire::Internal => LightningRoute::Internal,
+            RouteWire::Gateway { gateway_id } => LightningRoute::Gateway {
+                gateway_id: gateway_id.parse().map_err(|err: Error| {
+                    Error::new(
+                        ErrorCode::Internal,
+                        format!("a stored gateway id does not parse: {err}"),
+                    )
+                })?,
+            },
+        })
+    }
+}
+
+/// [`LnSendDetails`] as stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct LnSendDetailsWire {
+    pub(super) invoice: String,
+    pub(super) invoice_amount_msats: u64,
+    pub(super) fee_msats: u64,
+    pub(super) total_msats: u64,
+    pub(super) route: RouteWire,
+    pub(super) created_at: u64,
+}
+
+impl From<&LnSendDetails> for LnSendDetailsWire {
+    fn from(details: &LnSendDetails) -> LnSendDetailsWire {
+        LnSendDetailsWire {
+            invoice: details.invoice.to_string(),
+            invoice_amount_msats: details.invoice_amount.msats(),
+            fee_msats: details.fee.msats(),
+            total_msats: details.total.msats(),
+            route: RouteWire::from(&details.route),
+            created_at: details.created_at.epoch_millis(),
+        }
+    }
+}
+
+impl TryFrom<LnSendDetailsWire> for LnSendDetails {
+    type Error = Error;
+
+    fn try_from(wire: LnSendDetailsWire) -> Result<LnSendDetails> {
+        Ok(LnSendDetails {
+            invoice: parse_invoice(&wire.invoice)?,
+            invoice_amount: Amount::from_msats(wire.invoice_amount_msats),
+            fee: Amount::from_msats(wire.fee_msats),
+            total: Amount::from_msats(wire.total_msats),
+            route: LightningRoute::try_from(wire.route)?,
+            created_at: Timestamp::from_epoch_millis(wire.created_at),
+        })
+    }
+}
+
+/// [`LnReceiveDetails`] as stored, plus the one private fill-in-later field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct LnReceiveDetailsWire {
+    pub(super) invoice: String,
+    pub(super) description: String,
+    pub(super) requested_amount_msats: u64,
+    pub(super) invoice_amount_msats: u64,
+    pub(super) fee_msats: u64,
+    pub(super) net_credit_msats: u64,
+    pub(super) gateway_id: Option<String>,
+    pub(super) expires_at: u64,
+    pub(super) created_at: u64,
+    /// v1 only: the upstream operation a retried claim runs under, set once when a rejected
+    /// claim is retried. Not part of the public record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) reclaim_operation_id: Option<String>,
+}
+
+impl From<&LnReceiveDetails> for LnReceiveDetailsWire {
+    fn from(details: &LnReceiveDetails) -> LnReceiveDetailsWire {
+        LnReceiveDetailsWire {
+            invoice: details.invoice.to_string(),
+            description: details.description.clone(),
+            requested_amount_msats: details.requested_amount.msats(),
+            invoice_amount_msats: details.invoice_amount.msats(),
+            fee_msats: details.fee.msats(),
+            net_credit_msats: details.net_credit.msats(),
+            gateway_id: details.gateway_id.as_ref().map(ToString::to_string),
+            expires_at: details.expires_at.epoch_millis(),
+            created_at: details.created_at.epoch_millis(),
+            reclaim_operation_id: None,
+        }
+    }
+}
+
+impl TryFrom<LnReceiveDetailsWire> for LnReceiveDetails {
+    type Error = Error;
+
+    fn try_from(wire: LnReceiveDetailsWire) -> Result<LnReceiveDetails> {
+        let gateway_id = match wire.gateway_id {
+            Some(id) => Some(id.parse().map_err(|err: Error| {
+                Error::new(
+                    ErrorCode::Internal,
+                    format!("a stored gateway id does not parse: {err}"),
+                )
+            })?),
+            None => None,
+        };
+        Ok(LnReceiveDetails {
+            invoice: parse_invoice(&wire.invoice)?,
+            description: wire.description,
+            requested_amount: Amount::from_msats(wire.requested_amount_msats),
+            invoice_amount: Amount::from_msats(wire.invoice_amount_msats),
+            fee: Amount::from_msats(wire.fee_msats),
+            net_credit: Amount::from_msats(wire.net_credit_msats),
+            gateway_id,
+            expires_at: Timestamp::from_epoch_millis(wire.expires_at),
+            created_at: Timestamp::from_epoch_millis(wire.created_at),
+        })
+    }
+}
+
+/// [`LnSendState`] as stored on `OperationRecord::final_state`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+enum LnSendStateWire {
+    Created,
+    Funded,
+    Success {
+        preimage: String,
+        fee_msats: u64,
+        route: RouteWire,
+    },
+    Refunded,
+    Failed {
+        reason: String,
+    },
+}
+
+/// [`LnReceiveState`] as stored on `OperationRecord::final_state`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+enum LnReceiveStateWire {
+    Created,
+    WaitingForPayment,
+    Funded,
+    Claimed,
+    Canceled { reason: String },
+    Expired,
+    Failed,
+}
+
+pub(super) fn encode_send_state(state: &LnSendState) -> Result<String> {
+    let wire = match state {
+        LnSendState::Created => LnSendStateWire::Created,
+        LnSendState::Funded => LnSendStateWire::Funded,
+        LnSendState::Success {
+            preimage,
+            fee,
+            route,
+        } => LnSendStateWire::Success {
+            preimage: preimage.to_string(),
+            fee_msats: fee.msats(),
+            route: RouteWire::from(route),
+        },
+        LnSendState::Refunded => LnSendStateWire::Refunded,
+        LnSendState::Failed { reason } => LnSendStateWire::Failed {
+            reason: reason.clone(),
+        },
+    };
+    serde_json::to_string(&wire).map_err(encode_error)
+}
+
+pub(super) fn decode_send_state(encoded: &str) -> Result<LnSendState> {
+    let wire: LnSendStateWire = serde_json::from_str(encoded).map_err(decode_error)?;
+    Ok(match wire {
+        LnSendStateWire::Created => LnSendState::Created,
+        LnSendStateWire::Funded => LnSendState::Funded,
+        LnSendStateWire::Success {
+            preimage,
+            fee_msats,
+            route,
+        } => LnSendState::Success {
+            preimage: preimage.parse::<Preimage>().map_err(|err| {
+                Error::new(
+                    ErrorCode::Internal,
+                    format!("a stored preimage does not parse: {err}"),
+                )
+            })?,
+            fee: Amount::from_msats(fee_msats),
+            route: LightningRoute::try_from(route)?,
+        },
+        LnSendStateWire::Refunded => LnSendState::Refunded,
+        LnSendStateWire::Failed { reason } => LnSendState::Failed { reason },
+    })
+}
+
+pub(super) fn encode_receive_state(state: &LnReceiveState) -> Result<String> {
+    let wire = match state {
+        LnReceiveState::Created => LnReceiveStateWire::Created,
+        LnReceiveState::WaitingForPayment => LnReceiveStateWire::WaitingForPayment,
+        LnReceiveState::Funded => LnReceiveStateWire::Funded,
+        LnReceiveState::Claimed => LnReceiveStateWire::Claimed,
+        LnReceiveState::Canceled { reason } => LnReceiveStateWire::Canceled {
+            reason: reason.clone(),
+        },
+        LnReceiveState::Expired => LnReceiveStateWire::Expired,
+        LnReceiveState::Failed => LnReceiveStateWire::Failed,
+    };
+    serde_json::to_string(&wire).map_err(encode_error)
+}
+
+pub(super) fn decode_receive_state(encoded: &str) -> Result<LnReceiveState> {
+    let wire: LnReceiveStateWire = serde_json::from_str(encoded).map_err(decode_error)?;
+    Ok(match wire {
+        LnReceiveStateWire::Created => LnReceiveState::Created,
+        LnReceiveStateWire::WaitingForPayment => LnReceiveState::WaitingForPayment,
+        LnReceiveStateWire::Funded => LnReceiveState::Funded,
+        LnReceiveStateWire::Claimed => LnReceiveState::Claimed,
+        LnReceiveStateWire::Canceled { reason } => LnReceiveState::Canceled { reason },
+        LnReceiveStateWire::Expired => LnReceiveState::Expired,
+        LnReceiveStateWire::Failed => LnReceiveState::Failed,
+    })
+}
+
+pub(super) fn decode_send_details(json: &str) -> Result<LnSendDetails> {
+    let wire: LnSendDetailsWire = serde_json::from_str(json).map_err(decode_error)?;
+    LnSendDetails::try_from(wire)
+}
+
+pub(super) fn decode_receive_details(json: &str) -> Result<LnReceiveDetails> {
+    LnReceiveDetails::try_from(decode_receive_wire(json)?)
+}
+
+pub(super) fn decode_receive_wire(json: &str) -> Result<LnReceiveDetailsWire> {
+    serde_json::from_str(json).map_err(decode_error)
+}
+
+pub(super) fn encode_receive_wire(wire: &LnReceiveDetailsWire) -> Result<String> {
+    serde_json::to_string(wire).map_err(encode_error)
+}
+
+fn parse_invoice(text: &str) -> Result<crate::Bolt11Invoice> {
+    text.parse().map_err(|err: Error| {
+        Error::new(
+            ErrorCode::Internal,
+            format!("a stored invoice does not parse: {err}"),
+        )
+    })
+}
+
+fn encode_error(err: serde_json::Error) -> Error {
+    Error::new(
+        ErrorCode::Internal,
+        format!("could not encode a lightning record: {err}"),
+    )
+}
+
+fn decode_error(err: serde_json::Error) -> Error {
+    Error::new(
+        ErrorCode::Internal,
+        format!("could not decode a lightning record: {err}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Amount;
+
+    const GATEWAY_ID: &str = "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
+    const INVOICE: &str = "lnbcrt1u1pj48ugqdq2vdhkven9v5pp5g3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqsp5242424242424242424242424242424242424242424242424242s9qrsgqcqzys2reg4wsryjt5w8z33ugydecgfmgyvtttwa7e0yzlm803z203j9hqspa4lr6m09cd808xkw9uh4sxc8wf3w6k0gaf5zrqm7zhcxug0vqqpdkpja";
+
+    fn send_details() -> LnSendDetails {
+        LnSendDetails {
+            invoice: INVOICE.parse().expect("a valid regtest invoice"),
+            invoice_amount: Amount::from_msats(100_000),
+            fee: Amount::from_msats(1_050),
+            total: Amount::from_msats(101_050),
+            route: LightningRoute::Gateway {
+                gateway_id: GATEWAY_ID.parse().expect("a valid gateway id"),
+            },
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    fn receive_details() -> LnReceiveDetails {
+        LnReceiveDetails {
+            invoice: INVOICE.parse().expect("a valid regtest invoice"),
+            description: "coffee".to_owned(),
+            requested_amount: Amount::from_msats(100_000),
+            invoice_amount: Amount::from_msats(100_000),
+            fee: Amount::from_msats(500),
+            net_credit: Amount::from_msats(99_500),
+            gateway_id: Some(GATEWAY_ID.parse().expect("a valid gateway id")),
+            expires_at: Timestamp::from_epoch_millis(1_700_003_600_000),
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    #[test]
+    fn send_details_round_trip_through_json() {
+        let details = send_details();
+        let json = serde_json::to_string(&LnSendDetailsWire::from(&details)).expect("encode");
+        assert_eq!(decode_send_details(&json).expect("decode"), details);
+    }
+
+    #[test]
+    fn an_internal_route_round_trips() {
+        let details = LnSendDetails {
+            route: LightningRoute::Internal,
+            ..send_details()
+        };
+        let json = serde_json::to_string(&LnSendDetailsWire::from(&details)).expect("encode");
+        assert!(json.contains(r#""kind":"internal""#), "{json}");
+        assert_eq!(decode_send_details(&json).expect("decode"), details);
+    }
+
+    #[test]
+    fn receive_details_round_trip_through_json() {
+        let details = receive_details();
+        let json = serde_json::to_string(&LnReceiveDetailsWire::from(&details)).expect("encode");
+        assert!(!json.contains("reclaim_operation_id"), "{json}");
+        assert_eq!(decode_receive_details(&json).expect("decode"), details);
+    }
+
+    #[test]
+    fn a_receive_without_a_gateway_round_trips() {
+        let details = LnReceiveDetails {
+            gateway_id: None,
+            ..receive_details()
+        };
+        let json = serde_json::to_string(&LnReceiveDetailsWire::from(&details)).expect("encode");
+        assert_eq!(decode_receive_details(&json).expect("decode"), details);
+    }
+
+    #[test]
+    fn the_reclaim_id_is_kept_on_the_wire_record_only() {
+        let mut wire = LnReceiveDetailsWire::from(&receive_details());
+        wire.reclaim_operation_id = Some("ab".repeat(32));
+        let json = encode_receive_wire(&wire).expect("encode");
+        assert_eq!(
+            decode_receive_wire(&json)
+                .expect("decode")
+                .reclaim_operation_id
+                .as_deref(),
+            Some("ab".repeat(32).as_str())
+        );
+        // The public record does not expose it.
+        assert_eq!(
+            decode_receive_details(&json).expect("decode"),
+            receive_details()
+        );
+    }
+
+    #[test]
+    fn every_final_send_state_round_trips() {
+        let preimage: Preimage = "11".repeat(32).parse().expect("a preimage");
+        for state in [
+            LnSendState::Success {
+                preimage,
+                fee: Amount::from_msats(1_050),
+                route: LightningRoute::Internal,
+            },
+            LnSendState::Refunded,
+            LnSendState::Failed {
+                reason: "gone".to_owned(),
+            },
+        ] {
+            let encoded = encode_send_state(&state).expect("encode");
+            assert_eq!(decode_send_state(&encoded).expect("decode"), state);
+        }
+    }
+
+    #[test]
+    fn every_final_receive_state_round_trips() {
+        for state in [
+            LnReceiveState::Claimed,
+            LnReceiveState::Canceled {
+                reason: "withdrawn".to_owned(),
+            },
+            LnReceiveState::Expired,
+            LnReceiveState::Failed,
+        ] {
+            let encoded = encode_receive_state(&state).expect("encode");
+            assert_eq!(decode_receive_state(&encoded).expect("decode"), state);
+        }
+    }
+
+    #[test]
+    fn a_malformed_record_is_an_internal_error() {
+        for json in ["", "{}", r#"{"invoice":"nope"}"#] {
+            assert_eq!(
+                decode_send_details(json).expect_err("refused").code,
+                ErrorCode::Internal
+            );
+            assert_eq!(
+                decode_receive_details(json).expect_err("refused").code,
+                ErrorCode::Internal
+            );
+        }
+        assert_eq!(
+            decode_send_state("nonsense").expect_err("refused").code,
+            ErrorCode::Internal
+        );
+    }
+}

--- a/rust/fedimint-sdk/src/lightning/wire.rs
+++ b/rust/fedimint-sdk/src/lightning/wire.rs
@@ -15,6 +15,28 @@ use crate::{
 /// incoming contract was confirmed paid. The only phase a lightning record ever carries.
 pub(super) const PHASE_FUNDED: u32 = 1;
 
+/// The key under which the SDK's own details record rides inside the module's metadata, so a
+/// record rebuilt from the module's log entry after a crash carries the exact quoted terms.
+pub(super) const CUSTOM_META_KEY: &str = "fedimint_sdk";
+
+/// The details record wrapped for the module's custom metadata.
+pub(super) fn custom_meta<W>(wire: &W) -> Result<serde_json::Value>
+where
+    W: Serialize,
+{
+    let wire = serde_json::to_value(wire).map_err(encode_error)?;
+    Ok(serde_json::json!({ CUSTOM_META_KEY: wire }))
+}
+
+/// The details record carried inside the module's custom metadata, if this SDK put one there.
+pub(super) fn from_custom_meta<W>(meta: &serde_json::Value) -> Option<W>
+where
+    W: serde::de::DeserializeOwned,
+{
+    let wire = meta.as_object()?.get(CUSTOM_META_KEY)?;
+    serde_json::from_value(wire.clone()).ok()
+}
+
 /// [`LightningRoute`] as stored.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -383,6 +405,31 @@ mod tests {
         assert_eq!(
             decode_receive_details(&json).expect("decode"),
             receive_details()
+        );
+    }
+
+    #[test]
+    fn custom_meta_round_trips_through_from_custom_meta() {
+        let wire = LnSendDetailsWire::from(&send_details());
+        let meta = custom_meta(&wire).expect("encode");
+        assert_eq!(from_custom_meta::<LnSendDetailsWire>(&meta), Some(wire));
+    }
+
+    #[test]
+    fn from_custom_meta_is_none_when_absent_or_malformed() {
+        assert_eq!(
+            from_custom_meta::<LnSendDetailsWire>(&serde_json::Value::Null),
+            None
+        );
+        assert_eq!(
+            from_custom_meta::<LnSendDetailsWire>(&serde_json::json!({"other": 1})),
+            None
+        );
+        assert_eq!(
+            from_custom_meta::<LnSendDetailsWire>(
+                &serde_json::json!({ CUSTOM_META_KEY: "not the right shape" })
+            ),
+            None
         );
     }
 

--- a/rust/fedimint-sdk/src/lightning/wire.rs
+++ b/rust/fedimint-sdk/src/lightning/wire.rs
@@ -83,6 +83,11 @@ pub(super) struct LnSendDetailsWire {
     pub(super) total_msats: u64,
     pub(super) route: RouteWire,
     pub(super) created_at: u64,
+    /// v1 only: the gateway's share of `fee_msats` at quote time, so a record rebuilt from the
+    /// module's log can back it out when the module settled the payment internally after all.
+    /// Not part of the public record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) gateway_fee_msats: Option<u64>,
 }
 
 impl From<&LnSendDetails> for LnSendDetailsWire {
@@ -94,6 +99,7 @@ impl From<&LnSendDetails> for LnSendDetailsWire {
             total_msats: details.total.msats(),
             route: RouteWire::from(&details.route),
             created_at: details.created_at.epoch_millis(),
+            gateway_fee_msats: None,
         }
     }
 }
@@ -358,6 +364,40 @@ mod tests {
         let details = send_details();
         let json = serde_json::to_string(&LnSendDetailsWire::from(&details)).expect("encode");
         assert_eq!(decode_send_details(&json).expect("decode"), details);
+    }
+
+    #[test]
+    fn the_send_wire_round_trips_with_and_without_the_gateway_fee() {
+        let mut wire = LnSendDetailsWire::from(&send_details());
+        wire.gateway_fee_msats = Some(50);
+        let json = serde_json::to_string(&wire).expect("encode");
+        assert!(json.contains("gateway_fee_msats"), "{json}");
+        let decoded: LnSendDetailsWire = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, wire);
+
+        wire.gateway_fee_msats = None;
+        let json = serde_json::to_string(&wire).expect("encode");
+        assert!(!json.contains("gateway_fee_msats"), "{json}");
+        let decoded: LnSendDetailsWire = serde_json::from_str(&json).expect("decode");
+        assert_eq!(decoded, wire);
+    }
+
+    #[test]
+    fn a_send_record_without_the_gateway_fee_field_decodes() {
+        // An older build's record, written before this field existed: the key is absent
+        // entirely, not just `null`.
+        let mut value =
+            serde_json::to_value(LnSendDetailsWire::from(&send_details())).expect("encode");
+        value
+            .as_object_mut()
+            .expect("an object")
+            .remove("gateway_fee_msats");
+        let wire: LnSendDetailsWire = serde_json::from_value(value).expect("decode");
+        assert_eq!(wire.gateway_fee_msats, None);
+        assert_eq!(
+            LnSendDetails::try_from(wire).expect("decode"),
+            send_details()
+        );
     }
 
     #[test]

--- a/rust/fedimint-sdk/src/modules.rs
+++ b/rust/fedimint-sdk/src/modules.rs
@@ -41,17 +41,8 @@ pub(crate) fn module_inits() -> ClientModuleInitRegistry {
 ///
 /// The client defaults are taken with the environment's overrides applied, which is what lets a
 /// test federation redirect a guardian's advertised URL without the SDK growing a knob for it.
-pub(crate) async fn connectors() -> Result<ConnectorRegistry> {
-    ConnectorRegistry::build_from_client_env()
-        .map_err(|err| {
-            Error::new(
-                ErrorCode::Internal,
-                format!("unusable transport settings: {err}"),
-            )
-        })?
-        .bind()
-        .await
-        .map_err(|err| Error::new(ErrorCode::Internal, format!("no usable transport: {err}")))
+pub(crate) async fn connectors() -> ConnectorRegistry {
+    ConnectorRegistry::build_from_client_env().bind().await
 }
 
 /// The generation a module kind declares, or `None` for a kind that declares none.

--- a/rust/fedimint-sdk/src/operation.rs
+++ b/rust/fedimint-sdk/src/operation.rs
@@ -763,13 +763,13 @@ impl AnyOperation {
     /// reading the state will succeed.
     // "`Observable` means supported: the matching `as_*` accessor will hand back a typed handle"
     // is accurate once every kind in `kinds` has a driver arm in `driver_for` below, filled in by
-    // T7, T8, T9 and T12. Until then, `support_of` still answers `Observable` for every kind whose
-    // arm is `None`: the record's kind and schema version are all it looks at, and neither says
-    // whether a driver has been written yet. That is six kinds in a test build, where `ECASH_SEND`
-    // has its own probe arm and note below, and seven in any other build, where that arm is `None`
-    // too. This is not a bug in the accessor, which is honest about what it can do, but a
-    // temporary gap between what `support` promises and what a build this incomplete can deliver;
-    // it closes as each task above lands its arm.
+    // T7, T9 and T12 (T8 filled in the two lightning arms). Until then, `support_of` still answers
+    // `Observable` for every kind whose arm is `None`: the record's kind and schema version are
+    // all it looks at, and neither says whether a driver has been written yet. That is four kinds
+    // in a test build, where `ECASH_SEND` has its own probe arm, and five in any other build,
+    // where that arm is `None` too. This is not a bug in the accessor, which is honest about what
+    // it can do, but a temporary gap between what `support` promises and what a build this
+    // incomplete can deliver; it closes as each task above lands its arm.
     pub fn support(&self) -> OperationSupport {
         self.inner.support
     }
@@ -1411,9 +1411,9 @@ pub(crate) enum ErasedDriver {
 pub(crate) fn driver_for(kind: &str) -> Option<ErasedDriver> {
     match kind {
         // One arm per tag in `kinds`, filled in by the task that writes the facade owning that
-        // kind: ecash and lightning in T7-T8, on-chain in T9, recovery in T12. Until an arm is
-        // filled in this build cannot observe that kind, which is a real answer rather than a
-        // gap: the record is still found, still listed, and still says what it is.
+        // kind: ecash in T7, on-chain in T9, recovery in T12. Until an arm is filled in this
+        // build cannot observe that kind, which is a real answer rather than a gap: the record
+        // is still found, still listed, and still says what it is.
         //
         // The probe stands in for the ecash-send driver so that the type-erased accessors are
         // exercised end to end before any facade exists; T7 replaces the pair of arms below with
@@ -1423,8 +1423,12 @@ pub(crate) fn driver_for(kind: &str) -> Option<ErasedDriver> {
         #[cfg(not(test))]
         kinds::ECASH_SEND => None,
         kinds::ECASH_RECEIVE => None,
-        kinds::LN_SEND => None,
-        kinds::LN_RECEIVE => None,
+        kinds::LN_SEND => Some(ErasedDriver::LnSend(Arc::new(
+            crate::lightning::LnSendDriver,
+        ))),
+        kinds::LN_RECEIVE => Some(ErasedDriver::LnReceive(Arc::new(
+            crate::lightning::LnReceiveDriver,
+        ))),
         kinds::ONCHAIN_SEND => None,
         kinds::ONCHAIN_RECEIVE => None,
         kinds::RECOVERY => None,
@@ -1440,17 +1444,15 @@ pub(crate) fn driver_for(kind: &str) -> Option<ErasedDriver> {
 /// *module* kind and one module produces several of the SDK's kinds: the facade that owns the
 /// module is the only thing that can tell them apart.
 pub(crate) fn backfillers() -> Vec<Arc<dyn Backfiller>> {
-    // One entry per facade that owns a module kind, added by the task that writes the facade:
-    // ecash and lightning in T7-T8, on-chain in T9. The probe entry is the engine's own fixture
-    // and exists only in a test build.
+    // One entry per facade that owns a module kind: lightning here, ecash in T7, on-chain in T9.
+    // The probe entry is the engine's own fixture and exists only in a test build.
     #[cfg(test)]
-    {
-        vec![Arc::new(ProbeBackfiller) as Arc<dyn Backfiller>]
-    }
+    return vec![
+        Arc::new(ProbeBackfiller) as Arc<dyn Backfiller>,
+        Arc::new(crate::lightning::LnBackfiller),
+    ];
     #[cfg(not(test))]
-    {
-        Vec::new()
-    }
+    vec![Arc::new(crate::lightning::LnBackfiller)]
 }
 
 /// A driver for a real kind, so the type-erased accessors can be exercised end to end.
@@ -2286,13 +2288,13 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn a_kind_this_build_has_no_driver_for_yields_no_handle() {
-        let any = any_operation(kinds::LN_SEND, "lnv2", READABLE_STATE_SCHEMA).await;
-        assert_eq!(any.kind(), OperationKind::LnSend);
+        let any = any_operation(kinds::ONCHAIN_SEND, "walletv2", READABLE_STATE_SCHEMA).await;
+        assert_eq!(any.kind(), OperationKind::OnchainSend);
         // `support` is about the record rather than about what this build can observe, so it
         // still says observable; the accessor is where a kind no facade has written a driver for
         // yet answers `None`, in exactly the way a kind mismatch does.
         assert_eq!(any.support(), OperationSupport::Observable);
-        assert!(any.as_ln_send().is_none());
+        assert!(any.as_onchain_send().is_none());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2431,30 +2433,37 @@ mod tests {
 
     #[test]
     fn this_build_observes_the_kinds_it_has_a_driver_for_and_no_others() {
-        // The one arm T6 fills in is the probe fixture standing in for the ecash-send driver
-        // T7 writes. Every other kind is a record this build can find, list and label but not
-        // observe, which the accessors report as `None` rather than as a failure.
+        // The probe fixture stands in for the ecash-send driver T7 writes; the two lightning
+        // arms are real. Every other kind is a record this build can find, list and label but
+        // not observe, which the accessors report as `None` rather than as a failure.
         assert!(matches!(
             driver_for(kinds::ECASH_SEND),
             Some(ErasedDriver::EcashSend(_))
         ));
-        assert!(driver_for(kinds::LN_SEND).is_none());
+        assert!(matches!(
+            driver_for(kinds::LN_SEND),
+            Some(ErasedDriver::LnSend(_))
+        ));
+        assert!(matches!(
+            driver_for(kinds::LN_RECEIVE),
+            Some(ErasedDriver::LnReceive(_))
+        ));
+        assert!(driver_for(kinds::ONCHAIN_SEND).is_none());
         assert!(driver_for(kinds::RECOVERY).is_none());
         // A tag this build does not know is not a lookup failure either.
         assert!(driver_for("something_else").is_none());
         // Backfillers are a list rather than a lookup: one is asked about an upstream module
         // kind, and one module kind can produce several of the SDK's kinds.
         let backfillers = backfillers();
-        assert_eq!(backfillers.len(), 1);
-        assert!(
-            backfillers[0]
-                .backfill("probe_module", &serde_json::Value::Null, 0)
+        assert_eq!(backfillers.len(), 2);
+        assert!(backfillers.iter().any(|b| {
+            b.backfill("probe_module", &serde_json::Value::Null, 0)
                 .is_some()
-        );
+        }));
         assert!(
-            backfillers[0]
-                .backfill("mint", &serde_json::Value::Null, 0)
-                .is_none()
+            backfillers
+                .iter()
+                .all(|b| b.backfill("mint", &serde_json::Value::Null, 0).is_none())
         );
     }
 

--- a/rust/fedimint-sdk/src/operation.rs
+++ b/rust/fedimint-sdk/src/operation.rs
@@ -1346,10 +1346,16 @@ pub(crate) trait Backfiller: MaybeSend + MaybeSync + 'static {
     /// What the SDK would have written for this entry, or `None` if this backfiller does not
     /// recognise it.
     ///
-    /// `module_kind` is `OperationLogEntry::operation_module_kind`, and `meta` is the entry's
-    /// own JSON, read with `try_meta` so that a shape this build does not know is a `None` here
-    /// rather than a panic.
-    fn backfill(&self, module_kind: &str, meta: &serde_json::Value) -> Option<Backfilled>;
+    /// `module_kind` is `OperationLogEntry::operation_module_kind`, `meta` is the entry's own
+    /// JSON, read with `try_meta` so that a shape this build does not know is a `None` here
+    /// rather than a panic, and `created_at` is the client's own creation time in milliseconds,
+    /// for the details records that carry one.
+    fn backfill(
+        &self,
+        module_kind: &str,
+        meta: &serde_json::Value,
+        created_at: u64,
+    ) -> Option<Backfilled>;
 }
 
 /// What a [`Backfiller`] recovered from a log entry.
@@ -1508,7 +1514,12 @@ pub(crate) struct ProbeBackfiller;
 
 #[cfg(test)]
 impl Backfiller for ProbeBackfiller {
-    fn backfill(&self, module_kind: &str, meta: &serde_json::Value) -> Option<Backfilled> {
+    fn backfill(
+        &self,
+        module_kind: &str,
+        meta: &serde_json::Value,
+        _created_at: u64,
+    ) -> Option<Backfilled> {
         (module_kind == "probe_module").then(|| Backfilled {
             kind: kinds::ECASH_SEND,
             details: meta.to_string(),
@@ -1659,30 +1670,80 @@ impl OperationInner {
     ///
     /// [`Storage`](crate::ErrorCode::Storage).
     pub(crate) async fn record_phase(&self, phase: u32) -> Result<()> {
-        use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
-
-        let db = self.federation.db();
-        let id = self.id;
-        db.autocommit(
-            |dbtx, _| {
-                Box::pin(async move {
-                    let key = crate::db::OperationRecordKey(id);
-                    let Some(mut record) = dbtx.get_value(&key).await else {
-                        return Ok(());
-                    };
-                    if record.phase.is_some_and(|reached| reached >= phase) {
-                        return Ok(());
-                    }
-                    record.phase = Some(phase);
-                    dbtx.insert_entry(&key, &record).await;
-                    Ok::<(), core::convert::Infallible>(())
-                })
-            },
-            Some(100),
-        )
-        .await
-        .map_err(crate::db::storage_error)
+        record_phase_in(&self.federation.db(), self.id, phase).await
     }
+}
+
+/// [`OperationInner::record_phase`] for a caller that holds a database handle rather than an
+/// operation handle: a driver's stream, which outlives the borrow it was created from.
+///
+/// # Errors
+///
+/// [`Storage`](crate::ErrorCode::Storage).
+pub(crate) async fn record_phase_in(
+    db: &fedimint_core::db::Database,
+    id: UpstreamOperationId,
+    phase: u32,
+) -> Result<()> {
+    use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+
+    db.autocommit(
+        |dbtx, _| {
+            Box::pin(async move {
+                let key = crate::db::OperationRecordKey(id);
+                let Some(mut record) = dbtx.get_value(&key).await else {
+                    return Ok(());
+                };
+                if record.phase.is_some_and(|reached| reached >= phase) {
+                    return Ok(());
+                }
+                record.phase = Some(phase);
+                dbtx.insert_entry(&key, &record).await;
+                Ok::<(), core::convert::Infallible>(())
+            })
+        },
+        Some(100),
+    )
+    .await
+    .map_err(crate::db::storage_error)
+}
+
+/// Replaces the details JSON of one record, for a documented fill-in-later field.
+///
+/// The one legitimate use is a field that goes from absent to present once
+/// ([`OperationDetails`]'s placement rule); the caller passes the whole record re-encoded, and
+/// a record that has gone is not an error, exactly as in [`record_phase_in`].
+///
+/// # Errors
+///
+/// [`Storage`](crate::ErrorCode::Storage).
+pub(crate) async fn write_details_in(
+    db: &fedimint_core::db::Database,
+    id: UpstreamOperationId,
+    details: String,
+) -> Result<()> {
+    use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+
+    db.autocommit(
+        |dbtx, _| {
+            let details = details.clone();
+            Box::pin(async move {
+                let key = crate::db::OperationRecordKey(id);
+                let Some(mut record) = dbtx.get_value(&key).await else {
+                    return Ok(());
+                };
+                if record.details == details {
+                    return Ok(());
+                }
+                record.details = details;
+                dbtx.insert_entry(&key, &record).await;
+                Ok::<(), core::convert::Infallible>(())
+            })
+        },
+        Some(100),
+    )
+    .await
+    .map_err(crate::db::storage_error)
 }
 
 /// The shared state behind a type-erased operation handle.
@@ -2387,12 +2448,12 @@ mod tests {
         assert_eq!(backfillers.len(), 1);
         assert!(
             backfillers[0]
-                .backfill("probe_module", &serde_json::Value::Null)
+                .backfill("probe_module", &serde_json::Value::Null, 0)
                 .is_some()
         );
         assert!(
             backfillers[0]
-                .backfill("mint", &serde_json::Value::Null)
+                .backfill("mint", &serde_json::Value::Null, 0)
                 .is_none()
         );
     }
@@ -2990,5 +3051,35 @@ mod tests {
             operation.inner.reload().await.expect("record").phase,
             Some(3)
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn details_can_be_rewritten_once_a_later_fact_is_known() {
+        let db = crate::db::federation_namespace(&crate::db::in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let id = UpstreamOperationId([9u8; 32]);
+        let operation = federation
+            .create_operation(
+                id,
+                kinds::ECASH_SEND,
+                "mint",
+                &serde_json::json!({"settled_at": null}),
+                Arc::new(ProbeEcashSendDriver) as Arc<dyn Driver<EcashSendState>>,
+            )
+            .await
+            .expect("create");
+
+        write_details_in(&db, id, r#"{"settled_at":7}"#.to_owned())
+            .await
+            .expect("rewrite");
+        assert_eq!(
+            operation.inner().reload().await.expect("reload").details,
+            r#"{"settled_at":7}"#
+        );
+
+        // A record that has gone is not a failure to write.
+        write_details_in(&db, UpstreamOperationId([10u8; 32]), "{}".to_owned())
+            .await
+            .expect("no record is fine");
     }
 }

--- a/rust/fedimint-sdk/src/sdk.rs
+++ b/rust/fedimint-sdk/src/sdk.rs
@@ -1250,7 +1250,7 @@ impl SdkBuilder {
         // answer even when every federation goes on to quarantine itself.
         let inner = Arc::new(SdkInner {
             db,
-            connectors: crate::modules::connectors().await?,
+            connectors: crate::modules::connectors().await,
             module_inits: crate::modules::module_inits(),
             root_secret: RootSecret::StandardDoubleDerive(
                 Bip39RootSecretStrategy::<12>::to_root_secret(mnemonic.inner()),
@@ -1681,12 +1681,7 @@ impl SdkInner {
         &self,
         invite: &InviteCode,
     ) -> Result<fedimint_core::config::ClientConfig> {
-        let mut builder = Client::builder().await.map_err(|err| {
-            crate::Error::new(
-                crate::ErrorCode::Internal,
-                format!("no client builder: {err}"),
-            )
-        })?;
+        let mut builder = Client::builder().await;
         builder.with_module_inits(self.module_inits.clone());
         let preview = fedimint_core::runtime::timeout(
             CONTACT_TIMEOUT,
@@ -1710,12 +1705,7 @@ impl SdkInner {
 
     /// Opens the client for a federation the storage already holds.
     pub(crate) async fn open_client(&self, id: &config::FederationId) -> Result<ClientHandleArc> {
-        let mut builder = Client::builder().await.map_err(|err| {
-            crate::Error::new(
-                crate::ErrorCode::Internal,
-                format!("no client builder: {err}"),
-            )
-        })?;
+        let mut builder = Client::builder().await;
         builder.with_module_inits(self.module_inits.clone());
         let db = self
             .db
@@ -1743,12 +1733,7 @@ impl SdkInner {
         id: &config::FederationId,
         record: &FederationRecord,
     ) -> Result<ClientHandleArc> {
-        let mut builder = Client::builder().await.map_err(|err| {
-            crate::Error::new(
-                crate::ErrorCode::Internal,
-                format!("no client builder: {err}"),
-            )
-        })?;
+        let mut builder = Client::builder().await;
         builder.with_module_inits(self.module_inits.clone());
         let preview = fedimint_core::runtime::timeout(
             CONTACT_TIMEOUT,

--- a/rust/fedimint-sdk/src/types/ids.rs
+++ b/rust/fedimint-sdk/src/types/ids.rs
@@ -164,11 +164,6 @@ impl GatewayId {
     pub(crate) fn from_upstream(id: PublicKey) -> Self {
         Self { id }
     }
-
-    /// The wrapped key, for looking a gateway up again by id.
-    pub(crate) fn inner(&self) -> PublicKey {
-        self.id
-    }
 }
 
 impl core::fmt::Display for GatewayId {

--- a/rust/fedimint-sdk/src/types/ids.rs
+++ b/rust/fedimint-sdk/src/types/ids.rs
@@ -164,6 +164,11 @@ impl GatewayId {
     pub(crate) fn from_upstream(id: PublicKey) -> Self {
         Self { id }
     }
+
+    /// The wrapped key, for looking a gateway up again by id.
+    pub(crate) fn inner(&self) -> PublicKey {
+        self.id
+    }
 }
 
 impl core::fmt::Display for GatewayId {

--- a/rust/fedimint-sdk/src/types/invoice.rs
+++ b/rust/fedimint-sdk/src/types/invoice.rs
@@ -90,6 +90,11 @@ impl Bolt11Invoice {
         Self { invoice }
     }
 
+    /// The wrapped invoice, for the lightning facade's route-hint and payee checks.
+    pub(crate) fn inner(&self) -> &lightning_invoice::Bolt11Invoice {
+        &self.invoice
+    }
+
     /// The network this invoice's BOLT11 currency names, or `None` for a
     /// currency this crate's [`Network`] cannot represent.
     ///

--- a/rust/fedimint-sdk/src/types/invoice.rs
+++ b/rust/fedimint-sdk/src/types/invoice.rs
@@ -13,7 +13,7 @@ use crate::{Error, ErrorCode};
 /// field. It round-trips through [`Display`](core::fmt::Display) (recovering
 /// the original bolt11 string) and [`FromStr`](core::str::FromStr) with a
 /// validating parse.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct Bolt11Invoice {
     invoice: lightning_invoice::Bolt11Invoice,
 }
@@ -173,6 +173,27 @@ impl core::str::FromStr for Bolt11Invoice {
     }
 }
 
+impl PartialEq for Bolt11Invoice {
+    /// Equal when the bolt11 encodings are equal. The in-memory form is not canonical: an
+    /// invoice built by a module and the same invoice parsed back from its string differ in
+    /// fields BOLT11 does not encode (a route hint's HTLC bounds, for instance), while the
+    /// string, which is what a payer receives, is the same.
+    fn eq(&self, other: &Self) -> bool {
+        self.to_string() == other.to_string()
+    }
+}
+
+impl Eq for Bolt11Invoice {}
+
+impl core::hash::Hash for Bolt11Invoice {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: core::hash::Hasher,
+    {
+        self.to_string().hash(state);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,5 +335,53 @@ mod tests {
                 .expect_err("a malformed invoice is rejected");
             assert_eq!(error.code, crate::ErrorCode::InvalidInput);
         }
+    }
+
+    #[test]
+    fn a_built_invoice_equals_its_parsed_twin() {
+        // A route hint's hop leaves `htlc_minimum_msat` and `htlc_maximum_msat` unset here,
+        // exactly as an issuing module does; BOLT11 does not encode either field, and
+        // `lightning-invoice` fills both in with defaults on parse, so the built invoice and its
+        // parsed twin differ in memory although they encode identically.
+        use std::collections::HashSet;
+
+        use fedimint_core::bitcoin::hashes::{Hash, sha256};
+        use fedimint_core::secp256k1::{PublicKey, Secp256k1, SecretKey};
+        use lightning_invoice::{
+            InvoiceBuilder, PaymentSecret, RouteHint, RouteHintHop, RoutingFees,
+        };
+
+        let secp = Secp256k1::new();
+        let private_key = SecretKey::from_slice(&[0x11; 32]).expect("a valid secret key");
+        let hop = RouteHintHop {
+            src_node_id: PublicKey::from_secret_key(&secp, &private_key),
+            short_channel_id: 42,
+            fees: RoutingFees {
+                base_msat: 1,
+                proportional_millionths: 1,
+            },
+            cltv_expiry_delta: 144,
+            htlc_minimum_msat: None,
+            htlc_maximum_msat: None,
+        };
+        let built = InvoiceBuilder::new(Currency::Regtest)
+            .amount_milli_satoshis(1_000)
+            .payment_hash(sha256::Hash::hash(&[0x22; 32]))
+            .payment_secret(PaymentSecret([0x33; 32]))
+            .description("route hint".to_owned())
+            .duration_since_epoch(core::time::Duration::from_secs(1_700_000_000))
+            .min_final_cltv_expiry_delta(144)
+            .private_route(RouteHint(vec![hop]))
+            .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
+            .expect("a valid invoice");
+        let built = Bolt11Invoice::from_upstream(built);
+        let parsed: Bolt11Invoice = built.to_string().parse().expect("the encoding parses back");
+
+        assert_eq!(built, parsed);
+
+        let mut unique = HashSet::new();
+        unique.insert(built);
+        unique.insert(parsed);
+        assert_eq!(unique.len(), 1);
     }
 }

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -65,10 +65,17 @@ fn invite_from_client_dir() -> Option<String> {
 }
 
 /// The faucet's `GET /connect-string`, for a setup that exposes only that.
-///
-/// A four-line HTTP/1.0 request rather than a client crate: this is the one network call the test
-/// harness makes, and it is not worth a dependency in the lockfile the crate ships.
 fn invite_from_faucet() -> Option<String> {
+    faucet("GET", "/connect-string", "")
+}
+
+/// One request to devimint's faucet, which is also this suite's counterparty on the lightning
+/// network: `POST /pay` pays an invoice from a node outside the federation, `POST /invoice`
+/// issues one.
+///
+/// A hand-written HTTP/1.0 exchange rather than a client crate: these are the only network calls
+/// the harness makes, and they are not worth a dependency in the lockfile the crate ships.
+fn faucet(method: &str, path: &str, body: &str) -> Option<String> {
     use std::net::ToSocketAddrs;
     use std::time::Duration;
 
@@ -81,18 +88,28 @@ fn invite_from_faucet() -> Option<String> {
         .find_map(|addr| {
             std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(5)).ok()
         })?;
+    // Paying an invoice waits for the payment to settle, which can take a while on a fresh
+    // channel.
     stream
-        .set_read_timeout(Some(Duration::from_secs(10)))
+        .set_read_timeout(Some(Duration::from_secs(120)))
         .ok()?;
     stream
         .set_write_timeout(Some(Duration::from_secs(10)))
         .ok()?;
-    stream
-        .write_all(b"GET /connect-string HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n")
-        .ok()?;
+    let request = format!(
+        "{method} {path} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\
+         Content-Type: text/plain\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).ok()?;
     let mut response = String::new();
     stream.read_to_string(&mut response).ok()?;
-    let (_headers, body) = response.split_once("\r\n\r\n")?;
+    let (headers, body) = response.split_once("\r\n\r\n")?;
+    let status = headers.lines().next()?;
+    assert!(
+        status.contains(" 200 "),
+        "faucet {method} {path} answered {status}: {body}"
+    );
     Some(body.to_owned())
 }
 
@@ -326,4 +343,354 @@ async fn mixed_generation_federation_is_rejected() {
     );
 
     sdk.shutdown().await.expect("the instance shuts down");
+}
+
+/// Builds an instance on a fresh directory and joins devimint's federation.
+///
+/// The directory is returned so it outlives the instance; a caller that reopens the same storage
+/// keeps it and builds again over `path`.
+async fn joined(devimint: &Devimint) -> (tempfile::TempDir, String, Sdk, fedimint_sdk::Federation) {
+    let invite: fedimint_sdk::InviteCode = devimint
+        .invite
+        .parse()
+        .expect("devimint's invite code parses");
+    let storage = tempfile::tempdir().expect("a temporary directory");
+    let path = storage.path().to_str().expect("a utf-8 path").to_owned();
+    let sdk = Sdk::builder()
+        .storage(Storage::at(&path).expect("a valid path"))
+        .build()
+        .await
+        .expect("an instance opens on a fresh directory");
+    let federation = sdk.join(&invite).await.expect("the federation joins");
+    (storage, path, sdk, federation)
+}
+
+/// Funds the wallet by having the faucet pay an invoice this SDK issued, and returns what landed.
+async fn fund(lightning: &fedimint_sdk::Lightning, msats: u64) -> fedimint_sdk::Amount {
+    let receive = lightning
+        .receive(fedimint_sdk::Amount::from_msats(msats), "funding")
+        .await
+        .expect("an invoice is issued");
+    let paid = faucet("POST", "/pay", &receive.invoice.to_string());
+    assert!(paid.is_some(), "the faucet pays the invoice");
+    let state = receive
+        .operation
+        .await_final()
+        .await
+        .expect("the receive settles");
+    assert_eq!(state, fedimint_sdk::LnReceiveState::Claimed);
+    receive
+        .operation
+        .details()
+        .await
+        .expect("details")
+        .net_credit
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightning_receive_is_paid_by_the_faucet_and_survives_a_restart() {
+    use fedimint_sdk::{Amount, LnReceiveState, OperationKind};
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    let (_storage, path, sdk, federation) = joined(&devimint).await;
+    let lightning = federation
+        .lightning()
+        .expect("devimint runs a lightning module");
+
+    let receive = lightning
+        .receive(Amount::from_msats(100_000), "coffee")
+        .await
+        .expect("an invoice is issued");
+    let id = receive.operation.id();
+    let details = receive.operation.details().await.expect("details");
+    assert_eq!(details.invoice, receive.invoice);
+    assert_eq!(details.description, "coffee");
+    assert_eq!(details.requested_amount, Amount::from_msats(100_000));
+    assert_eq!(details.invoice_amount, Amount::from_msats(100_000));
+    assert_eq!(
+        details.net_credit.checked_add(details.fee),
+        Some(details.invoice_amount)
+    );
+    assert!(details.gateway_id.is_some(), "a gateway took the invoice");
+    assert!(details.expires_at > details.created_at);
+    assert_eq!(receive.invoice.amount(), Some(Amount::from_msats(100_000)));
+    assert_eq!(receive.invoice.description(), "coffee");
+
+    let mut updates = receive.operation.updates();
+    let first = updates.next().await.expect("a state").expect("a state");
+    assert!(
+        matches!(
+            first,
+            LnReceiveState::Created | LnReceiveState::WaitingForPayment
+        ),
+        "{first:?}"
+    );
+
+    assert!(faucet("POST", "/pay", &receive.invoice.to_string()).is_some());
+    let last = receive.operation.await_final().await.expect("settles");
+    assert_eq!(last, LnReceiveState::Claimed);
+    assert_eq!(
+        federation.balance().await.expect("balance"),
+        details.net_credit
+    );
+    // A subscription opened before the payment ends cleanly after it.
+    let mut seen = vec![first];
+    while let Some(state) = updates.next().await.expect("a state") {
+        seen.push(state);
+    }
+    assert_eq!(seen.last(), Some(&LnReceiveState::Claimed));
+
+    // Reattaching by id, same process.
+    let any = federation
+        .operation(&id)
+        .await
+        .expect("lookup")
+        .expect("recorded");
+    assert_eq!(any.kind(), OperationKind::LnReceive);
+    let typed = any.as_ln_receive().expect("a typed handle");
+    assert_eq!(typed.details().await.expect("details"), details);
+    assert_eq!(typed.state().await.expect("state"), LnReceiveState::Claimed);
+
+    // And after a restart.
+    let federation_id = federation.id();
+    sdk.shutdown().await.expect("shuts down");
+    drop(lightning);
+    drop(federation);
+    drop(receive);
+    drop(sdk);
+    let reopened = Sdk::builder()
+        .storage(Storage::at(&path).expect("a valid path"))
+        .build()
+        .await
+        .expect("reopens");
+    let federation = reopened.federation(&federation_id).expect("still there");
+    let any = federation
+        .operation(&id)
+        .await
+        .expect("lookup")
+        .expect("still recorded");
+    let typed = any.as_ln_receive().expect("a typed handle");
+    assert_eq!(typed.details().await.expect("details"), details);
+    assert_eq!(typed.state().await.expect("state"), LnReceiveState::Claimed);
+    assert_eq!(
+        federation.balance().await.expect("balance"),
+        details.net_credit
+    );
+    reopened.shutdown().await.expect("shuts down");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightning_send_pays_an_invoice_from_outside_the_federation() {
+    use fedimint_sdk::{Amount, LightningRoute, LnSendState, OperationKind};
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    let (_storage, _path, sdk, federation) = joined(&devimint).await;
+    let lightning = federation
+        .lightning()
+        .expect("devimint runs a lightning module");
+    let funded = fund(&lightning, 200_000).await;
+
+    let invoice: fedimint_sdk::Bolt11Invoice = faucet("POST", "/invoice", "50000")
+        .expect("the faucet issues an invoice")
+        .trim()
+        .parse()
+        .expect("a bolt11 invoice");
+    let quote = lightning.quote(&invoice).await.expect("a quote");
+    assert_eq!(quote.invoice_amount(), Amount::from_msats(50_000));
+    assert_eq!(
+        quote.invoice_amount().checked_add(quote.fee()),
+        Some(quote.total())
+    );
+    let breakdown = quote.fee_breakdown();
+    let summed = [
+        breakdown.gateway,
+        breakdown.lightning_module,
+        breakdown.primary_module,
+        breakdown.dust,
+    ]
+    .into_iter()
+    .try_fold(Amount::from_msats(0), Amount::checked_add);
+    assert_eq!(summed, Some(quote.fee()));
+    assert!(
+        matches!(quote.route(), LightningRoute::Gateway { .. }),
+        "an outside payee goes through a gateway"
+    );
+    assert!(quote.expires_at() > fedimint_sdk::Timestamp::from_epoch_millis(0));
+    let total = quote.total();
+    let fee = quote.fee();
+    let route = quote.route();
+
+    let operation = lightning.send(quote).await.expect("the payment starts");
+    let id = operation.id();
+    let details = operation.details().await.expect("details");
+    assert_eq!(details.invoice, invoice);
+    assert_eq!(details.invoice_amount, Amount::from_msats(50_000));
+    assert_eq!(details.fee, fee);
+    assert_eq!(details.total, total);
+    assert_eq!(details.route, route);
+
+    let last = operation.await_final().await.expect("settles");
+    match last {
+        LnSendState::Success {
+            preimage,
+            fee: reported_fee,
+            route: reported_route,
+        } => {
+            assert_eq!(reported_fee, fee);
+            assert_eq!(reported_route, route);
+            assert_eq!(preimage.to_string().len(), 64);
+        }
+        other => panic!("expected Success, got {other:?}"),
+    }
+    assert_eq!(
+        federation.balance().await.expect("balance"),
+        funded.checked_sub(total).expect("the total was debited")
+    );
+
+    let any = federation
+        .operation(&id)
+        .await
+        .expect("lookup")
+        .expect("recorded");
+    assert_eq!(any.kind(), OperationKind::LnSend);
+    let typed = any.as_ln_send().expect("a typed handle");
+    assert_eq!(typed.details().await.expect("details"), details);
+    assert!(matches!(
+        typed.state().await.expect("state"),
+        LnSendState::Success { .. }
+    ));
+    sdk.shutdown().await.expect("shuts down");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightning_quote_refuses_what_cannot_be_paid() {
+    use fedimint_sdk::{Amount, Network};
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    let (_storage, _path, sdk, federation) = joined(&devimint).await;
+    let lightning = federation
+        .lightning()
+        .expect("devimint runs a lightning module");
+
+    // A mainnet invoice with no amount: the amount is refused first.
+    let amountless: fedimint_sdk::Bolt11Invoice = "lnbc1pj48ugqdq0dehjqctdda6kuaqpp5yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3qsp5xvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxves9qrsgqcqzyswm4efuu52zkzgrcc35fra9fmvj7s9ppxmej85s83hjkh7crcy9vqlradwalsmq40knf3552panjvlhjlrfazmvs86krxuaygut8v30sq0y0422".parse().expect("valid");
+    assert_eq!(
+        lightning
+            .quote(&amountless)
+            .await
+            .expect_err("refused")
+            .code,
+        ErrorCode::AmountlessInvoice
+    );
+
+    // A mainnet invoice with an amount: the network is refused, with details.
+    let mainnet: fedimint_sdk::Bolt11Invoice = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqqqqqqqqqqqpqsq67gye39hfg3zd8rgc80k32tvy9xk2xunwm5lzexnvpx6fd77en8qaq424dxgt56cag2dpt359k3ssyhetktkpqh24jqnjyw6uqd08sgptq44qu".parse().expect("valid");
+    let err = lightning.quote(&mainnet).await.expect_err("refused");
+    assert_eq!(err.code, ErrorCode::NetworkMismatch);
+    match err.detail() {
+        Some(ErrorDetails::NetworkMismatch {
+            expected,
+            compatible,
+            observed_prefix,
+        }) => {
+            assert_eq!(*expected, Network::Regtest);
+            assert_eq!(compatible, &vec![Network::Bitcoin]);
+            assert_eq!(observed_prefix, "bc");
+        }
+        other => panic!("expected NetworkMismatch details, got {other:?}"),
+    }
+
+    // A fresh regtest invoice on an empty wallet: everything upstream succeeds and the balance
+    // is what refuses it, naming both numbers.
+    let invoice: fedimint_sdk::Bolt11Invoice = faucet("POST", "/invoice", "50000")
+        .expect("the faucet issues an invoice")
+        .trim()
+        .parse()
+        .expect("a bolt11 invoice");
+    let err = lightning
+        .quote(&invoice)
+        .await
+        .expect_err("nothing to pay with");
+    assert_eq!(err.code, ErrorCode::InsufficientBalance);
+    match err.detail() {
+        Some(ErrorDetails::InsufficientBalance {
+            required,
+            available,
+        }) => {
+            assert!(*required >= Amount::from_msats(50_000));
+            assert_eq!(*available, Amount::from_msats(0));
+        }
+        other => panic!("expected InsufficientBalance details, got {other:?}"),
+    }
+
+    // A zero-amount receive and an over-long description are refused before any gateway is
+    // asked.
+    assert_eq!(
+        lightning
+            .receive(Amount::from_msats(0), "nothing")
+            .await
+            .expect_err("refused")
+            .code,
+        ErrorCode::InvalidInput
+    );
+    assert_eq!(
+        lightning
+            .receive(Amount::from_msats(1_000), &"x".repeat(640))
+            .await
+            .expect_err("refused")
+            .code,
+        ErrorCode::InvalidInput
+    );
+    sdk.shutdown().await.expect("shuts down");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn lightning_send_refuses_a_quote_used_twice() {
+    use fedimint_sdk::LnSendState;
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    let (_storage, _path, sdk, federation) = joined(&devimint).await;
+    let lightning = federation
+        .lightning()
+        .expect("devimint runs a lightning module");
+    fund(&lightning, 200_000).await;
+
+    let invoice: fedimint_sdk::Bolt11Invoice = faucet("POST", "/invoice", "10000")
+        .expect("the faucet issues an invoice")
+        .trim()
+        .parse()
+        .expect("a bolt11 invoice");
+    let first = lightning.quote(&invoice).await.expect("a quote");
+    let second = lightning.quote(&invoice).await.expect("a second quote");
+    let operation = lightning.send(first).await.expect("the payment starts");
+    assert!(matches!(
+        operation.await_final().await.expect("settles"),
+        LnSendState::Success { .. }
+    ));
+    // The invoice is paid; a second quote for it is refused as already executed.
+    let err = lightning.send(second).await.expect_err("already paid");
+    assert_eq!(err.code, ErrorCode::QuoteExpired);
+    match err.detail() {
+        Some(ErrorDetails::QuoteExpired {
+            already_executed, ..
+        }) => assert!(already_executed),
+        other => panic!("expected QuoteExpired details, got {other:?}"),
+    }
+    sdk.shutdown().await.expect("shuts down");
 }

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -537,23 +537,33 @@ async fn lightning_send_pays_an_invoice_from_outside_the_federation() {
     assert_eq!(details.total, total);
     assert_eq!(details.route, route);
 
-    let last = operation.await_final().await.expect("settles");
-    match last {
-        LnSendState::Success {
-            preimage,
-            fee: reported_fee,
-            route: reported_route,
-        } => {
-            assert_eq!(reported_fee, fee);
-            assert_eq!(reported_route, route);
-            assert_eq!(preimage.to_string().len(), 64);
+    if devimint.shape == "v1" {
+        // fedimint/fedimint#8969: the v1 client strips two characters off the preimage the
+        // gateway returns, so the SDK cannot decode the success state. The payment itself goes
+        // through; only its observation fails, and the record and the reattached handle are
+        // still checked below. Remove this branch once the pin includes the fix.
+        let err = operation.await_final().await.expect_err("fedimint#8969");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert!(err.message.contains("preimage"), "{}", err.message);
+    } else {
+        let last = operation.await_final().await.expect("settles");
+        match last {
+            LnSendState::Success {
+                preimage,
+                fee: reported_fee,
+                route: reported_route,
+            } => {
+                assert_eq!(reported_fee, fee);
+                assert_eq!(reported_route, route);
+                assert_eq!(preimage.to_string().len(), 64);
+            }
+            other => panic!("expected Success, got {other:?}"),
         }
-        other => panic!("expected Success, got {other:?}"),
+        assert_eq!(
+            federation.balance().await.expect("balance"),
+            funded.checked_sub(total).expect("the total was debited")
+        );
     }
-    assert_eq!(
-        federation.balance().await.expect("balance"),
-        funded.checked_sub(total).expect("the total was debited")
-    );
 
     let any = federation
         .operation(&id)
@@ -563,10 +573,16 @@ async fn lightning_send_pays_an_invoice_from_outside_the_federation() {
     assert_eq!(any.kind(), OperationKind::LnSend);
     let typed = any.as_ln_send().expect("a typed handle");
     assert_eq!(typed.details().await.expect("details"), details);
-    assert!(matches!(
-        typed.state().await.expect("state"),
-        LnSendState::Success { .. }
-    ));
+    if devimint.shape == "v1" {
+        // Same cause as above: `state()` replays the same undecodable stream.
+        let err = typed.state().await.expect_err("fedimint#8969");
+        assert_eq!(err.code, ErrorCode::Internal);
+    } else {
+        assert!(matches!(
+            typed.state().await.expect("state"),
+            LnSendState::Success { .. }
+        ));
+    }
     sdk.shutdown().await.expect("shuts down");
 }
 
@@ -585,7 +601,7 @@ async fn lightning_quote_refuses_what_cannot_be_paid() {
         .expect("devimint runs a lightning module");
 
     // A mainnet invoice with no amount: the amount is refused first.
-    let amountless: fedimint_sdk::Bolt11Invoice = "lnbc1pj48ugqdq0dehjqctdda6kuaqpp5yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3qsp5xvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxves9qrsgqcqzyswm4efuu52zkzgrcc35fra9fmvj7s9ppxmej85s83hjkh7crcy9vqlradwalsmq40knf3552panjvlhjlrfazmvs86krxuaygut8v30sq0y0422".parse().expect("valid");
+    let amountless: fedimint_sdk::Bolt11Invoice = "lnbc1pj48ugqdq0dehjqctdda6kuaqpp5yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3qsp5xvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxves9qrsgqcqzyswm4efuu52zkzgrcc35fra9fmvj7s9ppxmej85s83hjkh7crcy9vqlradwalsmq40knf3552panjvlhjlrfazmvs86krxuaygut8v30sq0y0422".parse().expect("valid");
     assert_eq!(
         lightning
             .quote(&amountless)
@@ -669,7 +685,7 @@ async fn lightning_send_refuses_a_quote_used_twice() {
     let lightning = federation
         .lightning()
         .expect("devimint runs a lightning module");
-    fund(&lightning, 200_000).await;
+    let funded = fund(&lightning, 200_000).await;
 
     let invoice: fedimint_sdk::Bolt11Invoice = faucet("POST", "/invoice", "10000")
         .expect("the faucet issues an invoice")
@@ -679,10 +695,25 @@ async fn lightning_send_refuses_a_quote_used_twice() {
     let first = lightning.quote(&invoice).await.expect("a quote");
     let second = lightning.quote(&invoice).await.expect("a second quote");
     let operation = lightning.send(first).await.expect("the payment starts");
-    assert!(matches!(
-        operation.await_final().await.expect("settles"),
-        LnSendState::Success { .. }
-    ));
+    if devimint.shape == "v1" {
+        // fedimint/fedimint#8969: the v1 client strips two characters off the preimage the
+        // gateway returns, so `await_final` cannot decode the success state. The payment itself
+        // goes through, so the second send below is still refused as already executed; the
+        // balance drop confirms the first payment settled since `await_final` cannot.
+        let _ = operation.await_final().await.expect_err("fedimint#8969");
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+        let mut balance = federation.balance().await.expect("balance");
+        while balance >= funded && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            balance = federation.balance().await.expect("balance");
+        }
+        assert!(balance < funded, "the payment never debited the balance");
+    } else {
+        assert!(matches!(
+            operation.await_final().await.expect("settles"),
+            LnSendState::Success { .. }
+        ));
+    }
     // The invoice is paid; a second quote for it is refused as already executed.
     let err = lightning.send(second).await.expect_err("already paid");
     assert_eq!(err.code, ErrorCode::QuoteExpired);

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -387,6 +387,76 @@ async fn fund(lightning: &fedimint_sdk::Lightning, msats: u64) -> fedimint_sdk::
         .net_credit
 }
 
+/// On the lnv2 shape, leaves the LND gateway as the guardian's only lnv2 gateway, once per test
+/// process.
+///
+/// The lnv2 client picks a gateway at random from the guardians' list on purpose, and devimint's
+/// `wasm-test-setup` funds only the LND gateway's ecash, so a receive through either LDK gateway
+/// cannot be funded and a send through the faucet's own LDK gateway to the faucet's invoice is a
+/// self-payment. Removing the two LDK entries through the same admin call devimint used to add
+/// them makes the SDK's choice the funded gateway, and leaves the faucet's LDK node as the
+/// counterparty, as on the v1 shape.
+fn pin_lnv2_gateway_to_lnd(devimint: &Devimint) {
+    if devimint.shape != "v2" {
+        return;
+    }
+    static PINNED: std::sync::Once = std::sync::Once::new();
+    PINNED.call_once(|| {
+        // The wrapper always sets these when it runs a federation for these tests; a run
+        // outside it (a plain `cargo test`) never reaches this function, because every
+        // caller checks `FM_SDK_SHAPE` through `Devimint::detect` first.
+        let mint_client = std::env::var("FM_MINT_CLIENT")
+            .unwrap_or_else(|err| panic!("FM_MINT_CLIENT is not set ({err}); run under devimint"));
+        let lnd_port = std::env::var("FM_PORT_GW_LND")
+            .unwrap_or_else(|err| panic!("FM_PORT_GW_LND is not set ({err}); run under devimint"));
+        let mut words = mint_client.split_whitespace();
+        let program = words
+            .next()
+            .expect("FM_MINT_CLIENT names at least a program");
+        let base_args: Vec<&str> = words.collect();
+
+        // `--our-id 0`: the harness always runs a single guardian (`FM_FED_SIZE=1`).
+        // `pass` is the admin password devimint sets everywhere
+        // (`fedimint_testing_core::config::API_AUTH`).
+        let run_admin = |admin_args: &[&str]| -> std::process::Output {
+            std::process::Command::new(program)
+                .args(&base_args)
+                .args(["--our-id", "0", "--password", "pass"])
+                .args(admin_args)
+                .output()
+                .unwrap_or_else(|err| panic!("could not run `{program}`: {err}"))
+        };
+        let expect_success = |output: &std::process::Output, what: &str| {
+            assert!(
+                output.status.success(),
+                "{what} failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        };
+
+        let listed = run_admin(&["module", "lnv2", "gateways", "list"]);
+        expect_success(&listed, "listing the guardian's lnv2 gateways");
+        let stdout = String::from_utf8_lossy(&listed.stdout).into_owned();
+        // `serde_json` is not a dev-dependency of this crate, and the list is a JSON array of
+        // plain URL strings, so it is cheaper to pick the quoted tokens out by hand than to add
+        // one for this alone.
+        let lnd_needle = format!(":{lnd_port}/");
+        let urls: Vec<&str> = stdout
+            .split('"')
+            .filter(|token| token.starts_with("http"))
+            .collect();
+        assert!(
+            urls.iter().any(|url| url.contains(&lnd_needle)),
+            "the LND gateway is not among the guardian's lnv2 gateways: {stdout}"
+        );
+        for url in urls.into_iter().filter(|url| !url.contains(&lnd_needle)) {
+            let removed = run_admin(&["module", "lnv2", "gateways", "remove", url]);
+            expect_success(&removed, &format!("removing the lnv2 gateway {url}"));
+        }
+    });
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn lightning_receive_is_paid_by_the_faucet_and_survives_a_restart() {
     use fedimint_sdk::{Amount, LnReceiveState, OperationKind};
@@ -396,6 +466,7 @@ async fn lightning_receive_is_paid_by_the_faucet_and_survives_a_restart() {
         eprintln!("skipping: the mixed shape is covered by its own test");
         return;
     }
+    pin_lnv2_gateway_to_lnd(&devimint);
     let (_storage, path, sdk, federation) = joined(&devimint).await;
     let lightning = federation
         .lightning()
@@ -498,6 +569,7 @@ async fn lightning_send_pays_an_invoice_from_outside_the_federation() {
         eprintln!("skipping: the mixed shape is covered by its own test");
         return;
     }
+    pin_lnv2_gateway_to_lnd(&devimint);
     let (_storage, _path, sdk, federation) = joined(&devimint).await;
     let lightning = federation
         .lightning()
@@ -601,6 +673,7 @@ async fn lightning_quote_refuses_what_cannot_be_paid() {
         eprintln!("skipping: the mixed shape is covered by its own test");
         return;
     }
+    pin_lnv2_gateway_to_lnd(&devimint);
     let (_storage, _path, sdk, federation) = joined(&devimint).await;
     let lightning = federation
         .lightning()
@@ -687,6 +760,7 @@ async fn lightning_send_refuses_a_quote_used_twice() {
         eprintln!("skipping: the mixed shape is covered by its own test");
         return;
     }
+    pin_lnv2_gateway_to_lnd(&devimint);
     let (_storage, _path, sdk, federation) = joined(&devimint).await;
     let lightning = federation
         .lightning()

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -458,6 +458,12 @@ async fn lightning_receive_is_paid_by_the_faucet_and_survives_a_restart() {
     // And after a restart.
     let federation_id = federation.id();
     sdk.shutdown().await.expect("shuts down");
+    // Every handle goes before the second build, as in `stored_federation_survives_restart`: a
+    // subscriber and a reattached operation hold the federation's store open exactly as the
+    // federation handle does, and the embedded store's own lock waits for all of them.
+    drop(updates);
+    drop(typed);
+    drop(any);
     drop(lightning);
     drop(federation);
     drop(receive);


### PR DESCRIPTION
Follow-up to #377 (ref #344). The lightning facade, the first facade that moves money end to end on the operation engine.

`Lightning::quote`, `send` and `receive` run over both module generations behind one surface. A quote freezes what the user approves: the invoice amount, the gateway's charge, the federation's own fees for funding the contract and the dust, priced through the client's shared fee dry-run so the parts sum to the total exactly. Executing it reads the same inputs again and refuses on any change, and an invoice the module already paid is refused before anything is funded. A receive issues the invoice through a gateway the module selects, with the receive-side fee taken out of what lands, and persists everything a screen needs to redraw the QR code after a restart. Two drivers fold the four upstream state machines onto the two public state enums.

- v1's `Rejected` means two things depending on whether the receive was ever funded, so the phase is persisted and the answer survives a restart. lnv2's `Failure` is the same story on the send side
- a claim the federation rejects on v1 is retried under the same SDK operation. The module can only retry as a new upstream operation, so the retry's id is recorded and followed, one retry per receive, started as a task a dropped poll cannot cancel
- a quote is executed exactly or not at all, with one exception. When the module settles a gateway-quoted v1 payment inside the federation after the route re-check, the record backs out the gateway charge it knows was not taken and says the rest is the quote's estimate
- `Bolt11Invoice` equality goes by the bolt11 encoding. An invoice a module builds and the same invoice parsed back differ in fields BOLT11 does not carry
- the quoted terms ride along in the module's own metadata, so a record rebuilt from the module's log after a crash carries the exact fees, not an estimate
- lnv2 payments and invoices are funded at the terms the SDK checked, through the `send_with_terms` and `receive_with_terms` calls from fedimint/fedimint#9125. Until that lands on master the fedimint pin follows the `rust-sdk` branch upstream, whose head is that PR's tree
- two places where the diff carries an upstream limitation instead of hiding it
  - v1 hands back a preimage two characters short (fedimint/fedimint#8969), so the v1 send test asserts `Internal` where the lnv2 one asserts `Success`
  - neither module pays a `tb` invoice on testnet4 (fedimint/fedimint#9100), surfaced as `NetworkMismatch` and noted in the error docs
- the engine gains the two things the drivers needed: record writers a stream can call, and the creation time on the backfiller

## Testing

- unit tests for every mapping table, the wire records, the quote checks and arithmetic, and the drivers through the engine on a detached federation
- the devimint suite on both shapes, 8/8 each: an issued invoice paid from outside, with the credit landing and the operation readable by id before and after a restart; an outbound payment that debits exactly the quoted total and ends with a preimage on lnv2, while on v1 the test asserts the #8969 outcome; the refusals with their details; a quote used twice
- on the lnv2 shape the harness pins the guardian's gateway list to the LND gateway, because the lnv2 client shuffles gateways on purpose and `wasm-test-setup` funds only that one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QEJrgHniYSGG69T2Fcmyj

