### PR TITLE
feat(sdk-ffi): scaffold uniffi bindings crate (T4 spike)

### DIFF
--- a/js/.changeset/ffi-shape-spike.md
+++ b/js/.changeset/ffi-shape-spike.md
@@ -1,0 +1,5 @@
+---
+'@fedimint/core': patch
+---
+
+Add fedimint-sdk-ffi crate scaffold: T4 FFI shape spike prototyping separate-crate UniFFI bindings for Mnemonic.

--- a/rust/fedimint-sdk-ffi/.gitignore
+++ b/rust/fedimint-sdk-ffi/.gitignore
@@ -1,0 +1,38 @@
+# Rust related
+target
+build
+
+# Nix
+result
+result-*
+
+# Kotlin related
+.gradle
+wallet_db
+local.properties
+*.log
+*.dylib
+*.so
+*.db
+*/data/signet
+.DS_Store
+testdb
+.lsp
+.clj-kondo
+.idea/
+.editorconfig
+.kotlin/
+
+# Swift related
+/.build
+.swiftpm
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.build
+*.xcframework/
+Info.plist
+Sources/
+xcuserdata

--- a/rust/fedimint-sdk-ffi/Cargo.toml
+++ b/rust/fedimint-sdk-ffi/Cargo.toml
@@ -19,7 +19,6 @@ path = "uniffi-bindgen.rs"
 [dependencies]
 fedimint-sdk = { path = "../fedimint-sdk" }
 thiserror = "2.0.12"
-tokio = { version = "1.48.0", features = ["rt-multi-thread"] }
 uniffi = { version = "0.29", features = ["cli"] }
 
 [profile.release]

--- a/rust/fedimint-sdk-ffi/Cargo.toml
+++ b/rust/fedimint-sdk-ffi/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "fedimint-sdk-ffi"
+version = "0.1.0-alpha.1"
+edition = "2024"
+license = "MIT"
+authors = ["The Fedimint Developers"]
+description = "UniFFI bindings for fedimint-sdk: the language-binding layer for Swift, Kotlin, and other targets"
+repository = "https://github.com/fedimint/fedimint-sdk"
+publish = false
+
+[lib]
+crate-type = ["staticlib", "cdylib", "lib"]
+name = "fedimint_sdk_ffi"
+
+[[bin]]
+name = "uniffi-bindgen"
+path = "uniffi-bindgen.rs"
+
+[dependencies]
+fedimint-sdk = { path = "../fedimint-sdk" }
+thiserror = "2.0.12"
+tokio = { version = "1.48.0", features = ["rt-multi-thread"] }
+uniffi = { version = "0.29", features = ["cli"] }
+
+[profile.release]
+opt-level = 'z'
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = "debuginfo"

--- a/rust/fedimint-sdk-ffi/README.md
+++ b/rust/fedimint-sdk-ffi/README.md
@@ -1,0 +1,23 @@
+# Fedimint SDK FFI
+
+UniFFI bindings for [fedimint-sdk](../fedimint-sdk/): the language-binding layer
+for Swift, Kotlin, and other targets.
+
+This crate wraps the SDK's public API into types that `uniffi` can generate
+bindings from. Every type here is a thin wrapper; the logic lives in
+`fedimint-sdk` and this crate adds only the FFI annotations and the `Arc<Self>`
+ownership that UniFFI requires.
+
+## Status
+
+Prototype. Currently wraps `Mnemonic` as the T4 FFI shape spike proof-of-concept.
+Full bindings will be added as the SDK facades are implemented.
+
+## Why a separate crate?
+
+See the [T4 spike discussion](#380) for the full analysis. In short:
+`fedimint-sdk` enforces `#![deny(missing_docs)]` and a `wasm32-unknown-unknown`
+check gate. UniFFI's macro expansions generate items that conflict with both, and
+adding UniFFI as even an optional dependency would pull its proc-macro tree into
+the SDK's `Cargo.lock`. Keeping the boundary here means the SDK crate stays lean
+and portable, and this crate can set its own lint policy.

--- a/rust/fedimint-sdk-ffi/src/lib.rs
+++ b/rust/fedimint-sdk-ffi/src/lib.rs
@@ -1,0 +1,121 @@
+//! UniFFI bindings for `fedimint-sdk`.
+//!
+//! This crate wraps the SDK's public API into types that `uniffi` can
+//! generate Swift, Kotlin and Python bindings from. Every type here is a
+//! thin wrapper; the logic lives in `fedimint-sdk` and this crate adds only
+//! the FFI annotations and the `Arc<Self>` ownership that UniFFI requires.
+//!
+//! # Why a separate crate?
+//!
+//! `fedimint-sdk` carries `wasm-bindgen` for its WASM target and enforces
+//! `#![deny(missing_docs)]` plus a `wasm32-unknown-unknown` check gate.
+//! UniFFI's proc-macro expansions generate items that break both of those
+//! gates, and adding UniFFI as even an optional dependency would pull its
+//! proc-macro tree into the SDK's `Cargo.lock`, bloating every contributor's
+//! build whether they touch FFI or not. Keeping the boundary here means the
+//! SDK crate stays lean and portable, and this crate can set its own lint
+//! policy.
+
+use std::sync::Arc;
+
+use fedimint_sdk::Mnemonic as SdkMnemonic;
+
+uniffi::setup_scaffolding!();
+
+// ── Error ────────────────────────────────────────────────────────────────
+
+/// Errors surfaced to the binding layer.
+///
+/// Each variant maps onto one or more [`fedimint_sdk::ErrorCode`] cases;
+/// the full error taxonomy stays in the SDK, and this enum is the
+/// coarsened view the binding sees.
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum FfiError {
+    /// The platform's secure random source was unavailable.
+    #[error("Entropy error: {msg}")]
+    Entropy { msg: String },
+
+    /// The input did not parse or was otherwise invalid.
+    #[error("Invalid input: {msg}")]
+    InvalidInput { msg: String },
+
+    /// Catch-all for errors that don't have a specific variant yet.
+    #[error("SDK error: {msg}")]
+    Sdk { msg: String },
+}
+
+impl From<fedimint_sdk::Error> for FfiError {
+    fn from(e: fedimint_sdk::Error) -> Self {
+        match e.code {
+            fedimint_sdk::ErrorCode::Entropy => FfiError::Entropy {
+                msg: e.message.clone(),
+            },
+            fedimint_sdk::ErrorCode::InvalidInput => FfiError::InvalidInput {
+                msg: e.message.clone(),
+            },
+            _ => FfiError::Sdk {
+                msg: format!("{}: {}", e.code, e.message),
+            },
+        }
+    }
+}
+
+// ── Mnemonic ─────────────────────────────────────────────────────────────
+
+/// A BIP-39 seed phrase, wrapped for FFI.
+///
+/// The SDK's `Mnemonic` deliberately omits `Debug` and `Display` to
+/// prevent accidental logging. This wrapper preserves that discipline:
+/// the only way to get the words out is [`Mnemonic::words`].
+#[derive(uniffi::Object)]
+pub struct Mnemonic {
+    inner: SdkMnemonic,
+}
+
+#[uniffi::export]
+impl Mnemonic {
+    /// Generates a fresh 12-word BIP-39 mnemonic.
+    #[uniffi::constructor]
+    pub fn generate() -> Result<Arc<Self>, FfiError> {
+        let inner = SdkMnemonic::generate()?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Parses a whitespace-separated BIP-39 phrase.
+    #[uniffi::constructor]
+    pub fn from_phrase(phrase: String) -> Result<Arc<Self>, FfiError> {
+        let inner: SdkMnemonic = phrase.parse()?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    /// Returns the mnemonic's words in order.
+    pub fn words(&self) -> Vec<String> {
+        self.inner.words()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PHRASE: &str = "abandon abandon abandon abandon abandon abandon abandon abandon \
+                          abandon abandon abandon about";
+
+    #[test]
+    fn generate_produces_twelve_words() {
+        let m = Mnemonic::generate().expect("entropy available");
+        assert_eq!(m.words().len(), 12);
+    }
+
+    #[test]
+    fn from_phrase_round_trips() {
+        let m = Mnemonic::from_phrase(PHRASE.to_owned()).expect("valid phrase");
+        assert_eq!(m.words().join(" "), PHRASE);
+    }
+
+    #[test]
+    fn from_phrase_rejects_garbage() {
+        let result = Mnemonic::from_phrase("not a mnemonic".to_owned());
+        assert!(matches!(result, Err(FfiError::InvalidInput { .. })));
+    }
+}

--- a/rust/fedimint-sdk-ffi/src/lib.rs
+++ b/rust/fedimint-sdk-ffi/src/lib.rs
@@ -9,8 +9,8 @@
 //!
 //! `fedimint-sdk` carries `wasm-bindgen` for its WASM target and enforces
 //! `#![deny(missing_docs)]` plus a `wasm32-unknown-unknown` check gate.
-//! UniFFI's proc-macro expansions generate items that break both of those
-//! gates, and adding UniFFI as even an optional dependency would pull its
+//! UniFFI's proc-macro expansions conflict with the documentation lint
+//! and complicate the wasm target, and adding UniFFI as even an optional dependency would pull its
 //! proc-macro tree into the SDK's `Cargo.lock`, bloating every contributor's
 //! build whether they touch FFI or not. Keeping the boundary here means the
 //! SDK crate stays lean and portable, and this crate can set its own lint
@@ -46,6 +46,9 @@ pub enum FfiError {
 
 impl From<fedimint_sdk::Error> for FfiError {
     fn from(e: fedimint_sdk::Error) -> Self {
+        // TODO: forward `e.details` (ErrorDetails from T3) to the binding
+        // layer once the full FFI surface is built, so Swift/Kotlin callers
+        // can read structured fields like `required` / `available` amounts.
         match e.code {
             fedimint_sdk::ErrorCode::Entropy => FfiError::Entropy {
                 msg: e.message.clone(),
@@ -53,6 +56,11 @@ impl From<fedimint_sdk::Error> for FfiError {
             fedimint_sdk::ErrorCode::InvalidInput => FfiError::InvalidInput {
                 msg: e.message.clone(),
             },
+            // TODO: expand as facades are wrapped. Mnemonic only returns
+            // Entropy and InvalidInput; the remaining 21 ErrorCode variants
+            // (InsufficientBalance, GatewayUnavailable, QuoteExpired, etc.)
+            // need dedicated FfiError variants once Ecash/Lightning/Onchain
+            // are exposed.
             _ => FfiError::Sdk {
                 msg: format!("{}: {}", e.code, e.message),
             },

--- a/rust/fedimint-sdk-ffi/uniffi-bindgen.rs
+++ b/rust/fedimint-sdk-ffi/uniffi-bindgen.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}


### PR DESCRIPTION
Adds `rust/fedimint-sdk-ffi/`, a standalone UniFFI bindings crate wrapping
`fedimint-sdk`. This is the T4 FFI shape spike: prototype one method both ways,
Decision Reasoning :- #380 

## What this PR adds

- `Cargo.toml` pinned to uniffi 0.29, matching `fedimint-client-uniffi`
- `src/lib.rs` wrapping `Mnemonic::generate()` and `Mnemonic::from_phrase()`
  with `Arc<Self>` ownership and `FfiError` error mapping
- `uniffi-bindgen.rs` CLI entry point
- `README.md` explaining why a separate crate
- `.gitignore` matching the existing FFI crate

## Decision: Option A (Separate Crate)

A separate crate is the recommended path over an in-crate `ffi` feature because:

1. The SDK enforces `#![deny(missing_docs)]`. UniFFI's `setup_scaffolding!()`
   generates undocumented internal items that break this lint.
2. UniFFI generates `Send + Sync` bounds incompatible with `wasm32-unknown-unknown`
   without unstable flags. Keeping it out of the SDK avoids wasm fragility.
3. A separate lockfile keeps UniFFI's proc-macro dependency tree out of the SDK's
   `Cargo.lock`, matching how `fedimint-client-uniffi` already works.

## What this does NOT include

- No full bindings. This is the shape decision only.
- No changes to `nix/ffi.nix` or `ubrn.config.yaml` (those come at cutover).
- No changes to `fedimint-sdk` itself.

**Note :-** This PR is created by AI but It goes through the manual review of author
