### PR TITLE
feat(sdk): activity history over the operation log (T11)

### DIFF
--- a/rust/fedimint-sdk/src/activity.rs
+++ b/rust/fedimint-sdk/src/activity.rs
@@ -2,6 +2,8 @@
 
 use crate::{Amount, Cursor, OperationId, OperationKind, Timestamp};
 
+mod rows;
+
 /// One row of a federation's activity history.
 ///
 /// Read through [`Federation::activity`](crate::Federation::activity),

--- a/rust/fedimint-sdk/src/activity.rs
+++ b/rust/fedimint-sdk/src/activity.rs
@@ -347,18 +347,23 @@ pub enum ActivityStatus {
     /// This SDK version cannot interpret how the row turned out.
     ///
     /// Not a sixth outcome, but the absence of a reading, and it is reported
-    /// in two situations:
+    /// in three situations:
     ///
     /// - the row's [`kind`](crate::ActivityItem::kind) is
     ///   [`OperationKind::Unknown`](crate::OperationKind::Unknown), a record
     ///   written by a build that understood a module or an operation this one
-    ///   does not; and
+    ///   does not;
     /// - the kind is one this build knows but the persisted final state is a
     ///   variant its state enum does not have, which a newer build can write
-    ///   because every state enum here is `#[non_exhaustive]`.
+    ///   because every state enum here is `#[non_exhaustive]`; and
+    /// - the kind is one this build knows, no ending has been recorded, and
+    ///   the operation's current state could not be read on this call. Such
+    ///   a row reports [`is_final`](crate::ActivityItem::is_final) as
+    ///   `false`, which says only that no ending is on record, and a later
+    ///   page may read it.
     ///
-    /// In both, the outcome is unreadable while the row itself is perfectly
-    /// real. Guessing is not an option, and neither is
+    /// In all three, the outcome is unreadable while the row itself is
+    /// perfectly real. Guessing is not an option, and neither is
     /// [`Pending`](Self::Pending): see [the section
     /// above](ActivityStatus#an-uninterpretable-row).
     ///

--- a/rust/fedimint-sdk/src/activity.rs
+++ b/rust/fedimint-sdk/src/activity.rs
@@ -2,7 +2,10 @@
 
 use crate::{Amount, Cursor, OperationId, OperationKind, Timestamp};
 
+mod page;
 mod rows;
+
+pub(crate) use page::page;
 
 /// One row of a federation's activity history.
 ///

--- a/rust/fedimint-sdk/src/activity/page.rs
+++ b/rust/fedimint-sdk/src/activity/page.rs
@@ -207,8 +207,10 @@ where
                 return Err(err);
             }
             // An upstream state this build's driver cannot decode (fedimint/fedimint#8969 on
-            // the v1 module today) must not make the whole list unreadable: the record still
-            // says what it knows.
+            // the v1 module today) must not make the whole list unreadable, and it is not a
+            // reading either: `Pending` would claim the operation is still running when all
+            // that is known is that no ending was recorded. So the outcome is `Unknown` and
+            // finality is what the record says, which in this branch is "not yet".
             Err(err) => {
                 tracing::warn!(
                     target: "fedimint_sdk",
@@ -216,7 +218,7 @@ where
                     error = %err,
                     "could not refresh this operation's current state",
                 );
-                (ActivityStatus::Pending, false)
+                (ActivityStatus::Unknown, false)
             }
         },
     };
@@ -789,7 +791,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn a_refresh_that_fails_leaves_the_row_at_what_its_record_says() {
+    async fn a_refresh_that_fails_is_an_unknown_outcome_with_the_recorded_finality() {
         let db = federation_namespace(&in_memory_root(), [1u8; 32]);
         let federation = FederationInner::detached(db.clone(), true);
         // `Operation::state` reloads the record before calling the driver, so the id it is
@@ -811,8 +813,9 @@ mod tests {
         )
         .await
         .expect("an unrecognised refresh error still yields a row");
-        assert_eq!(item.status, ActivityStatus::Pending);
+        assert_eq!(item.status, ActivityStatus::Unknown);
         assert!(!item.is_final);
+        assert_eq!((item.amount, item.fee, item.direction), (None, None, None));
 
         let err = typed(
             inner.clone(),

--- a/rust/fedimint-sdk/src/activity/page.rs
+++ b/rust/fedimint-sdk/src/activity/page.rs
@@ -1,0 +1,839 @@
+//! The page walk behind `Federation::activity`: the index, the records, the rows.
+
+use std::sync::Arc;
+
+use fedimint_core::core::OperationId as UpstreamOperationId;
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+use futures::StreamExt;
+
+use super::rows::{Figures, Row};
+use crate::db::{OperationIndexKey, OperationIndexKeyPrefix, OperationRecord, OperationRecordKey};
+use crate::federation::FederationInner;
+use crate::operation::{AnyOperation, Driver, ErasedDriver, Operation, OperationInner, driver_for};
+use crate::{
+    ActivityItem, ActivityPage, ActivityStatus, Cursor, Error, ErrorCode, FederationId,
+    OperationId, OperationKind, OperationSupport, Result, Timestamp,
+};
+
+/// One page of a federation's activity, newest first.
+///
+/// # Errors
+///
+/// [`FederationClosed`](ErrorCode::FederationClosed), [`InvalidInput`](ErrorCode::InvalidInput)
+/// for a zero `limit` or a cursor another federation issued, and
+/// [`Storage`](ErrorCode::Storage).
+pub(crate) async fn page(
+    federation: &Arc<FederationInner>,
+    cursor: Option<Cursor>,
+    limit: u16,
+) -> Result<ActivityPage> {
+    federation.ensure_open()?;
+    if limit == 0 {
+        return Err(Error::new(
+            ErrorCode::InvalidInput,
+            "limit must be at least 1",
+        ));
+    }
+    if let Some(cursor) = &cursor {
+        let issuer = FederationId::from_upstream(federation.id);
+        if cursor.federation() != &issuer {
+            return Err(Error::new(
+                ErrorCode::InvalidInput,
+                "this cursor was issued by another federation",
+            ));
+        }
+    }
+    // The boundary the walk skips past: everything at or before it belongs to a page already
+    // served.
+    let boundary = cursor
+        .as_ref()
+        .map(|cursor| (cursor.created_at(), cursor.id().upstream()));
+
+    let db = federation.db();
+    let mut dbtx = db.begin_transaction_nc().await;
+    let mut entries = dbtx
+        .find_by_prefix_sorted_descending(&OperationIndexKeyPrefix)
+        .await;
+    let mut keys: Vec<OperationIndexKey> = Vec::new();
+    while let Some((key, ())) = entries.next().await {
+        if boundary.is_some_and(|boundary| (key.created_at, key.id) >= boundary) {
+            continue;
+        }
+        keys.push(key);
+        // One key beyond `limit`, if the walk gets that far, only says a next page exists; it
+        // is never read as a row.
+        if keys.len() == usize::from(limit) + 1 {
+            break;
+        }
+    }
+    drop(entries);
+    drop(dbtx);
+
+    let has_more = keys.len() > usize::from(limit);
+    keys.truncate(usize::from(limit));
+
+    let mut dbtx = db.begin_transaction_nc().await;
+    let mut records = Vec::with_capacity(keys.len());
+    for key in keys {
+        match dbtx.get_value(&OperationRecordKey(key.id)).await {
+            Some(record) => records.push((key.id, record)),
+            // The index and its record are written together (`FederationInner::write_record`),
+            // so this never happens; a missing row is a better failure than a panic.
+            None => tracing::warn!(
+                target: "fedimint_sdk",
+                federation = %federation.id,
+                operation = %key.id.fmt_full(),
+                "an activity index entry has no record",
+            ),
+        }
+    }
+    drop(dbtx);
+
+    // The rows of one page are built concurrently rather than one at a time: a row still in
+    // flight costs its driver's current-state read, half a second on the lightning drivers, and
+    // a page pays that once rather than once per row.
+    let items = futures::future::join_all(
+        records
+            .iter()
+            .map(|(id, record)| row(federation, *id, record.clone())),
+    )
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>>>()?;
+
+    let next = has_more
+        .then(|| records.last())
+        .flatten()
+        .map(|(id, record)| {
+            Cursor::new(
+                FederationId::from_upstream(federation.id),
+                record.created_at,
+                OperationId::from_upstream(*id),
+            )
+        });
+
+    Ok(ActivityPage { items, next })
+}
+
+/// The row for one record, brought up to date if its ending is not recorded yet.
+async fn row(
+    federation: &Arc<FederationInner>,
+    id: UpstreamOperationId,
+    record: OperationRecord,
+) -> Result<ActivityItem> {
+    let inner = Arc::new(OperationInner {
+        federation: federation.clone(),
+        id,
+        record,
+    });
+    let any = AnyOperation::from_record(inner.clone());
+    let kind = any.kind();
+
+    let driver = (any.support() == OperationSupport::Observable)
+        .then(|| driver_for(&inner.record.kind))
+        .flatten();
+    let Some(driver) = driver else {
+        return Ok(unreadable(id, &inner.record, kind));
+    };
+
+    match driver {
+        ErasedDriver::EcashSend(driver) => typed(inner, driver, kind).await,
+        ErasedDriver::EcashReceive(driver) => typed(inner, driver, kind).await,
+        ErasedDriver::LnSend(driver) => typed(inner, driver, kind).await,
+        ErasedDriver::LnReceive(driver) => typed(inner, driver, kind).await,
+        ErasedDriver::OnchainSend(driver) => typed(inner, driver, kind).await,
+        ErasedDriver::OnchainReceive(driver) => typed(inner, driver, kind).await,
+        ErasedDriver::Recovery(driver) => typed(inner, driver, kind).await,
+    }
+}
+
+/// The row for a record this build cannot observe as a typed state: an unrecognised kind, a
+/// state schema newer than this build reads, or a kind with no driver yet.
+fn unreadable(
+    id: UpstreamOperationId,
+    record: &OperationRecord,
+    kind: OperationKind,
+) -> ActivityItem {
+    ActivityItem {
+        operation_id: OperationId::from_upstream(id),
+        kind,
+        time: Timestamp::from_epoch_millis(record.created_at),
+        amount: None,
+        fee: None,
+        direction: None,
+        status: ActivityStatus::Unknown,
+        is_final: record.final_state.is_some(),
+    }
+}
+
+/// The row for one observable record, through the driver its kind registered.
+async fn typed<S>(
+    inner: Arc<OperationInner>,
+    driver: Arc<dyn Driver<S>>,
+    kind: OperationKind,
+) -> Result<ActivityItem>
+where
+    S: Row,
+{
+    // A record whose details cannot be read still has a time, a kind and an outcome.
+    let figures = S::figures(driver.as_ref(), &inner.record.details).unwrap_or_else(|err| {
+        tracing::warn!(
+            target: "fedimint_sdk",
+            operation = %inner.id.fmt_full(),
+            error = %err,
+            "could not read this operation's details",
+        );
+        Figures::NONE
+    });
+
+    let (status, is_final) = match &inner.record.final_state {
+        Some(encoded) => match driver.decode_state(encoded) {
+            Ok(state) if state.is_final() => (state.bucket(), true),
+            // Either the decode failed, or it produced a state that is not final, which is a
+            // corrupt record either way: this build cannot say how it turned out, but the
+            // record does say it is finished.
+            _ => (ActivityStatus::Unknown, true),
+        },
+        None => match Operation::attach(inner.clone(), driver.clone())
+            .state()
+            .await
+        {
+            Ok(state) => (state.bucket(), state.is_final()),
+            Err(err) if matches!(err.code, ErrorCode::FederationClosed | ErrorCode::Storage) => {
+                return Err(err);
+            }
+            // An upstream state this build's driver cannot decode (fedimint/fedimint#8969 on
+            // the v1 module today) must not make the whole list unreadable: the record still
+            // says what it knows.
+            Err(err) => {
+                tracing::warn!(
+                    target: "fedimint_sdk",
+                    operation = %inner.id.fmt_full(),
+                    error = %err,
+                    "could not refresh this operation's current state",
+                );
+                (ActivityStatus::Pending, false)
+            }
+        },
+    };
+
+    // `Unknown` implies no figures, enforced here once rather than by every branch above
+    // remembering to clear them.
+    let figures = if status == ActivityStatus::Unknown {
+        Figures::NONE
+    } else {
+        figures
+    };
+
+    Ok(ActivityItem {
+        operation_id: OperationId::from_upstream(inner.id),
+        kind,
+        time: Timestamp::from_epoch_millis(inner.record.created_at),
+        amount: figures.amount,
+        fee: figures.fee,
+        direction: figures.direction,
+        status,
+        is_final,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use fedimint_core::db::Database;
+    use fedimint_core::util::{BoxFuture, BoxStream};
+
+    use super::*;
+    use crate::db::{federation_namespace, in_memory_root};
+    use crate::lightning::fixtures::{
+        receive_details, receive_details_json, send_details, send_details_json,
+    };
+    use crate::lightning::{LnReceiveDriver, LnSendDriver};
+    use crate::operation::kinds;
+    use crate::{Amount, Direction, EcashSendState, LnReceiveState, LnSendState};
+
+    /// An operation id with the given last byte, the rest zero, so a test can build several
+    /// distinct ids by a small number alone.
+    fn id_bytes(n: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[31] = n;
+        bytes
+    }
+
+    /// The public [`OperationId`] for [`id_bytes`], to compare against a row's
+    /// [`ActivityItem::operation_id`].
+    fn opid(n: u8) -> OperationId {
+        OperationId::from_upstream(UpstreamOperationId(id_bytes(n)))
+    }
+
+    /// Writes one operation's record and its index entry together, mirroring
+    /// `FederationInner::write_record`.
+    #[expect(clippy::too_many_arguments, reason = "a test fixture, not API")]
+    async fn write(
+        db: &Database,
+        id: [u8; 32],
+        kind: &str,
+        module: &str,
+        created_at: u64,
+        details: String,
+        final_state: Option<String>,
+        schema_version: u32,
+    ) {
+        let id = UpstreamOperationId(id);
+        let record = OperationRecord {
+            schema_version,
+            kind: kind.to_owned(),
+            module: module.to_owned(),
+            created_at,
+            details,
+            phase: None,
+            cancel_requested_at: None,
+            final_state,
+        };
+        let mut dbtx = db.begin_transaction().await;
+        dbtx.insert_entry(&OperationRecordKey(id), &record).await;
+        dbtx.insert_entry(&OperationIndexKey { created_at, id }, &())
+            .await;
+        dbtx.commit_tx().await;
+    }
+
+    fn ids(activity: &ActivityPage) -> Vec<OperationId> {
+        activity
+            .items
+            .iter()
+            .map(|item| item.operation_id.clone())
+            .collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pages_run_newest_first_and_continue_through_the_cursor() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let details = receive_details_json(&receive_details());
+        let claimed = LnReceiveDriver
+            .encode_state(&LnReceiveState::Claimed)
+            .expect("encode");
+        for n in 1..=5u8 {
+            write(
+                &db,
+                id_bytes(n),
+                kinds::LN_RECEIVE,
+                "lnv2",
+                u64::from(n),
+                details.clone(),
+                Some(claimed.clone()),
+                1,
+            )
+            .await;
+        }
+
+        let first = page(&federation, None, 2).await.expect("first page");
+        assert_eq!(ids(&first), vec![opid(5), opid(4)]);
+        let cursor = first.next.expect("three rows remain");
+
+        let second = page(&federation, Some(cursor), 2)
+            .await
+            .expect("second page");
+        assert_eq!(ids(&second), vec![opid(3), opid(2)]);
+        let cursor = second.next.expect("one row remains");
+
+        let third = page(&federation, Some(cursor), 2).await.expect("last page");
+        assert_eq!(ids(&third), vec![opid(1)]);
+        assert!(third.next.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn two_rows_created_in_the_same_millisecond_are_ordered_by_id_and_never_repeated() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let details = receive_details_json(&receive_details());
+        let claimed = LnReceiveDriver
+            .encode_state(&LnReceiveState::Claimed)
+            .expect("encode");
+        for n in 1..=3u8 {
+            write(
+                &db,
+                id_bytes(n),
+                kinds::LN_RECEIVE,
+                "lnv2",
+                1_000,
+                details.clone(),
+                Some(claimed.clone()),
+                1,
+            )
+            .await;
+        }
+
+        let mut seen = Vec::new();
+        let mut cursor = None;
+        for _ in 0..3 {
+            let one_page = page(&federation, cursor, 1).await.expect("a page");
+            assert_eq!(one_page.items.len(), 1);
+            seen.push(one_page.items[0].operation_id.clone());
+            cursor = one_page.next;
+        }
+        assert!(cursor.is_none());
+        // The index orders a tie on `created_at` by descending id, the same as the walk orders
+        // everything else.
+        assert_eq!(seen, vec![opid(3), opid(2), opid(1)]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_zero_limit_is_refused() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db, true);
+        let err = page(&federation, None, 0)
+            .await
+            .expect_err("zero is not a valid limit");
+        assert_eq!(err.code, ErrorCode::InvalidInput);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_cursor_from_another_federation_is_refused() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db, true);
+        let other = "00".repeat(32).parse::<FederationId>().expect("valid");
+        let cursor = Cursor::new(other, 0, opid(1));
+
+        let err = page(&federation, Some(cursor), 1)
+            .await
+            .expect_err("a cursor from another federation is refused");
+        assert_eq!(err.code, ErrorCode::InvalidInput);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_closed_federation_says_so() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db, false);
+        let err = page(&federation, None, 1)
+            .await
+            .expect_err("a closed federation refuses to page");
+        assert_eq!(err.code, ErrorCode::FederationClosed);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_recorded_ending_is_read_from_the_record() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let details = send_details();
+        let success = LnSendState::Success {
+            preimage: "11".repeat(32).parse().expect("a preimage"),
+            fee: Amount::from_msats(1_000),
+            route: details.route.clone(),
+        };
+        let encoded = LnSendDriver.encode_state(&success).expect("encode");
+        write(
+            &db,
+            id_bytes(1),
+            kinds::LN_SEND,
+            "lnv2",
+            1_700_000_000_000,
+            send_details_json(&details),
+            Some(encoded),
+            1,
+        )
+        .await;
+
+        // No client exists on a detached federation, so a successful call here also proves no
+        // refresh was attempted: reading the current state would have failed with
+        // `FederationClosed`.
+        let activity = page(&federation, None, 10)
+            .await
+            .expect("no refresh needed");
+        assert_eq!(activity.items.len(), 1);
+        let row = &activity.items[0];
+        assert_eq!(row.status, ActivityStatus::Success);
+        assert!(row.is_final);
+        assert_eq!(row.amount, Some(Amount::from_msats(100_000)));
+        assert_eq!(row.fee, Some(Amount::from_msats(1_000)));
+        assert_eq!(row.direction, Some(Direction::Outgoing));
+        assert_eq!(row.kind, OperationKind::LnSend);
+        assert_eq!(row.time, Timestamp::from_epoch_millis(1_700_000_000_000));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn every_lightning_ending_lands_in_its_bucket() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let send_details = send_details_json(&send_details());
+        let receive_details = receive_details_json(&receive_details());
+
+        let refunded = LnSendDriver
+            .encode_state(&LnSendState::Refunded)
+            .expect("encode");
+        write(
+            &db,
+            id_bytes(1),
+            kinds::LN_SEND,
+            "lnv2",
+            1,
+            send_details.clone(),
+            Some(refunded),
+            1,
+        )
+        .await;
+
+        let failed = LnSendDriver
+            .encode_state(&LnSendState::Failed {
+                reason: "gone".to_owned(),
+            })
+            .expect("encode");
+        write(
+            &db,
+            id_bytes(2),
+            kinds::LN_SEND,
+            "lnv2",
+            2,
+            send_details,
+            Some(failed),
+            1,
+        )
+        .await;
+
+        let claimed = LnReceiveDriver
+            .encode_state(&LnReceiveState::Claimed)
+            .expect("encode");
+        write(
+            &db,
+            id_bytes(3),
+            kinds::LN_RECEIVE,
+            "lnv2",
+            3,
+            receive_details.clone(),
+            Some(claimed),
+            1,
+        )
+        .await;
+
+        let canceled = LnReceiveDriver
+            .encode_state(&LnReceiveState::Canceled {
+                reason: "withdrawn".to_owned(),
+            })
+            .expect("encode");
+        write(
+            &db,
+            id_bytes(4),
+            kinds::LN_RECEIVE,
+            "lnv2",
+            4,
+            receive_details.clone(),
+            Some(canceled),
+            1,
+        )
+        .await;
+
+        let expired = LnReceiveDriver
+            .encode_state(&LnReceiveState::Expired)
+            .expect("encode");
+        write(
+            &db,
+            id_bytes(5),
+            kinds::LN_RECEIVE,
+            "lnv2",
+            5,
+            receive_details.clone(),
+            Some(expired),
+            1,
+        )
+        .await;
+
+        let failed_receive = LnReceiveDriver
+            .encode_state(&LnReceiveState::Failed)
+            .expect("encode");
+        write(
+            &db,
+            id_bytes(6),
+            kinds::LN_RECEIVE,
+            "lnv2",
+            6,
+            receive_details,
+            Some(failed_receive),
+            1,
+        )
+        .await;
+
+        let activity = page(&federation, None, 10).await.expect("a page");
+        let by_id = |n: u8| {
+            activity
+                .items
+                .iter()
+                .find(|item| item.operation_id == opid(n))
+                .unwrap_or_else(|| panic!("operation {n} was not listed"))
+        };
+        assert_eq!(by_id(1).status, ActivityStatus::Refunded);
+        assert_eq!(by_id(2).status, ActivityStatus::Failed);
+        let claimed_row = by_id(3);
+        assert_eq!(claimed_row.status, ActivityStatus::Success);
+        assert_eq!(claimed_row.direction, Some(Direction::Incoming));
+        assert_eq!(claimed_row.amount, Some(Amount::from_msats(100_000)));
+        assert_eq!(claimed_row.fee, Some(Amount::from_msats(500)));
+        assert_eq!(by_id(4).status, ActivityStatus::Canceled);
+        assert_eq!(by_id(5).status, ActivityStatus::Canceled);
+        assert_eq!(by_id(6).status, ActivityStatus::Failed);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_ending_this_build_cannot_read_is_unknown_and_final() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        write(
+            &db,
+            id_bytes(1),
+            kinds::LN_SEND,
+            "lnv2",
+            1,
+            send_details_json(&send_details()),
+            Some(r#"{"Settled":{}}"#.to_owned()),
+            1,
+        )
+        .await;
+
+        let activity = page(&federation, None, 10).await.expect("a page");
+        assert_eq!(activity.items.len(), 1);
+        let row = &activity.items[0];
+        assert_eq!(row.status, ActivityStatus::Unknown);
+        assert!(row.is_final);
+        assert_eq!(row.amount, None);
+        assert_eq!(row.fee, None);
+        assert_eq!(row.direction, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_record_of_an_unknown_kind_is_listed_without_numbers() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        write(
+            &db,
+            id_bytes(1),
+            "widget",
+            "widget",
+            1,
+            "{}".to_owned(),
+            None,
+            1,
+        )
+        .await;
+        write(
+            &db,
+            id_bytes(2),
+            "widget",
+            "widget",
+            2,
+            "{}".to_owned(),
+            Some("done".to_owned()),
+            1,
+        )
+        .await;
+
+        let activity = page(&federation, None, 10).await.expect("a page");
+        let running = activity
+            .items
+            .iter()
+            .find(|item| item.operation_id == opid(1))
+            .expect("listed");
+        let finished = activity
+            .items
+            .iter()
+            .find(|item| item.operation_id == opid(2))
+            .expect("listed");
+
+        for row in [running, finished] {
+            assert_eq!(row.kind, OperationKind::Unknown);
+            assert_eq!(row.status, ActivityStatus::Unknown);
+            assert_eq!(row.amount, None);
+            assert_eq!(row.fee, None);
+            assert_eq!(row.direction, None);
+        }
+        assert!(!running.is_final);
+        assert!(finished.is_final);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_state_schema_newer_than_this_build_is_unknown() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let details = send_details();
+        let success = LnSendState::Success {
+            preimage: "11".repeat(32).parse().expect("a preimage"),
+            fee: Amount::from_msats(1_000),
+            route: details.route.clone(),
+        };
+        let encoded = LnSendDriver.encode_state(&success).expect("encode");
+        write(
+            &db,
+            id_bytes(1),
+            kinds::LN_SEND,
+            "lnv2",
+            1,
+            send_details_json(&details),
+            Some(encoded),
+            2,
+        )
+        .await;
+
+        let activity = page(&federation, None, 10).await.expect("a page");
+        assert_eq!(activity.items.len(), 1);
+        let row = &activity.items[0];
+        assert_eq!(row.kind, OperationKind::LnSend);
+        assert_eq!(row.status, ActivityStatus::Unknown);
+        assert!(row.is_final);
+        assert_eq!(row.amount, None);
+        assert_eq!(row.fee, None);
+        assert_eq!(row.direction, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_row_with_no_recorded_ending_is_refreshed_through_its_driver() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        write(
+            &db,
+            id_bytes(1),
+            kinds::ECASH_SEND,
+            "mint",
+            1,
+            String::new(),
+            None,
+            1,
+        )
+        .await;
+
+        let activity = page(&federation, None, 10).await.expect("a page");
+        assert_eq!(activity.items.len(), 1);
+        let row = &activity.items[0];
+        assert_eq!(row.status, ActivityStatus::Success);
+        assert!(row.is_final);
+        // The probe driver has no details to decode, so the outcome is known but the figures
+        // are not: this is the details-unreadable path, not the `Unknown`-status one.
+        assert_eq!(row.amount, None);
+        assert_eq!(row.fee, None);
+        assert_eq!(row.direction, None);
+
+        let mut dbtx = db.begin_transaction_nc().await;
+        let record = dbtx
+            .get_value(&OperationRecordKey(UpstreamOperationId(id_bytes(1))))
+            .await
+            .expect("the record still exists");
+        assert!(
+            record.final_state.is_some(),
+            "the refresh recorded the final state it observed"
+        );
+    }
+
+    /// A driver whose `current` answers a chosen error, so a refresh can be made to fail in a
+    /// chosen way without a real client.
+    struct FailingDriver {
+        error: ErrorCode,
+    }
+
+    impl Driver<EcashSendState> for FailingDriver {
+        fn current<'a>(
+            &'a self,
+            _federation: &'a FederationInner,
+            _id: UpstreamOperationId,
+            _record: &'a OperationRecord,
+        ) -> BoxFuture<'a, Result<EcashSendState>> {
+            Box::pin(async move { Err(Error::new(self.error, "chosen by the test")) })
+        }
+
+        fn subscribe<'a>(
+            &'a self,
+            _federation: &'a FederationInner,
+            _id: UpstreamOperationId,
+            _record: &'a OperationRecord,
+        ) -> BoxFuture<'a, Result<BoxStream<'static, Result<EcashSendState>>>> {
+            Box::pin(async move { Err(Error::new(self.error, "chosen by the test")) })
+        }
+
+        fn same_state(&self, previous: &EcashSendState, next: &EcashSendState) -> bool {
+            previous == next
+        }
+
+        fn encode_state(&self, _state: &EcashSendState) -> Result<String> {
+            Err(Error::new(ErrorCode::Internal, "not exercised"))
+        }
+
+        fn decode_state(&self, _encoded: &str) -> Result<EcashSendState> {
+            Err(Error::new(ErrorCode::Internal, "not exercised"))
+        }
+
+        fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {
+            Err(Error::new(
+                ErrorCode::Internal,
+                "the failing driver has no details",
+            ))
+        }
+    }
+
+    fn a_pending_ecash_send(federation: &Arc<FederationInner>) -> Arc<OperationInner> {
+        Arc::new(OperationInner {
+            federation: federation.clone(),
+            id: UpstreamOperationId(id_bytes(1)),
+            record: OperationRecord {
+                schema_version: 1,
+                kind: kinds::ECASH_SEND.to_owned(),
+                module: "mint".to_owned(),
+                created_at: 1,
+                details: String::new(),
+                phase: None,
+                cancel_requested_at: None,
+                final_state: None,
+            },
+        })
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_refresh_that_fails_leaves_the_row_at_what_its_record_says() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        // `Operation::state` reloads the record before calling the driver, so the id it is
+        // called for must actually have one.
+        write(
+            &db,
+            id_bytes(1),
+            kinds::ECASH_SEND,
+            "mint",
+            1,
+            String::new(),
+            None,
+            1,
+        )
+        .await;
+        let inner = a_pending_ecash_send(&federation);
+
+        let item = typed(
+            inner.clone(),
+            Arc::new(FailingDriver {
+                error: ErrorCode::Internal,
+            }) as Arc<dyn Driver<EcashSendState>>,
+            OperationKind::EcashSend,
+        )
+        .await
+        .expect("an unrecognised refresh error still yields a row");
+        assert_eq!(item.status, ActivityStatus::Pending);
+        assert!(!item.is_final);
+
+        let err = typed(
+            inner.clone(),
+            Arc::new(FailingDriver {
+                error: ErrorCode::Storage,
+            }) as Arc<dyn Driver<EcashSendState>>,
+            OperationKind::EcashSend,
+        )
+        .await
+        .expect_err("a storage failure propagates");
+        assert_eq!(err.code, ErrorCode::Storage);
+
+        let err = typed(
+            inner,
+            Arc::new(FailingDriver {
+                error: ErrorCode::FederationClosed,
+            }) as Arc<dyn Driver<EcashSendState>>,
+            OperationKind::EcashSend,
+        )
+        .await
+        .expect_err("a federation-closed failure propagates");
+        assert_eq!(err.code, ErrorCode::FederationClosed);
+    }
+}

--- a/rust/fedimint-sdk/src/activity/page.rs
+++ b/rust/fedimint-sdk/src/activity/page.rs
@@ -132,6 +132,10 @@ async fn row(
     let driver = (any.support() == OperationSupport::Observable)
         .then(|| driver_for(&inner.record.kind))
         .flatten();
+    // A kind this build knows but has no driver for (`driver_for` answers `None`: ecash receive,
+    // on-chain, recovery until T7, T9, T12 land) falls through to `unreadable` below. Nothing
+    // then records a final state for it, so its row keeps `is_final == false` even after the
+    // operation finishes; the gap closes the moment that kind's arm in `driver_for` lands.
     let Some(driver) = driver else {
         return Ok(unreadable(id, &inner.record, kind));
     };
@@ -269,20 +273,27 @@ mod tests {
 
     /// Writes one operation's record and its index entry together, mirroring
     /// `FederationInner::write_record`.
-    #[expect(clippy::too_many_arguments, reason = "a test fixture, not API")]
-    async fn write(
-        db: &Database,
-        id: [u8; 32],
+    async fn write(db: &Database, id: [u8; 32], record: OperationRecord) {
+        let id = UpstreamOperationId(id);
+        let created_at = record.created_at;
+        let mut dbtx = db.begin_transaction().await;
+        dbtx.insert_entry(&OperationRecordKey(id), &record).await;
+        dbtx.insert_entry(&OperationIndexKey { created_at, id }, &())
+            .await;
+        dbtx.commit_tx().await;
+    }
+
+    /// The record most tests need: a readable schema, no phase and no cancellation. The one test
+    /// that needs a different schema version overrides it on the returned struct.
+    fn record(
         kind: &str,
         module: &str,
         created_at: u64,
         details: String,
         final_state: Option<String>,
-        schema_version: u32,
-    ) {
-        let id = UpstreamOperationId(id);
-        let record = OperationRecord {
-            schema_version,
+    ) -> OperationRecord {
+        OperationRecord {
+            schema_version: crate::operation::READABLE_STATE_SCHEMA,
             kind: kind.to_owned(),
             module: module.to_owned(),
             created_at,
@@ -290,12 +301,7 @@ mod tests {
             phase: None,
             cancel_requested_at: None,
             final_state,
-        };
-        let mut dbtx = db.begin_transaction().await;
-        dbtx.insert_entry(&OperationRecordKey(id), &record).await;
-        dbtx.insert_entry(&OperationIndexKey { created_at, id }, &())
-            .await;
-        dbtx.commit_tx().await;
+        }
     }
 
     fn ids(activity: &ActivityPage) -> Vec<OperationId> {
@@ -318,12 +324,13 @@ mod tests {
             write(
                 &db,
                 id_bytes(n),
-                kinds::LN_RECEIVE,
-                "lnv2",
-                u64::from(n),
-                details.clone(),
-                Some(claimed.clone()),
-                1,
+                record(
+                    kinds::LN_RECEIVE,
+                    "lnv2",
+                    u64::from(n),
+                    details.clone(),
+                    Some(claimed.clone()),
+                ),
             )
             .await;
         }
@@ -355,12 +362,13 @@ mod tests {
             write(
                 &db,
                 id_bytes(n),
-                kinds::LN_RECEIVE,
-                "lnv2",
-                1_000,
-                details.clone(),
-                Some(claimed.clone()),
-                1,
+                record(
+                    kinds::LN_RECEIVE,
+                    "lnv2",
+                    1_000,
+                    details.clone(),
+                    Some(claimed.clone()),
+                ),
             )
             .await;
         }
@@ -426,12 +434,13 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            kinds::LN_SEND,
-            "lnv2",
-            1_700_000_000_000,
-            send_details_json(&details),
-            Some(encoded),
-            1,
+            record(
+                kinds::LN_SEND,
+                "lnv2",
+                1_700_000_000_000,
+                send_details_json(&details),
+                Some(encoded),
+            ),
         )
         .await;
 
@@ -465,12 +474,13 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            kinds::LN_SEND,
-            "lnv2",
-            1,
-            send_details.clone(),
-            Some(refunded),
-            1,
+            record(
+                kinds::LN_SEND,
+                "lnv2",
+                1,
+                send_details.clone(),
+                Some(refunded),
+            ),
         )
         .await;
 
@@ -482,12 +492,7 @@ mod tests {
         write(
             &db,
             id_bytes(2),
-            kinds::LN_SEND,
-            "lnv2",
-            2,
-            send_details,
-            Some(failed),
-            1,
+            record(kinds::LN_SEND, "lnv2", 2, send_details, Some(failed)),
         )
         .await;
 
@@ -497,12 +502,13 @@ mod tests {
         write(
             &db,
             id_bytes(3),
-            kinds::LN_RECEIVE,
-            "lnv2",
-            3,
-            receive_details.clone(),
-            Some(claimed),
-            1,
+            record(
+                kinds::LN_RECEIVE,
+                "lnv2",
+                3,
+                receive_details.clone(),
+                Some(claimed),
+            ),
         )
         .await;
 
@@ -514,12 +520,13 @@ mod tests {
         write(
             &db,
             id_bytes(4),
-            kinds::LN_RECEIVE,
-            "lnv2",
-            4,
-            receive_details.clone(),
-            Some(canceled),
-            1,
+            record(
+                kinds::LN_RECEIVE,
+                "lnv2",
+                4,
+                receive_details.clone(),
+                Some(canceled),
+            ),
         )
         .await;
 
@@ -529,12 +536,13 @@ mod tests {
         write(
             &db,
             id_bytes(5),
-            kinds::LN_RECEIVE,
-            "lnv2",
-            5,
-            receive_details.clone(),
-            Some(expired),
-            1,
+            record(
+                kinds::LN_RECEIVE,
+                "lnv2",
+                5,
+                receive_details.clone(),
+                Some(expired),
+            ),
         )
         .await;
 
@@ -544,12 +552,13 @@ mod tests {
         write(
             &db,
             id_bytes(6),
-            kinds::LN_RECEIVE,
-            "lnv2",
-            6,
-            receive_details,
-            Some(failed_receive),
-            1,
+            record(
+                kinds::LN_RECEIVE,
+                "lnv2",
+                6,
+                receive_details,
+                Some(failed_receive),
+            ),
         )
         .await;
 
@@ -580,12 +589,13 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            kinds::LN_SEND,
-            "lnv2",
-            1,
-            send_details_json(&send_details()),
-            Some(r#"{"Settled":{}}"#.to_owned()),
-            1,
+            record(
+                kinds::LN_SEND,
+                "lnv2",
+                1,
+                send_details_json(&send_details()),
+                Some(r#"{"Settled":{}}"#.to_owned()),
+            ),
         )
         .await;
 
@@ -606,23 +616,19 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            "widget",
-            "widget",
-            1,
-            "{}".to_owned(),
-            None,
-            1,
+            record("widget", "widget", 1, "{}".to_owned(), None),
         )
         .await;
         write(
             &db,
             id_bytes(2),
-            "widget",
-            "widget",
-            2,
-            "{}".to_owned(),
-            Some("done".to_owned()),
-            1,
+            record(
+                "widget",
+                "widget",
+                2,
+                "{}".to_owned(),
+                Some("done".to_owned()),
+            ),
         )
         .await;
 
@@ -663,12 +669,16 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            kinds::LN_SEND,
-            "lnv2",
-            1,
-            send_details_json(&details),
-            Some(encoded),
-            2,
+            OperationRecord {
+                schema_version: 2,
+                ..record(
+                    kinds::LN_SEND,
+                    "lnv2",
+                    1,
+                    send_details_json(&details),
+                    Some(encoded),
+                )
+            },
         )
         .await;
 
@@ -690,12 +700,7 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            kinds::ECASH_SEND,
-            "mint",
-            1,
-            String::new(),
-            None,
-            1,
+            record(kinds::ECASH_SEND, "mint", 1, String::new(), None),
         )
         .await;
 
@@ -792,12 +797,7 @@ mod tests {
         write(
             &db,
             id_bytes(1),
-            kinds::ECASH_SEND,
-            "mint",
-            1,
-            String::new(),
-            None,
-            1,
+            record(kinds::ECASH_SEND, "mint", 1, String::new(), None),
         )
         .await;
         let inner = a_pending_ecash_send(&federation);

--- a/rust/fedimint-sdk/src/activity/rows.rs
+++ b/rust/fedimint-sdk/src/activity/rows.rs
@@ -190,24 +190,6 @@ pub(super) trait Row: Bucket {
     fn figures(driver: &dyn Driver<Self>, details: &str) -> Result<Figures>;
 }
 
-/// [`Row::figures`] for a kind that persists a details record.
-fn detailed<S>(driver: &dyn Driver<S>, details: &str) -> Result<Figures>
-where
-    S: DetailedOperationState,
-    S::Details: Accounted,
-{
-    let decoded = driver.decode_details(details)?;
-    match decoded.downcast::<S::Details>() {
-        Ok(details) => Ok(details.figures()),
-        // Unreachable through the page walk, which pairs each kind with its own driver; an
-        // `Internal` rather than a panic for the same reason `Operation::details` gives.
-        Err(_) => Err(Error::new(
-            ErrorCode::Internal,
-            "this operation's details record does not match its kind",
-        )),
-    }
-}
-
 impl Row for EcashSendState {
     fn figures(driver: &dyn Driver<EcashSendState>, details: &str) -> Result<Figures> {
         detailed(driver, details)
@@ -249,6 +231,24 @@ impl Row for RecoveryState {
     /// its driver is `Internal` by contract, and no caller can reach it.
     fn figures(_driver: &dyn Driver<RecoveryState>, _details: &str) -> Result<Figures> {
         Ok(Figures::NONE)
+    }
+}
+
+/// [`Row::figures`] for a kind that persists a details record.
+fn detailed<S>(driver: &dyn Driver<S>, details: &str) -> Result<Figures>
+where
+    S: DetailedOperationState,
+    S::Details: Accounted,
+{
+    let decoded = driver.decode_details(details)?;
+    match decoded.downcast::<S::Details>() {
+        Ok(details) => Ok(details.figures()),
+        // Unreachable through the page walk, which pairs each kind with its own driver; an
+        // `Internal` rather than a panic for the same reason `Operation::details` gives.
+        Err(_) => Err(Error::new(
+            ErrorCode::Internal,
+            "this operation's details record does not match its kind",
+        )),
     }
 }
 

--- a/rust/fedimint-sdk/src/activity/rows.rs
+++ b/rust/fedimint-sdk/src/activity/rows.rs
@@ -1,0 +1,724 @@
+//! The two tables behind an activity row: which bucket a state lands in, and which figures a
+//! details record yields.
+
+use crate::operation::Driver;
+use crate::{
+    ActivityStatus, Amount, DetailedOperationState, Direction, EcashReceiveDetails,
+    EcashReceiveState, EcashSendDetails, EcashSendState, Error, ErrorCode, LnReceiveDetails,
+    LnReceiveState, LnSendDetails, LnSendState, OnchainReceiveDetails, OnchainReceiveState,
+    OnchainSendDetails, OnchainSendState, OperationDetails, OperationState, RecoveryState, Result,
+    Sats,
+};
+
+/// The three numbers a row carries, as the table on [`ActivityItem`](crate::ActivityItem) fixes
+/// them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Figures {
+    pub(super) amount: Option<Amount>,
+    pub(super) fee: Option<Amount>,
+    pub(super) direction: Option<Direction>,
+}
+
+impl Figures {
+    /// No figures at all: a recovery, or a row whose outcome cannot be read.
+    pub(super) const NONE: Figures = Figures {
+        amount: None,
+        fee: None,
+        direction: None,
+    };
+}
+
+/// Which bucket a state lands in, exactly as the table on
+/// [`ActivityStatus`](crate::ActivityStatus) says.
+pub(super) trait Bucket: OperationState {
+    fn bucket(&self) -> ActivityStatus;
+}
+
+impl Bucket for EcashSendState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            EcashSendState::Created | EcashSendState::CancelRequested => ActivityStatus::Pending,
+            EcashSendState::Redeemed => ActivityStatus::Success,
+            EcashSendState::Canceled => ActivityStatus::Canceled,
+        }
+    }
+}
+
+impl Bucket for EcashReceiveState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            EcashReceiveState::Created | EcashReceiveState::Issuing => ActivityStatus::Pending,
+            EcashReceiveState::Done => ActivityStatus::Success,
+            EcashReceiveState::Failed { .. } => ActivityStatus::Failed,
+        }
+    }
+}
+
+impl Bucket for LnSendState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            LnSendState::Created | LnSendState::Funded => ActivityStatus::Pending,
+            LnSendState::Success { .. } => ActivityStatus::Success,
+            LnSendState::Refunded => ActivityStatus::Refunded,
+            LnSendState::Failed { .. } => ActivityStatus::Failed,
+        }
+    }
+}
+
+impl Bucket for LnReceiveState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            LnReceiveState::Created
+            | LnReceiveState::WaitingForPayment
+            | LnReceiveState::Funded => ActivityStatus::Pending,
+            LnReceiveState::Claimed => ActivityStatus::Success,
+            LnReceiveState::Canceled { .. } => ActivityStatus::Canceled,
+            // An invoice that simply lapsed unpaid is not a failure: nothing broke, the payment
+            // just never arrived, so it joins the withdrawn-invoice case here.
+            LnReceiveState::Expired => ActivityStatus::Canceled,
+            LnReceiveState::Failed => ActivityStatus::Failed,
+        }
+    }
+}
+
+impl Bucket for OnchainSendState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            OnchainSendState::Created => ActivityStatus::Pending,
+            OnchainSendState::Succeeded { .. } => ActivityStatus::Success,
+            OnchainSendState::Refunded { .. } => ActivityStatus::Refunded,
+            OnchainSendState::Failed { .. } => ActivityStatus::Failed,
+        }
+    }
+}
+
+impl Bucket for OnchainReceiveState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            OnchainReceiveState::WaitingForTransaction
+            | OnchainReceiveState::WaitingForConfirmation { .. }
+            | OnchainReceiveState::Confirmed { .. } => ActivityStatus::Pending,
+            OnchainReceiveState::Claimed { .. } => ActivityStatus::Success,
+            OnchainReceiveState::Failed { .. } => ActivityStatus::Failed,
+        }
+    }
+}
+
+impl Bucket for RecoveryState {
+    fn bucket(&self) -> ActivityStatus {
+        match self {
+            RecoveryState::Running => ActivityStatus::Pending,
+            RecoveryState::Done => ActivityStatus::Success,
+            RecoveryState::Failed { .. } => ActivityStatus::Failed,
+        }
+    }
+}
+
+/// The figures a details record yields, exactly as the table on
+/// [`ActivityItem`](crate::ActivityItem) says.
+pub(super) trait Accounted: OperationDetails {
+    fn figures(&self) -> Figures;
+}
+
+impl Accounted for EcashSendDetails {
+    fn figures(&self) -> Figures {
+        Figures {
+            amount: Some(self.notes_value),
+            fee: Some(self.fee),
+            direction: Some(Direction::Outgoing),
+        }
+    }
+}
+
+impl Accounted for EcashReceiveDetails {
+    fn figures(&self) -> Figures {
+        Figures {
+            amount: Some(self.notes_value),
+            fee: Some(self.fee),
+            direction: Some(Direction::Incoming),
+        }
+    }
+}
+
+impl Accounted for LnSendDetails {
+    fn figures(&self) -> Figures {
+        Figures {
+            amount: Some(self.invoice_amount),
+            fee: Some(self.fee),
+            direction: Some(Direction::Outgoing),
+        }
+    }
+}
+
+impl Accounted for LnReceiveDetails {
+    fn figures(&self) -> Figures {
+        Figures {
+            amount: Some(self.invoice_amount),
+            fee: Some(self.fee),
+            direction: Some(Direction::Incoming),
+        }
+    }
+}
+
+impl Accounted for OnchainSendDetails {
+    fn figures(&self) -> Figures {
+        Figures {
+            amount: self.amount.to_amount(),
+            fee: Some(self.fee),
+            direction: Some(Direction::Outgoing),
+        }
+    }
+}
+
+impl Accounted for OnchainReceiveDetails {
+    fn figures(&self) -> Figures {
+        Figures {
+            // `gross_deposited` is `Option<Sats>`, so `to_amount`'s own `Option<Amount>` has to
+            // be flattened rather than mapped into it; the brief's `.map` would leave this an
+            // `Option<Option<Amount>>`, which does not typecheck against `Figures::amount`.
+            amount: self.gross_deposited.and_then(Sats::to_amount),
+            fee: self.fee,
+            direction: Some(Direction::Incoming),
+        }
+    }
+}
+
+/// A state type whose rows the page walk can build: its bucket, and the figures of the record
+/// its kind persists.
+pub(super) trait Row: Bucket {
+    /// The figures from this kind's details JSON, decoded through its driver.
+    fn figures(driver: &dyn Driver<Self>, details: &str) -> Result<Figures>;
+}
+
+/// [`Row::figures`] for a kind that persists a details record.
+fn detailed<S>(driver: &dyn Driver<S>, details: &str) -> Result<Figures>
+where
+    S: DetailedOperationState,
+    S::Details: Accounted,
+{
+    let decoded = driver.decode_details(details)?;
+    match decoded.downcast::<S::Details>() {
+        Ok(details) => Ok(details.figures()),
+        // Unreachable through the page walk, which pairs each kind with its own driver; an
+        // `Internal` rather than a panic for the same reason `Operation::details` gives.
+        Err(_) => Err(Error::new(
+            ErrorCode::Internal,
+            "this operation's details record does not match its kind",
+        )),
+    }
+}
+
+impl Row for EcashSendState {
+    fn figures(driver: &dyn Driver<EcashSendState>, details: &str) -> Result<Figures> {
+        detailed(driver, details)
+    }
+}
+
+impl Row for EcashReceiveState {
+    fn figures(driver: &dyn Driver<EcashReceiveState>, details: &str) -> Result<Figures> {
+        detailed(driver, details)
+    }
+}
+
+impl Row for LnSendState {
+    fn figures(driver: &dyn Driver<LnSendState>, details: &str) -> Result<Figures> {
+        detailed(driver, details)
+    }
+}
+
+impl Row for LnReceiveState {
+    fn figures(driver: &dyn Driver<LnReceiveState>, details: &str) -> Result<Figures> {
+        detailed(driver, details)
+    }
+}
+
+impl Row for OnchainSendState {
+    fn figures(driver: &dyn Driver<OnchainSendState>, details: &str) -> Result<Figures> {
+        detailed(driver, details)
+    }
+}
+
+impl Row for OnchainReceiveState {
+    fn figures(driver: &dyn Driver<OnchainReceiveState>, details: &str) -> Result<Figures> {
+        detailed(driver, details)
+    }
+}
+
+impl Row for RecoveryState {
+    /// A recovery has no details record, so this never touches the driver: `decode_details` on
+    /// its driver is `Internal` by contract, and no caller can reach it.
+    fn figures(_driver: &dyn Driver<RecoveryState>, _details: &str) -> Result<Figures> {
+        Ok(Figures::NONE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use fedimint_core::core::OperationId as UpstreamOperationId;
+    use fedimint_core::util::{BoxFuture, BoxStream};
+
+    use super::*;
+    use crate::db::OperationRecord;
+    use crate::federation::FederationInner;
+    use crate::{Address, LightningRoute, OnchainReceiveFeeBreakdown, Timestamp, Txid};
+
+    /// A real out-of-band ecash token worth 1 satoshi, copied from `ecash.rs`'s own tests: no
+    /// part of it may appear in a `Debug` output, but nothing here prints one.
+    const TOKEN: &str = "AgEEKioqKgBVAf0D6AGl3T66ytG8SL2HGO7VqNodaPkTI77yhIrE-i5vju1xDzF4_UrvBHzCNOaxEnCG8zzECLOYGHgdlSFHU2DeayBfMyjkkKbZnV4lU6RVMgfIvQ==";
+
+    /// A real regtest invoice for 100_000 msat, copied from `lightning/wire.rs`'s own tests.
+    const INVOICE: &str = "lnbcrt1u1pj48ugqdq2vdhkven9v5pp5g3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqsp5242424242424242424242424242424242424242424242424242s9qrsgqcqzys2reg4wsryjt5w8z33ugydecgfmgyvtttwa7e0yzlm803z203j9hqspa4lr6m09cd808xkw9uh4sxc8wf3w6k0gaf5zrqm7zhcxug0vqqpdkpja";
+
+    /// A real regtest address, copied from `onchain.rs`'s own tests.
+    fn an_address() -> Address {
+        "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl"
+            .parse()
+            .expect("a valid regtest address")
+    }
+
+    /// The all-zero txid: these tests never look at its value, only carry it through a payload.
+    fn a_txid() -> Txid {
+        "0000000000000000000000000000000000000000000000000000000000000000"
+            .parse()
+            .expect("a well-formed transaction id")
+    }
+
+    fn ecash_send_details() -> EcashSendDetails {
+        EcashSendDetails {
+            notes: TOKEN.parse().expect("a valid ecash token"),
+            requested_amount: Amount::from_msats(750),
+            notes_value: Amount::from_msats(1_000),
+            fee: Amount::from_msats(50),
+            total_debited: Amount::from_msats(1_050),
+            reclaim_at: Timestamp::from_epoch_millis(1_700_086_400_000),
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    fn ecash_receive_details() -> EcashReceiveDetails {
+        EcashReceiveDetails {
+            notes: TOKEN.parse().expect("a valid ecash token"),
+            notes_value: Amount::from_msats(1_000),
+            fee: Amount::from_msats(36),
+            net_credit: Amount::from_msats(964),
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    fn ln_send_details() -> LnSendDetails {
+        LnSendDetails {
+            invoice: INVOICE.parse().expect("a valid regtest invoice"),
+            invoice_amount: Amount::from_msats(100_000),
+            fee: Amount::from_msats(1_050),
+            total: Amount::from_msats(101_050),
+            route: LightningRoute::Internal,
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    fn ln_receive_details() -> LnReceiveDetails {
+        LnReceiveDetails {
+            invoice: INVOICE.parse().expect("a valid regtest invoice"),
+            description: "coffee".to_owned(),
+            requested_amount: Amount::from_msats(100_000),
+            invoice_amount: Amount::from_msats(100_000),
+            fee: Amount::from_msats(500),
+            net_credit: Amount::from_msats(99_500),
+            gateway_id: None,
+            expires_at: Timestamp::from_epoch_millis(1_700_003_600_000),
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    fn onchain_send_details() -> OnchainSendDetails {
+        let amount = Sats::from_sats(25_000);
+        let fee = Amount::from_msats(4_321);
+        OnchainSendDetails {
+            address: an_address(),
+            amount,
+            fee,
+            total: amount
+                .to_amount()
+                .expect("25 000 sat is representable in msat")
+                .checked_add(fee)
+                .expect("no overflow at this magnitude"),
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    /// A deposit before any transaction has been seen: every fillable field is still `None`.
+    fn onchain_receive_details_waiting() -> OnchainReceiveDetails {
+        OnchainReceiveDetails {
+            address: an_address(),
+            txid: None,
+            gross_deposited: None,
+            fee: None,
+            fee_breakdown: None,
+            net_credit: None,
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    /// The same deposit once its claim has settled.
+    fn onchain_receive_details_claimed() -> OnchainReceiveDetails {
+        let gross = Sats::from_sats(100_000);
+        let fee = Amount::from_msats(1_500);
+        let net_credit = gross
+            .to_amount()
+            .expect("100 000 sat is representable in msat")
+            .checked_sub(fee)
+            .expect("the fee is smaller than the deposit");
+        OnchainReceiveDetails {
+            txid: Some(a_txid()),
+            gross_deposited: Some(gross),
+            fee: Some(fee),
+            fee_breakdown: Some(OnchainReceiveFeeBreakdown {
+                peg_in: fee,
+                network_claim: Amount::from_msats(0),
+                primary_module: Amount::from_msats(0),
+                dust: Amount::from_msats(0),
+            }),
+            net_credit: Some(net_credit),
+            ..onchain_receive_details_waiting()
+        }
+    }
+
+    #[test]
+    fn ecash_send_state_lands_in_its_documented_bucket() {
+        assert_eq!(EcashSendState::Created.bucket(), ActivityStatus::Pending);
+        assert_eq!(
+            EcashSendState::CancelRequested.bucket(),
+            ActivityStatus::Pending
+        );
+        assert_eq!(EcashSendState::Redeemed.bucket(), ActivityStatus::Success);
+        assert_eq!(EcashSendState::Canceled.bucket(), ActivityStatus::Canceled);
+
+        for state in [
+            EcashSendState::Created,
+            EcashSendState::CancelRequested,
+            EcashSendState::Redeemed,
+            EcashSendState::Canceled,
+        ] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn ecash_receive_state_lands_in_its_documented_bucket() {
+        let failed = EcashReceiveState::Failed {
+            reason: String::new(),
+        };
+
+        assert_eq!(EcashReceiveState::Created.bucket(), ActivityStatus::Pending);
+        assert_eq!(EcashReceiveState::Issuing.bucket(), ActivityStatus::Pending);
+        assert_eq!(EcashReceiveState::Done.bucket(), ActivityStatus::Success);
+        assert_eq!(failed.bucket(), ActivityStatus::Failed);
+
+        for state in [
+            EcashReceiveState::Created,
+            EcashReceiveState::Issuing,
+            EcashReceiveState::Done,
+            failed,
+        ] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn ln_send_state_lands_in_its_documented_bucket() {
+        let success = LnSendState::Success {
+            preimage: "0000000000000000000000000000000000000000000000000000000000000000"
+                .parse()
+                .expect("a well-formed preimage"),
+            fee: Amount::from_msats(1_050),
+            route: LightningRoute::Internal,
+        };
+        let failed = LnSendState::Failed {
+            reason: String::new(),
+        };
+
+        assert_eq!(LnSendState::Created.bucket(), ActivityStatus::Pending);
+        assert_eq!(LnSendState::Funded.bucket(), ActivityStatus::Pending);
+        assert_eq!(success.bucket(), ActivityStatus::Success);
+        assert_eq!(LnSendState::Refunded.bucket(), ActivityStatus::Refunded);
+        assert_eq!(failed.bucket(), ActivityStatus::Failed);
+
+        for state in [
+            LnSendState::Created,
+            LnSendState::Funded,
+            success,
+            LnSendState::Refunded,
+            failed,
+        ] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn ln_receive_state_lands_in_its_documented_bucket() {
+        let canceled = LnReceiveState::Canceled {
+            reason: String::new(),
+        };
+
+        assert_eq!(LnReceiveState::Created.bucket(), ActivityStatus::Pending);
+        assert_eq!(
+            LnReceiveState::WaitingForPayment.bucket(),
+            ActivityStatus::Pending
+        );
+        assert_eq!(LnReceiveState::Funded.bucket(), ActivityStatus::Pending);
+        assert_eq!(LnReceiveState::Claimed.bucket(), ActivityStatus::Success);
+        assert_eq!(canceled.bucket(), ActivityStatus::Canceled);
+        // The one placement that is a judgement rather than a reading: an invoice that simply
+        // lapsed unpaid is not a failure.
+        assert_eq!(LnReceiveState::Expired.bucket(), ActivityStatus::Canceled);
+        assert_eq!(LnReceiveState::Failed.bucket(), ActivityStatus::Failed);
+
+        for state in [
+            LnReceiveState::Created,
+            LnReceiveState::WaitingForPayment,
+            LnReceiveState::Funded,
+            LnReceiveState::Claimed,
+            canceled,
+            LnReceiveState::Expired,
+            LnReceiveState::Failed,
+        ] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn onchain_send_state_lands_in_its_documented_bucket() {
+        let succeeded = OnchainSendState::Succeeded { txid: a_txid() };
+        let refunded = OnchainSendState::Refunded {
+            reason: String::new(),
+        };
+        let failed = OnchainSendState::Failed {
+            reason: String::new(),
+        };
+
+        assert_eq!(OnchainSendState::Created.bucket(), ActivityStatus::Pending);
+        assert_eq!(succeeded.bucket(), ActivityStatus::Success);
+        assert_eq!(refunded.bucket(), ActivityStatus::Refunded);
+        assert_eq!(failed.bucket(), ActivityStatus::Failed);
+
+        for state in [OnchainSendState::Created, succeeded, refunded, failed] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn onchain_receive_state_lands_in_its_documented_bucket() {
+        let waiting_for_confirmation = OnchainReceiveState::WaitingForConfirmation {
+            txid: a_txid(),
+            gross_deposited: Sats::from_sats(100_000),
+        };
+        let confirmed = OnchainReceiveState::Confirmed {
+            txid: a_txid(),
+            gross_deposited: Sats::from_sats(100_000),
+        };
+        let claimed = OnchainReceiveState::Claimed {
+            txid: a_txid(),
+            gross_deposited: Sats::from_sats(100_000),
+            net_credit: Amount::from_msats(99_998_500),
+        };
+        let failed = OnchainReceiveState::Failed {
+            reason: String::new(),
+        };
+
+        assert_eq!(
+            OnchainReceiveState::WaitingForTransaction.bucket(),
+            ActivityStatus::Pending
+        );
+        assert_eq!(waiting_for_confirmation.bucket(), ActivityStatus::Pending);
+        assert_eq!(confirmed.bucket(), ActivityStatus::Pending);
+        assert_eq!(claimed.bucket(), ActivityStatus::Success);
+        assert_eq!(failed.bucket(), ActivityStatus::Failed);
+
+        for state in [
+            OnchainReceiveState::WaitingForTransaction,
+            waiting_for_confirmation,
+            confirmed,
+            claimed,
+            failed,
+        ] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn recovery_state_lands_in_its_documented_bucket() {
+        let failed = RecoveryState::Failed {
+            reason: String::new(),
+        };
+
+        assert_eq!(RecoveryState::Running.bucket(), ActivityStatus::Pending);
+        assert_eq!(RecoveryState::Done.bucket(), ActivityStatus::Success);
+        assert_eq!(failed.bucket(), ActivityStatus::Failed);
+
+        for state in [RecoveryState::Running, RecoveryState::Done, failed] {
+            assert_eq!(state.bucket() == ActivityStatus::Pending, !state.is_final());
+        }
+    }
+
+    #[test]
+    fn ecash_send_details_yield_notes_value_fee_and_outgoing() {
+        let details = ecash_send_details();
+        assert_eq!(
+            details.figures(),
+            Figures {
+                amount: Some(details.notes_value),
+                fee: Some(details.fee),
+                direction: Some(Direction::Outgoing),
+            }
+        );
+    }
+
+    #[test]
+    fn ecash_receive_details_yield_notes_value_fee_and_incoming() {
+        let details = ecash_receive_details();
+        assert_eq!(
+            details.figures(),
+            Figures {
+                amount: Some(details.notes_value),
+                fee: Some(details.fee),
+                direction: Some(Direction::Incoming),
+            }
+        );
+    }
+
+    #[test]
+    fn ln_send_details_yield_invoice_amount_fee_and_outgoing() {
+        let details = ln_send_details();
+        assert_eq!(
+            details.figures(),
+            Figures {
+                amount: Some(details.invoice_amount),
+                fee: Some(details.fee),
+                direction: Some(Direction::Outgoing),
+            }
+        );
+    }
+
+    #[test]
+    fn ln_receive_details_yield_invoice_amount_fee_and_incoming() {
+        let details = ln_receive_details();
+        assert_eq!(
+            details.figures(),
+            Figures {
+                amount: Some(details.invoice_amount),
+                fee: Some(details.fee),
+                direction: Some(Direction::Incoming),
+            }
+        );
+    }
+
+    #[test]
+    fn onchain_send_details_yield_a_whole_multiple_of_a_thousand_msats() {
+        let details = onchain_send_details();
+        let figures = details.figures();
+        assert_eq!(figures.amount, Some(Amount::from_msats(25_000_000)));
+        assert_eq!(
+            figures.amount.and_then(Amount::to_sats_exact),
+            Some(details.amount)
+        );
+        assert_eq!(figures.fee, Some(details.fee));
+        assert_eq!(figures.direction, Some(Direction::Outgoing));
+    }
+
+    #[test]
+    fn onchain_receive_details_yield_no_figures_before_a_transaction_and_the_credit_after() {
+        let waiting = onchain_receive_details_waiting();
+        assert_eq!(
+            waiting.figures(),
+            Figures {
+                amount: None,
+                fee: None,
+                direction: Some(Direction::Incoming),
+            }
+        );
+
+        let claimed = onchain_receive_details_claimed();
+        assert_eq!(
+            claimed.figures(),
+            Figures {
+                amount: claimed.gross_deposited.and_then(Sats::to_amount),
+                fee: claimed.fee,
+                direction: Some(Direction::Incoming),
+            }
+        );
+    }
+
+    /// A driver whose every method reports `Internal`. [`RecoveryState`]'s [`Row::figures`]
+    /// must never call any of them: a recovery has no details record to decode.
+    struct RefusingDriver;
+
+    impl Driver<RecoveryState> for RefusingDriver {
+        fn current<'a>(
+            &'a self,
+            _federation: &'a FederationInner,
+            _id: UpstreamOperationId,
+            _record: &'a OperationRecord,
+        ) -> BoxFuture<'a, Result<RecoveryState>> {
+            Box::pin(async { Err(Error::new(ErrorCode::Internal, "not to be called")) })
+        }
+
+        fn subscribe<'a>(
+            &'a self,
+            _federation: &'a FederationInner,
+            _id: UpstreamOperationId,
+            _record: &'a OperationRecord,
+        ) -> BoxFuture<'a, Result<BoxStream<'static, Result<RecoveryState>>>> {
+            Box::pin(async { Err(Error::new(ErrorCode::Internal, "not to be called")) })
+        }
+
+        fn same_state(&self, _previous: &RecoveryState, _next: &RecoveryState) -> bool {
+            false
+        }
+
+        fn encode_state(&self, _state: &RecoveryState) -> Result<String> {
+            Err(Error::new(ErrorCode::Internal, "not to be called"))
+        }
+
+        fn decode_state(&self, _encoded: &str) -> Result<RecoveryState> {
+            Err(Error::new(ErrorCode::Internal, "not to be called"))
+        }
+
+        fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {
+            Err(Error::new(ErrorCode::Internal, "not to be called"))
+        }
+    }
+
+    #[test]
+    fn a_recovery_yields_no_figures() {
+        let figures = RecoveryState::figures(&RefusingDriver, "").expect("a recovery never fails");
+        assert_eq!(figures, Figures::NONE);
+    }
+
+    #[test]
+    fn figures_of_a_detailed_kind_go_through_the_driver() {
+        // A hand-written `LnSendDetailsWire` (`lightning/wire.rs:79-92`), since that type is
+        // `pub(super)` to `lightning` and unreachable from here.
+        let json = serde_json::json!({
+            "invoice": INVOICE,
+            "invoice_amount_msats": 100_000,
+            "fee_msats": 1_050,
+            "total_msats": 101_050,
+            "route": { "kind": "internal" },
+            "created_at": 1_700_000_000_000u64,
+        })
+        .to_string();
+
+        let figures = LnSendState::figures(&crate::lightning::LnSendDriver, &json)
+            .expect("a well-formed record decodes");
+        assert_eq!(
+            figures,
+            Figures {
+                amount: Some(Amount::from_msats(100_000)),
+                fee: Some(Amount::from_msats(1_050)),
+                direction: Some(Direction::Outgoing),
+            }
+        );
+    }
+}

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -276,6 +276,10 @@ impl Federation {
     /// each following one. At most `limit` items are returned; fewer is
     /// normal, and an empty page with no cursor means the end.
     ///
+    /// Rows still in flight are brought up to date before the page is
+    /// returned, so a page that has any takes a moment longer than one
+    /// that has none.
+    ///
     /// The history is *local*, see [`ActivityItem`](crate::ActivityItem)
     /// for exactly what that excludes.
     ///
@@ -283,7 +287,7 @@ impl Federation {
     ///
     /// [`Storage`](crate::ErrorCode::Storage),
     /// [`InvalidInput`](crate::ErrorCode::InvalidInput) for a cursor that
-    /// is not one this federation issued, and
+    /// is not one this federation issued or for a `limit` of zero, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn activity(&self, cursor: Option<Cursor>, limit: u16) -> Result<ActivityPage> {
         crate::activity::page(&self.inner, cursor, limit).await

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -286,7 +286,7 @@ impl Federation {
     /// is not one this federation issued, and
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
     pub async fn activity(&self, cursor: Option<Cursor>, limit: u16) -> Result<ActivityPage> {
-        unimplemented!()
+        crate::activity::page(&self.inner, cursor, limit).await
     }
 
     /// Uploads a fresh encrypted backup to the federation.

--- a/rust/fedimint-sdk/src/lightning.rs
+++ b/rust/fedimint-sdk/src/lightning.rs
@@ -1051,6 +1051,63 @@ pub(super) fn now() -> Timestamp {
     Timestamp::from_epoch_millis(crate::db::now_millis())
 }
 
+/// Realistic lightning records for other modules' tests, so a test elsewhere does not have to
+/// hand-assemble one.
+//
+// At file scope rather than inside `mod tests`, because a `mod tests` is private to its own
+// file and the page walk's own tests (`src/activity/page.rs`) need these too.
+#[cfg(test)]
+pub(crate) mod fixtures {
+    use super::wire::{LnReceiveDetailsWire, LnSendDetailsWire};
+    use crate::{Amount, LightningRoute, LnReceiveDetails, LnSendDetails, Timestamp};
+
+    /// A real regtest invoice for 100 000 msat, the same literal `lightning/wire.rs`'s own
+    /// tests use.
+    const INVOICE: &str = "lnbcrt1u1pj48ugqdq2vdhkven9v5pp5g3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqsp5242424242424242424242424242424242424242424242424242s9qrsgqcqzys2reg4wsryjt5w8z33ugydecgfmgyvtttwa7e0yzlm803z203j9hqspa4lr6m09cd808xkw9uh4sxc8wf3w6k0gaf5zrqm7zhcxug0vqqpdkpja";
+    /// A real compressed secp256k1 public key, from that crate's own test suite.
+    const GATEWAY_ID: &str = "0218845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166";
+
+    /// A send of 100 000 msat with a 1 000 msat fee, routed through a gateway.
+    pub(crate) fn send_details() -> LnSendDetails {
+        LnSendDetails {
+            invoice: INVOICE.parse().expect("a valid regtest invoice"),
+            invoice_amount: Amount::from_msats(100_000),
+            fee: Amount::from_msats(1_000),
+            total: Amount::from_msats(101_000),
+            route: LightningRoute::Gateway {
+                gateway_id: GATEWAY_ID.parse().expect("a valid gateway id"),
+            },
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    /// A receive of the same invoice with a 500 msat fee, crediting 99 500 msat.
+    pub(crate) fn receive_details() -> LnReceiveDetails {
+        LnReceiveDetails {
+            invoice: INVOICE.parse().expect("a valid regtest invoice"),
+            description: "coffee".to_owned(),
+            requested_amount: Amount::from_msats(100_000),
+            invoice_amount: Amount::from_msats(100_000),
+            fee: Amount::from_msats(500),
+            net_credit: Amount::from_msats(99_500),
+            gateway_id: Some(GATEWAY_ID.parse().expect("a valid gateway id")),
+            expires_at: Timestamp::from_epoch_millis(1_700_003_600_000),
+            created_at: Timestamp::from_epoch_millis(1_700_000_000_000),
+        }
+    }
+
+    /// [`send_details`], as it is actually persisted: through the wire type, the same JSON a
+    /// real send record's `details` field holds.
+    pub(crate) fn send_details_json(details: &LnSendDetails) -> String {
+        serde_json::to_string(&LnSendDetailsWire::from(details)).expect("a well-formed record")
+    }
+
+    /// [`receive_details`], as it is actually persisted.
+    pub(crate) fn receive_details_json(details: &LnReceiveDetails) -> String {
+        serde_json::to_string(&LnReceiveDetailsWire::from(details)).expect("a well-formed record")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/fedimint-sdk/src/lightning/driver.rs
+++ b/rust/fedimint-sdk/src/lightning/driver.rs
@@ -138,6 +138,10 @@ impl Driver<LnSendState> for LnSendDriver {
         wire::encode_send_state(state)
     }
 
+    fn decode_state(&self, encoded: &str) -> Result<LnSendState> {
+        wire::decode_send_state(encoded)
+    }
+
     fn decode_details(&self, json: &str) -> Result<Box<dyn Any + Send + Sync>> {
         Ok(Box::new(wire::decode_send_details(json)?))
     }
@@ -186,6 +190,10 @@ impl Driver<LnReceiveState> for LnReceiveDriver {
         wire::encode_receive_state(state)
     }
 
+    fn decode_state(&self, encoded: &str) -> Result<LnReceiveState> {
+        wire::decode_receive_state(encoded)
+    }
+
     fn decode_details(&self, json: &str) -> Result<Box<dyn Any + Send + Sync>> {
         Ok(Box::new(wire::decode_receive_details(json)?))
     }
@@ -222,6 +230,7 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
+    use crate::{Amount, LightningRoute, Preimage};
 
     // Only `LnSendState`'s non-final (`Created`, `Funded`) and final (`Refunded`, `Failed`)
     // variants that need no fields are used below; `settled` treats every state the same way
@@ -316,5 +325,46 @@ mod tests {
             .await
             .expect_err("an empty stream must not settle");
         assert_eq!(err.code, ErrorCode::Internal);
+    }
+
+    #[test]
+    fn send_driver_decodes_what_it_encodes() {
+        let driver = LnSendDriver;
+        let preimage: Preimage = "11".repeat(32).parse().expect("a preimage");
+        for state in [
+            LnSendState::Created,
+            LnSendState::Funded,
+            LnSendState::Success {
+                preimage,
+                fee: Amount::from_msats(1_050),
+                route: LightningRoute::Internal,
+            },
+            LnSendState::Refunded,
+            LnSendState::Failed {
+                reason: "gone".to_owned(),
+            },
+        ] {
+            let encoded = driver.encode_state(&state).expect("encode");
+            assert_eq!(driver.decode_state(&encoded).expect("decode"), state);
+        }
+    }
+
+    #[test]
+    fn receive_driver_decodes_what_it_encodes() {
+        let driver = LnReceiveDriver;
+        for state in [
+            LnReceiveState::Created,
+            LnReceiveState::WaitingForPayment,
+            LnReceiveState::Funded,
+            LnReceiveState::Claimed,
+            LnReceiveState::Canceled {
+                reason: "withdrawn".to_owned(),
+            },
+            LnReceiveState::Expired,
+            LnReceiveState::Failed,
+        ] {
+            let encoded = driver.encode_state(&state).expect("encode");
+            assert_eq!(driver.decode_state(&encoded).expect("decode"), state);
+        }
     }
 }

--- a/rust/fedimint-sdk/src/operation.rs
+++ b/rust/fedimint-sdk/src/operation.rs
@@ -1324,6 +1324,13 @@ where
     /// finished without decoding it.
     fn encode_state(&self, state: &S) -> Result<String>;
 
+    /// The state back from what [`encode_state`](Driver::encode_state) wrote.
+    ///
+    /// Read by a history row to report how a finished operation turned out without asking the
+    /// module again. A value this build cannot read, such as a variant a newer build added, is
+    /// an error here rather than a guess; the row then reports its outcome as unknown.
+    fn decode_state(&self, encoded: &str) -> Result<S>;
+
     /// The details record this kind persisted at creation, decoded from its JSON.
     ///
     /// Type-erased because [`Operation::details`] is one generic body over every kind: the
@@ -1496,6 +1503,19 @@ impl Driver<EcashSendState> for ProbeEcashSendDriver {
 
     fn encode_state(&self, state: &EcashSendState) -> Result<String> {
         Ok(format!("{state:?}"))
+    }
+
+    fn decode_state(&self, encoded: &str) -> Result<EcashSendState> {
+        match encoded {
+            "Created" => Ok(EcashSendState::Created),
+            "CancelRequested" => Ok(EcashSendState::CancelRequested),
+            "Canceled" => Ok(EcashSendState::Canceled),
+            "Redeemed" => Ok(EcashSendState::Redeemed),
+            _ => Err(Error::new(
+                ErrorCode::Internal,
+                format!("unrecognised ecash send state: {encoded}"),
+            )),
+        }
     }
 
     fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {
@@ -1804,6 +1824,20 @@ mod tests {
         }
     }
 
+    /// The inverse of every test driver's `encode_state` for [`ProbeState`]: a bare
+    /// `"Running"`/`"Done"` or a JSON-quoted `"\"Running\""`/`"\"Done\""`, matching whichever
+    /// form the calling driver wrote. Anything else is a state this fixture did not write.
+    fn decode_probe_state(encoded: &str) -> Result<ProbeState> {
+        match encoded.trim_matches('"') {
+            "Running" => Ok(ProbeState::Running),
+            "Done" => Ok(ProbeState::Done),
+            _ => Err(Error::new(
+                ErrorCode::Internal,
+                format!("unrecognised probe state: {encoded}"),
+            )),
+        }
+    }
+
     impl sealed::Sealed for ProbeDetails {}
 
     impl OperationDetails for ProbeDetails {}
@@ -1936,6 +1970,10 @@ mod tests {
             })
         }
 
+        fn decode_state(&self, encoded: &str) -> Result<ProbeState> {
+            decode_probe_state(encoded)
+        }
+
         fn decode_details(&self, json: &str) -> Result<Box<dyn Any + Send + Sync>> {
             let wire: ProbeDetailsWire = serde_json::from_str(json).map_err(|err| {
                 Error::new(
@@ -1976,6 +2014,15 @@ mod tests {
     fn probe_state_finality_is_unaffected_by_having_details() {
         assert!(!ProbeState::Running.is_final());
         assert!(ProbeState::Done.is_final());
+    }
+
+    #[test]
+    fn a_probe_driver_refuses_a_state_it_did_not_write() {
+        let driver = ScriptedDriver::new(vec![]);
+        let err = driver
+            .decode_state("\"Elsewhere\"")
+            .expect_err("no variant is named Elsewhere");
+        assert_eq!(err.code, ErrorCode::Internal);
     }
 
     #[test]
@@ -2521,6 +2568,10 @@ mod tests {
             Ok(format!("{state:?}"))
         }
 
+        fn decode_state(&self, encoded: &str) -> Result<ProbeState> {
+            decode_probe_state(encoded)
+        }
+
         fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {
             Err(Error::new(
                 ErrorCode::Internal,
@@ -2819,6 +2870,10 @@ mod tests {
             Ok(format!("{state:?}"))
         }
 
+        fn decode_state(&self, encoded: &str) -> Result<ProbeState> {
+            decode_probe_state(encoded)
+        }
+
         fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {
             Err(Error::new(ErrorCode::Internal, "no details"))
         }
@@ -2894,6 +2949,10 @@ mod tests {
 
         fn encode_state(&self, state: &ProbeState) -> Result<String> {
             Ok(format!("{state:?}"))
+        }
+
+        fn decode_state(&self, encoded: &str) -> Result<ProbeState> {
+            decode_probe_state(encoded)
         }
 
         fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {

--- a/rust/fedimint-sdk/src/types/ids.rs
+++ b/rust/fedimint-sdk/src/types/ids.rs
@@ -8,6 +8,7 @@
 //! side is the only place that knows the format.
 
 use fedimint_core::bitcoin;
+use fedimint_core::bitcoin::hashes::{Hash, sha256};
 use fedimint_core::config;
 use fedimint_core::secp256k1::PublicKey;
 
@@ -261,30 +262,55 @@ impl core::str::FromStr for Txid {
 /// the other ids in this module, purely so it can be stored and reloaded
 /// (e.g. to resume paging after an app restart) without a bespoke
 /// serialization path.
-// Unlike the other ids in this module, this one still wraps an opaque string rather than
-// an upstream type, since there is no activity facade yet to define what a cursor
-// actually addresses. Replace the field with whatever that facade needs once it lands.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Cursor {
-    token: String,
+    /// The federation whose index this position is in.
+    federation: FederationId,
+    /// `OperationRecord::created_at` of the last row of the page this cursor followed.
+    created_at: u64,
+    /// The last row's operation, which breaks ties on `created_at`.
+    id: OperationId,
 }
 
 impl Cursor {
-    /// Wraps an already-validated cursor token.
-    ///
-    /// Crate-internal: this performs no validation of its own, so it is not
-    /// part of the public API. Validation belongs in
-    /// [`FromStr`](core::str::FromStr), which is the only way a caller
-    /// outside this crate can build one.
-    pub(crate) fn from_raw(raw: String) -> Self {
-        Self { token: raw }
+    /// The position after one row, for the page that follows it.
+    pub(crate) fn new(federation: FederationId, created_at: u64, id: OperationId) -> Cursor {
+        Self {
+            federation,
+            created_at,
+            id,
+        }
+    }
+
+    /// The federation that issued this cursor.
+    pub(crate) fn federation(&self) -> &FederationId {
+        &self.federation
+    }
+
+    /// The creation time of the row this cursor follows, in milliseconds since the epoch.
+    pub(crate) fn created_at(&self) -> u64 {
+        self.created_at
+    }
+
+    /// The operation this cursor follows.
+    pub(crate) fn id(&self) -> &OperationId {
+        &self.id
     }
 }
 
+// One version byte, the federation id (32 bytes), `created_at` as big-endian `u64` (8 bytes),
+// and the operation id (32 bytes).
+const CURSOR_VERSION: u8 = 1;
+const CURSOR_LEN: usize = 1 + 32 + 8 + 32;
+
 impl core::fmt::Display for Cursor {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let _ = &self.token;
-        unimplemented!()
+        let mut bytes = [0u8; CURSOR_LEN];
+        bytes[0] = CURSOR_VERSION;
+        bytes[1..33].copy_from_slice(&self.federation.inner().0.to_byte_array());
+        bytes[33..41].copy_from_slice(&self.created_at.to_be_bytes());
+        bytes[41..73].copy_from_slice(&self.id.upstream().0);
+        write!(f, "{}", fedimint_core::hex::encode(bytes))
     }
 }
 
@@ -295,8 +321,31 @@ impl core::str::FromStr for Cursor {
     /// `Display` impl. Returns
     /// [`ErrorCode::InvalidInput`](crate::ErrorCode::InvalidInput) for a
     /// malformed value.
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        unimplemented!()
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // The format is opaque to callers, so every way it can be wrong (bad hex, the wrong
+        // length, an unrecognised version) collapses to the same message: which byte was wrong
+        // is not something a caller can act on.
+        let invalid = || Error::new(ErrorCode::InvalidInput, "not a cursor this SDK issued");
+        let bytes = fedimint_core::hex::decode(s).map_err(|_| invalid())?;
+        let bytes: [u8; CURSOR_LEN] = bytes.try_into().map_err(|_| invalid())?;
+        if bytes[0] != CURSOR_VERSION {
+            return Err(invalid());
+        }
+
+        let mut federation_bytes = [0u8; 32];
+        federation_bytes.copy_from_slice(&bytes[1..33]);
+        let mut created_at_bytes = [0u8; 8];
+        created_at_bytes.copy_from_slice(&bytes[33..41]);
+        let mut id_bytes = [0u8; 32];
+        id_bytes.copy_from_slice(&bytes[41..73]);
+
+        Ok(Self {
+            federation: FederationId::from_upstream(config::FederationId(
+                sha256::Hash::from_byte_array(federation_bytes),
+            )),
+            created_at: u64::from_be_bytes(created_at_bytes),
+            id: OperationId::from_upstream(fedimint_core::core::OperationId(id_bytes)),
+        })
     }
 }
 
@@ -432,5 +481,91 @@ mod tests {
         assert_eq!(printed.len(), 64);
         assert!(!printed.contains('_'));
         assert_eq!(printed.parse::<OperationId>().expect("re-parses"), id);
+    }
+
+    #[test]
+    fn a_cursor_round_trips_through_display_and_from_str() {
+        let federation = FEDERATION_ID
+            .parse::<FederationId>()
+            .expect("a valid federation id");
+        let id = ZEROS.parse::<OperationId>().expect("a valid operation id");
+        let cursor = Cursor::new(federation.clone(), 1_700_000_000_000, id.clone());
+
+        let printed = cursor.to_string();
+        let parsed = printed.parse::<Cursor>().expect("round-trips");
+
+        assert_eq!(parsed, cursor);
+        assert_eq!(parsed.federation(), &federation);
+        assert_eq!(parsed.created_at(), 1_700_000_000_000);
+        assert_eq!(parsed.id(), &id);
+    }
+
+    #[test]
+    fn a_cursor_renders_as_opaque_lowercase_hex() {
+        let federation = FEDERATION_ID
+            .parse::<FederationId>()
+            .expect("a valid federation id");
+        let id = ZEROS.parse::<OperationId>().expect("a valid operation id");
+        let cursor = Cursor::new(federation, 0, id.clone());
+
+        let printed = cursor.to_string();
+        assert_eq!(printed.len(), 146);
+        assert!(
+            printed
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+        );
+        assert_ne!(printed, id.to_string());
+    }
+
+    #[test]
+    fn a_cursor_from_a_different_version_is_refused() {
+        let federation = FEDERATION_ID
+            .parse::<FederationId>()
+            .expect("a valid federation id");
+        let id = ZEROS.parse::<OperationId>().expect("a valid operation id");
+        let cursor = Cursor::new(federation, 0, id);
+
+        let mut printed = cursor.to_string();
+        // Flip the version byte (the first hex pair) to one this SDK never writes.
+        let flipped = !CURSOR_VERSION;
+        printed.replace_range(0..2, &format!("{flipped:02x}"));
+
+        assert_eq!(
+            printed.parse::<Cursor>().expect_err("wrong version").code,
+            crate::ErrorCode::InvalidInput
+        );
+    }
+
+    #[test]
+    fn a_truncated_or_padded_cursor_is_refused() {
+        let federation = FEDERATION_ID
+            .parse::<FederationId>()
+            .expect("a valid federation id");
+        let id = ZEROS.parse::<OperationId>().expect("a valid operation id");
+        let cursor = Cursor::new(federation, 0, id);
+        let printed = cursor.to_string();
+
+        let truncated = &printed[..printed.len() - 2];
+        assert_eq!(
+            truncated.parse::<Cursor>().expect_err("too short").code,
+            crate::ErrorCode::InvalidInput
+        );
+
+        let padded = format!("{printed}aa");
+        assert_eq!(
+            padded.parse::<Cursor>().expect_err("too long").code,
+            crate::ErrorCode::InvalidInput
+        );
+    }
+
+    #[test]
+    fn text_that_is_not_hex_is_refused() {
+        for rejected in ["", "zz", "not a cursor"] {
+            assert_eq!(
+                rejected.parse::<Cursor>().expect_err("rejected").code,
+                crate::ErrorCode::InvalidInput
+            );
+        }
     }
 }

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -856,17 +856,21 @@ async fn activity_lists_what_the_federation_was_used_for() {
 
     assert_eq!(send_row.operation_id, send_id);
     assert_eq!(send_row.kind, OperationKind::LnSend);
-    assert_eq!(send_row.direction, Some(Direction::Outgoing));
-    assert_eq!(send_row.amount, Some(Amount::from_msats(50_000)));
-    assert_eq!(send_row.fee, Some(fee));
     if devimint.shape == "v1" {
-        // The record has no final state to read (fedimint/fedimint#8969, as above): the row
-        // reports what the record says rather than the outcome the payment actually reached.
-        assert_eq!(send_row.status, ActivityStatus::Pending);
+        // The record has no final state and the current one cannot be read
+        // (fedimint/fedimint#8969, as above): the outcome is unknown, not pending, and an
+        // unknown outcome carries no figures.
+        assert_eq!(send_row.status, ActivityStatus::Unknown);
         assert!(!send_row.is_final);
+        assert_eq!(send_row.direction, None);
+        assert_eq!(send_row.amount, None);
+        assert_eq!(send_row.fee, None);
     } else {
         assert_eq!(send_row.status, ActivityStatus::Success);
         assert!(send_row.is_final);
+        assert_eq!(send_row.direction, Some(Direction::Outgoing));
+        assert_eq!(send_row.amount, Some(Amount::from_msats(50_000)));
+        assert_eq!(send_row.fee, Some(fee));
     }
 
     assert_eq!(receive_row.kind, OperationKind::LnReceive);
@@ -918,15 +922,16 @@ async fn activity_lists_what_the_federation_was_used_for() {
     let receive_row = &restarted.items[1];
     assert_eq!(send_row.operation_id, send_id);
     assert_eq!(send_row.kind, OperationKind::LnSend);
-    assert_eq!(send_row.direction, Some(Direction::Outgoing));
-    assert_eq!(send_row.amount, Some(Amount::from_msats(50_000)));
-    assert_eq!(send_row.fee, Some(fee));
     if devimint.shape == "v1" {
-        assert_eq!(send_row.status, ActivityStatus::Pending);
+        assert_eq!(send_row.status, ActivityStatus::Unknown);
         assert!(!send_row.is_final);
+        assert_eq!(send_row.amount, None);
     } else {
         assert_eq!(send_row.status, ActivityStatus::Success);
         assert!(send_row.is_final);
+        assert_eq!(send_row.direction, Some(Direction::Outgoing));
+        assert_eq!(send_row.amount, Some(Amount::from_msats(50_000)));
+        assert_eq!(send_row.fee, Some(fee));
     }
     assert_eq!(receive_row.kind, OperationKind::LnReceive);
     assert_eq!(receive_row.direction, Some(Direction::Incoming));

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -909,9 +909,9 @@ async fn activity_lists_what_the_federation_was_used_for() {
         .expect("reopens");
     let federation = reopened.federation(&federation_id).expect("still there");
 
-    // The same two rows in the same order, with the same figures and buckets. On v2 the send's
-    // `Success` now comes off the record itself (the earlier read is what first persisted it),
-    // rather than a fresh read through the driver, but the row looks the same either way.
+    // The same two rows in the same order, with the same figures and buckets. `await_final`
+    // above already persisted the send's final state before the first `activity` call, so both
+    // that read and this one come off the record rather than a fresh one through the driver.
     let restarted = federation.activity(None, 10).await.expect("both rows");
     assert_eq!(restarted.items.len(), 2);
     let send_row = &restarted.items[0];

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -805,3 +805,147 @@ async fn lightning_send_refuses_a_quote_used_twice() {
     }
     sdk.shutdown().await.expect("shuts down");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn activity_lists_what_the_federation_was_used_for() {
+    use fedimint_sdk::{ActivityStatus, Amount, Cursor, Direction, OperationKind};
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    pin_lnv2_gateway_to_lnd(&devimint);
+    let (_storage, path, sdk, federation) = joined(&devimint).await;
+    let lightning = federation
+        .lightning()
+        .expect("devimint runs a lightning module");
+
+    let empty = federation.activity(None, 10).await.expect("an empty page");
+    assert!(empty.items.is_empty());
+    assert!(empty.next.is_none());
+
+    let funded = fund(&lightning, 200_000).await;
+
+    let invoice: fedimint_sdk::Bolt11Invoice = faucet("POST", "/invoice", "50000")
+        .expect("the faucet issues an invoice")
+        .trim()
+        .parse()
+        .expect("a bolt11 invoice");
+    let quote = lightning.quote(&invoice).await.expect("a quote");
+    let fee = quote.fee();
+    let send = lightning.send(quote).await.expect("the payment starts");
+    let send_id = send.id();
+
+    if devimint.shape == "v1" {
+        // fedimint/fedimint#8969: the v1 client strips two characters off the preimage the
+        // gateway returns, so the SDK cannot decode the success state. The payment itself goes
+        // through; only its observation fails.
+        let err = send.await_final().await.expect_err("fedimint#8969");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert!(err.message.contains("preimage"), "{}", err.message);
+    } else {
+        send.await_final().await.expect("settles");
+    }
+
+    let history = federation.activity(None, 10).await.expect("both rows");
+    assert_eq!(history.items.len(), 2);
+    assert!(history.next.is_none());
+    let send_row = &history.items[0];
+    let receive_row = &history.items[1];
+
+    assert_eq!(send_row.operation_id, send_id);
+    assert_eq!(send_row.kind, OperationKind::LnSend);
+    assert_eq!(send_row.direction, Some(Direction::Outgoing));
+    assert_eq!(send_row.amount, Some(Amount::from_msats(50_000)));
+    assert_eq!(send_row.fee, Some(fee));
+    if devimint.shape == "v1" {
+        // The record has no final state to read (fedimint/fedimint#8969, as above): the row
+        // reports what the record says rather than the outcome the payment actually reached.
+        assert_eq!(send_row.status, ActivityStatus::Pending);
+        assert!(!send_row.is_final);
+    } else {
+        assert_eq!(send_row.status, ActivityStatus::Success);
+        assert!(send_row.is_final);
+    }
+
+    assert_eq!(receive_row.kind, OperationKind::LnReceive);
+    assert_eq!(receive_row.direction, Some(Direction::Incoming));
+    assert_eq!(receive_row.amount, Some(Amount::from_msats(200_000)));
+    assert_eq!(
+        receive_row.fee,
+        Amount::from_msats(200_000).checked_sub(funded)
+    );
+    assert_eq!(receive_row.status, ActivityStatus::Success);
+    assert!(receive_row.is_final);
+    assert!(send_row.time >= receive_row.time);
+
+    // Paging: one row per page, the send first, then the receive with no cursor left after it.
+    let page_one = federation.activity(None, 1).await.expect("first page");
+    assert_eq!(page_one.items.len(), 1);
+    assert_eq!(page_one.items[0].operation_id, send_id);
+    let cursor = page_one.next.expect("the receive row remains");
+    let round_tripped: Cursor = cursor.to_string().parse().expect("the cursor round-trips");
+    let page_two = federation
+        .activity(Some(round_tripped), 1)
+        .await
+        .expect("second page");
+    assert_eq!(page_two.items.len(), 1);
+    assert_eq!(page_two.items[0].kind, OperationKind::LnReceive);
+    assert!(page_two.next.is_none());
+
+    // Restart, every handle dropped first, as in
+    // `lightning_receive_is_paid_by_the_faucet_and_survives_a_restart`.
+    let federation_id = federation.id();
+    sdk.shutdown().await.expect("shuts down");
+    drop(send);
+    drop(lightning);
+    drop(federation);
+    drop(sdk);
+    let reopened = Sdk::builder()
+        .storage(Storage::at(&path).expect("a valid path"))
+        .build()
+        .await
+        .expect("reopens");
+    let federation = reopened.federation(&federation_id).expect("still there");
+
+    // The same two rows in the same order, with the same figures and buckets. On v2 the send's
+    // `Success` now comes off the record itself (the earlier read is what first persisted it),
+    // rather than a fresh read through the driver, but the row looks the same either way.
+    let restarted = federation.activity(None, 10).await.expect("both rows");
+    assert_eq!(restarted.items.len(), 2);
+    let send_row = &restarted.items[0];
+    let receive_row = &restarted.items[1];
+    assert_eq!(send_row.operation_id, send_id);
+    assert_eq!(send_row.kind, OperationKind::LnSend);
+    assert_eq!(send_row.direction, Some(Direction::Outgoing));
+    assert_eq!(send_row.amount, Some(Amount::from_msats(50_000)));
+    assert_eq!(send_row.fee, Some(fee));
+    if devimint.shape == "v1" {
+        assert_eq!(send_row.status, ActivityStatus::Pending);
+        assert!(!send_row.is_final);
+    } else {
+        assert_eq!(send_row.status, ActivityStatus::Success);
+        assert!(send_row.is_final);
+    }
+    assert_eq!(receive_row.kind, OperationKind::LnReceive);
+    assert_eq!(receive_row.direction, Some(Direction::Incoming));
+    assert_eq!(receive_row.amount, Some(Amount::from_msats(200_000)));
+    assert_eq!(
+        receive_row.fee,
+        Amount::from_msats(200_000).checked_sub(funded)
+    );
+    assert_eq!(receive_row.status, ActivityStatus::Success);
+    assert!(receive_row.is_final);
+
+    assert_eq!(
+        federation
+            .activity(None, 0)
+            .await
+            .expect_err("zero is not a valid limit")
+            .code,
+        ErrorCode::InvalidInput
+    );
+
+    reopened.shutdown().await.expect("shuts down");
+}


### PR DESCRIPTION
## Description

- ref fedimint-sdk-implementation-plan T11; depends on nothing still open, lightning (#381) supplies the real rows
- `Federation::activity` pages over the SDK's own operation records newest first, one row per record, with the amount, fee, direction and outcome bucket the rustdoc on `ActivityItem` and `ActivityStatus` fixes. Both tables are implemented once, in `src/activity/rows.rs`, one impl per state enum and per details record, so the ecash, on-chain and recovery rows are written and unit-tested now and become reachable when each facade lands its driver arm
- a row whose ending was never observed is brought up to date on the way out through the same read `Operation::state` does, so a receive paid while the app was closed lists as done rather than pending. Those reads run concurrently per page. A refresh that fails with `FederationClosed` or `Storage` fails the call; any other failure leaves the row at what its record says, which is what a v1 send hits today because of fedimint/fedimint#8969
- every record renders, including the ones this build cannot open: an unrecognised kind, a state schema newer than this build reads, or a recorded ending it cannot decode all report `Unknown` with no numbers, and finality comes off the record independently of the outcome
- `Cursor` is now the position after the last row, bound to the federation that issued it, rendered as opaque hex; a cursor from another federation and a zero limit are `InvalidInput`
- `Driver::decode_state` joins `encode_state`; a driver added later (the ecash one in #383) has to implement it too

## Testing

- 384 unit tests (35 new: the two tables variant by variant, the cursor, the page walk with ties, cursors, unknown kinds, newer schemas, undecodable endings, refresh and refresh failure)
- devimint 9/9 on both the v1 and v2 shapes: the new test lists a receive and a send, pages through them with a cursor that survives a string round trip, and reads the same rows after a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QEJrgHniYSGG69T2Fcmyj
