### PR TITLE
feat(sdk): seed recovery, the lock and the retry (T12)

### DIFF
--- a/rust/fedimint-sdk/src/activity.rs
+++ b/rust/fedimint-sdk/src/activity.rs
@@ -21,8 +21,8 @@ pub(crate) use page::page;
 /// was happening, not because the federation kept a record of the account:
 ///
 /// - Restoring a seed does not restore this history. Recovery reconstructs
-///   what the federation and the backup can prove (notes, spendable
-///   balance, recoverable operations), not a narrative of past activity.
+///   what the federation can prove (notes, spendable balance,
+///   recoverable operations), not a narrative of past activity.
 ///   A wallet restored on a new device has a correct balance and an empty
 ///   or partial activity list.
 /// - Activity from another device or another client is not here. The same

--- a/rust/fedimint-sdk/src/db.rs
+++ b/rust/fedimint-sdk/src/db.rs
@@ -289,6 +289,7 @@ impl_db_lookup!(key = FederationKey, query_prefix = FederationKeyPrefix);
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub(crate) struct RecoveryKey(pub(crate) FederationId);
 
+/// Every recovery record in the instance.
 #[derive(Debug, Clone, Encodable, Decodable)]
 pub(crate) struct RecoveryKeyPrefix;
 

--- a/rust/fedimint-sdk/src/db.rs
+++ b/rust/fedimint-sdk/src/db.rs
@@ -57,6 +57,8 @@ pub(crate) enum SdkDbPrefix {
     Seed = 0x01,
     /// One row per federation the storage remembers, in any state.
     Federation = 0x02,
+    /// One row per federation that was joined with `Sdk::recover`, naming its current attempt.
+    Recovery = 0x03,
 }
 
 /// The key of the single seed record.
@@ -283,6 +285,31 @@ impl_db_record!(
 );
 impl_db_lookup!(key = FederationKey, query_prefix = FederationKeyPrefix);
 
+/// The key of one federation's recovery record.
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub(crate) struct RecoveryKey(pub(crate) FederationId);
+
+#[derive(Debug, Clone, Encodable, Decodable)]
+pub(crate) struct RecoveryKeyPrefix;
+
+/// Which attempt is the federation's current one.
+///
+/// Present from the moment `Sdk::recover` commits its join for the rest of the federation's
+/// life, so that a completed recovery keeps reporting `Done`; absent for a federation joined
+/// with `Sdk::join`, which is how `Sdk::recovery_status` tells the two apart.
+#[derive(Debug, Clone, PartialEq, Eq, Encodable, Decodable)]
+pub(crate) struct RecoveryRecord {
+    /// The operation record, in the federation's namespace, that tracks the current attempt.
+    pub(crate) attempt: fedimint_core::core::OperationId,
+}
+
+impl_db_record!(
+    key = RecoveryKey,
+    value = RecoveryRecord,
+    db_prefix = SdkDbPrefix::Recovery,
+);
+impl_db_lookup!(key = RecoveryKey, query_prefix = RecoveryKeyPrefix);
+
 /// Reads one record, reporting a backend or decode failure instead of panicking.
 ///
 /// `Cap: Send` on all four helpers is upstream's bound, not a choice: the raw transaction ops are
@@ -378,6 +405,52 @@ pub(crate) async fn write_federation(
     let sdk_db = db.with_prefix(sdk_prefix().to_vec());
     let mut dbtx = sdk_db.begin_transaction().await;
     write(&mut dbtx, &FederationKey(*id), record).await?;
+    commit(dbtx).await
+}
+
+/// The recovery record for `id`, if this instance ever called `Sdk::recover` on it.
+pub(crate) async fn read_recovery(
+    db: &Database,
+    id: &FederationId,
+) -> Result<Option<RecoveryRecord>> {
+    let sdk_db = db.with_prefix(sdk_prefix().to_vec());
+    let mut dbtx = sdk_db.begin_transaction_nc().await;
+    read(&mut dbtx, &RecoveryKey(*id)).await
+}
+
+/// Writes the recovery record for `id`.
+pub(crate) async fn write_recovery(
+    db: &Database,
+    id: &FederationId,
+    record: &RecoveryRecord,
+) -> Result<()> {
+    let sdk_db = db.with_prefix(sdk_prefix().to_vec());
+    let mut dbtx = sdk_db.begin_transaction().await;
+    write(&mut dbtx, &RecoveryKey(*id), record).await?;
+    commit(dbtx).await
+}
+
+/// Removes the recovery record for `id`. Done by `SdkInner::finish_erase`.
+pub(crate) async fn remove_recovery(db: &Database, id: &FederationId) -> Result<()> {
+    let sdk_db = db.with_prefix(sdk_prefix().to_vec());
+    let mut dbtx = sdk_db.begin_transaction().await;
+    remove(&mut dbtx, &RecoveryKey(*id)).await?;
+    commit(dbtx).await
+}
+
+/// The federation row and its recovery record in one transaction: a recovery intent never
+/// exists without the row that owns it, and a row `Sdk::recover` wrote never exists without
+/// the intent.
+pub(crate) async fn write_joining_with_recovery(
+    db: &Database,
+    id: &FederationId,
+    federation: &FederationRecord,
+    recovery: &RecoveryRecord,
+) -> Result<()> {
+    let sdk_db = db.with_prefix(sdk_prefix().to_vec());
+    let mut dbtx = sdk_db.begin_transaction().await;
+    write(&mut dbtx, &FederationKey(*id), federation).await?;
+    write(&mut dbtx, &RecoveryKey(*id), recovery).await?;
     commit(dbtx).await
 }
 
@@ -792,6 +865,77 @@ mod tests {
             .await
             .expect("the write succeeds");
         assert!(!is_empty(&db).await.expect("the scan succeeds"));
+    }
+
+    #[test]
+    fn the_recovery_prefix_is_0x03() {
+        assert_eq!(SdkDbPrefix::Recovery as u8, 0x03);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_recovery_record_round_trips() {
+        let db = db();
+        let id = FederationId::dummy();
+        let recovery = RecoveryRecord {
+            attempt: fedimint_core::core::OperationId([7u8; 32]),
+        };
+
+        write_recovery(&db, &id, &recovery)
+            .await
+            .expect("the write succeeds");
+        assert_eq!(
+            read_recovery(&db, &id).await.expect("the read succeeds"),
+            Some(recovery)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_recovery_record_is_absent_until_written() {
+        let db = db();
+        let id = FederationId::dummy();
+        assert_eq!(read_recovery(&db, &id).await.expect("read"), None);
+
+        write_recovery(
+            &db,
+            &id,
+            &RecoveryRecord {
+                attempt: fedimint_core::core::OperationId([1u8; 32]),
+            },
+        )
+        .await
+        .expect("write");
+        assert!(read_recovery(&db, &id).await.expect("read").is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_joining_row_and_the_recovery_record_land_together() {
+        let db = db();
+        let id = FederationId::dummy();
+        let federation = FederationRecord {
+            status: StoredStatus::Joining,
+            ..record(id)
+        };
+        let recovery = RecoveryRecord {
+            attempt: fedimint_core::core::OperationId([3u8; 32]),
+        };
+
+        write_joining_with_recovery(&db, &id, &federation, &recovery)
+            .await
+            .expect("the write succeeds");
+        assert_eq!(
+            read_federation(&db, &id).await.expect("read"),
+            Some(federation.clone())
+        );
+        assert_eq!(read_recovery(&db, &id).await.expect("read"), Some(recovery));
+
+        // Erasing the intent leaves the row that owns it alone; that row is removed
+        // separately, by `remove_federation`.
+        remove_recovery(&db, &id).await.expect("remove");
+        assert_eq!(read_recovery(&db, &id).await.expect("read"), None);
+        assert_eq!(
+            read_federation(&db, &id).await.expect("read"),
+            Some(federation)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -149,18 +149,27 @@ impl Federation {
         // Reading a balance is not fund-touching: a recovery-locked federation's number is
         // partial and worth showing as progress, and it is the spends that are refused.
         let client = self.inner.client(false).await?;
-        let balance = client
-            .get_balance_for_unit(AmountUnit::BITCOIN)
-            .await
-            .map_err(|err| {
+        let balance = match client.get_balance_for_unit(AmountUnit::BITCOIN).await {
+            Ok(balance) => balance,
+            // A v1 mint recovers as `RecoveryMode::Unusable` and is left out of the client's
+            // module registry until the client is opened again after the rescan
+            // (`fedimint-client/src/client/builder.rs:951`), so a recovering federation of that
+            // generation has no balance source at all yet. What has been recovered *so far* into
+            // something spendable is then exactly nothing, which is the provisional figure the
+            // docs promise; the swap that ends the recovery brings the real one.
+            Err(_) if self.inner.status() == FederationStatus::Recovering => {
+                return Ok(Amount::from_msats(0));
+            }
+            Err(err) => {
                 // The one way this fails in practice is a client with no primary module, which
                 // happens when API-version negotiation left every module out. That is not the
                 // caller's doing and not a storage fault.
-                crate::Error::new(
+                return Err(crate::Error::new(
                     crate::ErrorCode::Internal,
                     format!("this federation cannot report a balance: {err}"),
-                )
-            })?;
+                ));
+            }
+        };
         Ok(Amount::from_msats(balance.msats))
     }
 
@@ -387,20 +396,38 @@ impl BalanceUpdates {
             }
 
             if cursor.stream.is_none() {
+                // Taken before the read below, so a recovery that ends between the read and the
+                // wait on it is not missed.
+                let mut recovery_changed = self.inner.federation.recovery_changed();
                 let client = self.inner.federation.client(false).await?;
                 // Upstream's balance stream never yields and never ends when a client has no
                 // primary module, so a read has to prove there is one before a caller is handed
                 // something that could hang for the life of the process.
-                let initial = client
-                    .get_balance_for_unit(AmountUnit::BITCOIN)
-                    .await
-                    .map_err(|err| {
-                        crate::Error::new(
+                match client.get_balance_for_unit(AmountUnit::BITCOIN).await {
+                    Ok(_) => {}
+                    // No balance source yet because a v1 mint is still recovering (see
+                    // `Federation::balance`): the provisional figure is zero, handed out once,
+                    // and the next change is the recovery ending and swapping a usable client in.
+                    Err(_) if self.inner.federation.status() == FederationStatus::Recovering => {
+                        drop(client);
+                        let zero = Amount::from_msats(0);
+                        if cursor.last != Some(zero) {
+                            cursor.last = Some(zero);
+                            return Ok(zero);
+                        }
+                        tokio::select! {
+                            _ = recovery_changed.changed() => {}
+                            _ = closed.changed() => {}
+                        }
+                        continue;
+                    }
+                    Err(err) => {
+                        return Err(crate::Error::new(
                             crate::ErrorCode::Internal,
                             format!("this federation cannot report a balance: {err}"),
-                        )
-                    })?;
-                let _ = initial;
+                        ));
+                    }
+                }
                 cursor.stream = Some(client.subscribe_balance_changes(AmountUnit::BITCOIN).await);
             }
 
@@ -790,17 +817,7 @@ impl FederationInner {
         &self,
         attempt: fedimint_core::core::OperationId,
     ) -> crate::Result<()> {
-        let record = crate::db::OperationRecord {
-            schema_version: crate::operation::READABLE_STATE_SCHEMA,
-            kind: kinds::RECOVERY.to_owned(),
-            module: String::new(),
-            created_at: crate::db::now_millis(),
-            details: "{}".to_owned(),
-            phase: None,
-            cancel_requested_at: None,
-            final_state: None,
-        };
-        self.write_record(attempt, record, false).await.map(|_| ())
+        record_recovery_attempt_in(&self.db(), attempt).await
     }
 
     /// Looks one operation up by id, rebuilding its record from the client's own log if a crash
@@ -1030,53 +1047,7 @@ impl FederationInner {
         record: crate::db::OperationRecord,
         overwrite_placeholder: bool,
     ) -> crate::Result<crate::db::OperationRecord> {
-        let db = self.db();
-        db.autocommit(
-            |dbtx, _| {
-                let record = record.clone();
-                Box::pin(async move {
-                    let key = crate::db::OperationRecordKey(id);
-                    if let Some(existing) = dbtx.get_value(&key).await {
-                        if !(overwrite_placeholder && is_unclaimed_placeholder(&existing)) {
-                            return Ok::<_, core::convert::Infallible>(existing);
-                        }
-                        // The rebuilt placeholder says nothing the stored one did not already
-                        // say: writing it again would touch storage for no observable
-                        // difference. This is what keeps reconciliation's steady-state pass over
-                        // a module no backfiller has learned to place a pure read, rather than a
-                        // rewrite of the same two rows on every federation open.
-                        if existing == record {
-                            return Ok::<_, core::convert::Infallible>(existing);
-                        }
-                        // Being replaced: its index entry is only still correct if the new
-                        // record keeps the same creation time. A backfill recomputes `created_at`
-                        // from the client's own chronological log, which need not agree with
-                        // whatever an earlier write guessed or was given, and leaving the old
-                        // entry behind would leak it under a key nothing will ever look up again.
-                        if existing.created_at != record.created_at {
-                            dbtx.remove_entry(&crate::db::OperationIndexKey {
-                                created_at: existing.created_at,
-                                id,
-                            })
-                            .await;
-                        }
-                    }
-                    dbtx.insert_entry(&key, &record).await;
-                    dbtx.insert_entry(
-                        &crate::db::OperationIndexKey {
-                            created_at: record.created_at,
-                            id,
-                        },
-                        &(),
-                    )
-                    .await;
-                    Ok::<_, core::convert::Infallible>(record)
-                })
-            },
-            Some(100),
-        )
-        .await
-        .map_err(crate::db::storage_error)
+        write_record_in(&self.db(), id, record, overwrite_placeholder).await
     }
 
     /// A federation handle with no client behind it, for the operation engine's own tests.
@@ -1130,6 +1101,83 @@ impl FederationInner {
         federation.set_status(status);
         Arc::new(federation)
     }
+}
+
+/// [`FederationInner::write_record`] for a caller that holds the federation's namespace database
+/// rather than the federation itself: the reopen path, which writes a recovery attempt's record
+/// into a namespace it has just wiped and redone, before the federation's shared state exists.
+pub(crate) async fn write_record_in(
+    db: &Database,
+    id: fedimint_core::core::OperationId,
+    record: crate::db::OperationRecord,
+    overwrite_placeholder: bool,
+) -> crate::Result<crate::db::OperationRecord> {
+    db.autocommit(
+        |dbtx, _| {
+            let record = record.clone();
+            Box::pin(async move {
+                let key = crate::db::OperationRecordKey(id);
+                if let Some(existing) = dbtx.get_value(&key).await {
+                    if !(overwrite_placeholder && is_unclaimed_placeholder(&existing)) {
+                        return Ok::<_, core::convert::Infallible>(existing);
+                    }
+                    // The rebuilt placeholder says nothing the stored one did not already
+                    // say: writing it again would touch storage for no observable
+                    // difference. This is what keeps reconciliation's steady-state pass over
+                    // a module no backfiller has learned to place a pure read, rather than a
+                    // rewrite of the same two rows on every federation open.
+                    if existing == record {
+                        return Ok::<_, core::convert::Infallible>(existing);
+                    }
+                    // Being replaced: its index entry is only still correct if the new
+                    // record keeps the same creation time. A backfill recomputes `created_at`
+                    // from the client's own chronological log, which need not agree with
+                    // whatever an earlier write guessed or was given, and leaving the old
+                    // entry behind would leak it under a key nothing will ever look up again.
+                    if existing.created_at != record.created_at {
+                        dbtx.remove_entry(&crate::db::OperationIndexKey {
+                            created_at: existing.created_at,
+                            id,
+                        })
+                        .await;
+                    }
+                }
+                dbtx.insert_entry(&key, &record).await;
+                dbtx.insert_entry(
+                    &crate::db::OperationIndexKey {
+                        created_at: record.created_at,
+                        id,
+                    },
+                    &(),
+                )
+                .await;
+                Ok::<_, core::convert::Infallible>(record)
+            })
+        },
+        Some(100),
+    )
+    .await
+    .map_err(crate::db::storage_error)
+}
+
+/// [`FederationInner::record_recovery_attempt`] over a namespace database, for the same caller.
+pub(crate) async fn record_recovery_attempt_in(
+    db: &Database,
+    attempt: fedimint_core::core::OperationId,
+) -> crate::Result<()> {
+    let record = crate::db::OperationRecord {
+        schema_version: crate::operation::READABLE_STATE_SCHEMA,
+        kind: kinds::RECOVERY.to_owned(),
+        module: String::new(),
+        created_at: crate::db::now_millis(),
+        details: "{}".to_owned(),
+        phase: None,
+        cancel_requested_at: None,
+        final_state: None,
+    };
+    write_record_in(db, attempt, record, false)
+        .await
+        .map(|_| ())
 }
 
 /// Shuts a client down, waiting for its workers.

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -615,25 +615,38 @@ impl FederationInner {
     /// from `open`, the lock is released with no client installed, which reads exactly like any
     /// other reason there is currently no client; the caller decides what status that leaves the
     /// federation in.
+    ///
+    /// # Errors
+    ///
+    /// [`FederationClosed`](crate::ErrorCode::FederationClosed), without calling `open`, when no
+    /// client is in place: the federation was closed, quarantined or erased first, and a swap
+    /// must not undo that. Otherwise whatever `open` returns.
     pub(crate) async fn replace_client<F, Fut>(&self, open: F) -> Result<()>
     where
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<ClientHandleArc>>,
     {
         let mut guard = self.client.write().await;
-        if let Some(old) = guard.take() {
-            // Told to stop before the consuming shutdown is attempted, as `quiesce` does: a
-            // stray handle to the old client (a watcher's clone, say) makes that shutdown fail,
-            // and without this the old client would keep running until the stray handle went.
-            old.task_group().shutdown();
-            if let Err(err) = shutdown_client(old).await {
-                tracing::warn!(
-                    target: "fedimint_sdk",
-                    federation = %self.id,
-                    error = %err,
-                    "could not cleanly shut down the client being replaced",
-                );
-            }
+        // No client in place means the federation was closed, quarantined or erased while the
+        // caller was deciding to swap: opening a fresh client now would resurrect it behind
+        // the lifecycle's back, so the swap is refused and the caller leaves the status alone.
+        let Some(old) = guard.take() else {
+            return Err(crate::Error::new(
+                crate::ErrorCode::FederationClosed,
+                "this federation is closed",
+            ));
+        };
+        // Told to stop before the consuming shutdown is attempted, as `quiesce` does: a stray
+        // handle to the old client makes that shutdown fail, and without this the old client
+        // would keep running until the stray handle went.
+        old.task_group().shutdown();
+        if let Err(err) = shutdown_client(old).await {
+            tracing::warn!(
+                target: "fedimint_sdk",
+                federation = %self.id,
+                error = %err,
+                "could not cleanly shut down the client being replaced",
+            );
         }
         let fresh = open().await?;
         *guard = Some(fresh);
@@ -1121,15 +1134,33 @@ impl FederationInner {
 
 /// Shuts a client down, waiting for its workers.
 ///
-/// `ClientHandle::shutdown` consumes the handle, so it needs the last reference. If a caller is
-/// still holding a clone, the best that can be done is to stop the executor and let the eventual
-/// drop clean up, which upstream also logs about.
-pub(crate) async fn shutdown_client(client: ClientHandleArc) -> Result<()> {
-    let Some(handle) = Arc::into_inner(client) else {
-        return Err(crate::Error::new(
-            crate::ErrorCode::Internal,
-            "the federation's client is still in use elsewhere",
-        ));
+/// `ClientHandle::shutdown` consumes the handle, so it needs the last reference. A clone that is
+/// still held is waited for, briefly; if it does not go, the best that can be done is to leave the
+/// executor stopped and let the eventual drop clean up, which upstream also logs about.
+pub(crate) async fn shutdown_client(mut client: ClientHandleArc) -> Result<()> {
+    // A stray clone is normally on its way out already: the recovery watcher drops its clone
+    // the moment the federation's `closed` watch flips, which every caller of this function
+    // has done before calling it, but that drop runs on another task and may not have been
+    // scheduled yet. Waiting a bounded moment for it turns that race into a clean shutdown.
+    const STRAY_REFERENCE_WAIT: std::time::Duration = std::time::Duration::from_millis(20);
+    const STRAY_REFERENCE_ATTEMPTS: usize = 100;
+
+    let mut attempts = 0;
+    let handle = loop {
+        match Arc::try_unwrap(client) {
+            Ok(handle) => break handle,
+            Err(still_shared) => {
+                attempts += 1;
+                if attempts >= STRAY_REFERENCE_ATTEMPTS {
+                    return Err(crate::Error::new(
+                        crate::ErrorCode::Internal,
+                        "the federation's client is still in use elsewhere",
+                    ));
+                }
+                client = still_shared;
+                fedimint_core::runtime::sleep(STRAY_REFERENCE_WAIT).await;
+            }
+        }
     };
     handle.shutdown().await;
     Ok(())
@@ -2046,5 +2077,28 @@ mod tests {
 
         updates.changed().await.expect("the sender is still alive");
         assert_eq!(*updates.borrow(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_swap_is_refused_when_no_client_is_in_place() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        // A detached federation has no client, exactly as one that was closed or erased.
+        let federation = FederationInner::detached(db, true);
+        let opened = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = opened.clone();
+
+        let err = federation
+            .replace_client(|| async move {
+                observed.store(true, std::sync::atomic::Ordering::SeqCst);
+                Err(crate::Error::new(ErrorCode::Internal, "never reached"))
+            })
+            .await
+            .expect_err("no client to replace");
+
+        assert_eq!(err.code, ErrorCode::FederationClosed);
+        assert!(
+            !opened.load(std::sync::atomic::Ordering::SeqCst),
+            "the swap must not open a client on a federation that has none"
+        );
     }
 }

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -189,6 +189,7 @@ impl Federation {
                 federation: self.inner.clone(),
                 cursor: tokio::sync::Mutex::new(BalanceCursor {
                     stream: None,
+                    recovery_changed: None,
                     last: None,
                 }),
             }),
@@ -376,7 +377,8 @@ impl BalanceUpdates {
 
             if cursor.stream.is_none() {
                 // Taken before the read below, so a recovery that ends between the read and the
-                // wait on it is not missed.
+                // wait on it is not missed. It outlives the stream established here for the same
+                // reason: a recovery's swap retires the client that stream reads from.
                 let mut recovery_changed = self.inner.federation.recovery_changed();
                 let client = self.inner.federation.client(false).await?;
                 // Upstream's balance stream never yields and never ends when a client has no
@@ -408,19 +410,35 @@ impl BalanceUpdates {
                     }
                 }
                 cursor.stream = Some(client.subscribe_balance_changes(AmountUnit::BITCOIN).await);
+                cursor.recovery_changed = Some(recovery_changed);
             }
 
+            let cursor = &mut *cursor;
             let stream = cursor
                 .stream
                 .as_mut()
                 .expect("the stream was just established");
+            let recovery_changed = cursor
+                .recovery_changed
+                .as_mut()
+                .expect("taken with the stream");
             let next = tokio::select! {
                 next = stream.next() => next,
                 _ = closed.changed() => continue,
+                // A recovery ending swaps the client, and with it the module this stream reads
+                // from: a stream over the retired client never yields again.
+                _ = recovery_changed.changed() => {
+                    cursor.stream = None;
+                    continue;
+                }
             };
             let Some(balance) = next else {
-                // The stream only ends when the client behind it is gone, which from a caller's
-                // point of view is the federation no longer running.
+                // The stream only ends when the client behind it is gone: with the federation
+                // still running, that is a swap, and the successor is subscribed to instead.
+                if !*closed.borrow() {
+                    cursor.stream = None;
+                    continue;
+                }
                 return Err(crate::Error::new(
                     crate::ErrorCode::FederationClosed,
                     "this federation is not running",
@@ -1306,6 +1324,9 @@ struct BalanceCursor {
     /// on. Upstream's own stream hangs forever when a client has no primary module, so it is only
     /// opened after a balance read has proved there is one.
     stream: Option<fedimint_core::util::BoxStream<'static, fedimint_core::Amount>>,
+    /// Subscribed just before `stream` was, so the recovery swap that retires the client behind
+    /// it is seen and the stream re-established over the successor.
+    recovery_changed: Option<tokio::sync::watch::Receiver<u64>>,
     /// The last value handed out, so a repeat is not delivered as a change.
     last: Option<Amount>,
 }

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -45,8 +45,8 @@ use crate::{
 /// [`FederationClosed`](crate::ErrorCode::FederationClosed)" applies to the
 /// **fallible** calls: [`balance`](Federation::balance),
 /// [`operation`](Federation::operation),
-/// [`activity`](Federation::activity), [`backup`](Federation::backup), and
-/// every call made through a facade. The rest of this type returns plain
+/// [`activity`](Federation::activity), and every call made through a
+/// facade. The rest of this type returns plain
 /// values and has no way to report a failure, so each has a defined closed
 /// behaviour instead:
 ///
@@ -308,27 +308,6 @@ impl Federation {
         crate::activity::page(&self.inner, cursor, limit).await
     }
 
-    /// Uploads a fresh encrypted backup to the federation.
-    ///
-    /// Backups are what make seed-only restore possible: they let a
-    /// recovering client learn which notes and operations to look for
-    /// instead of rescanning blindly. The SDK also backs up automatically
-    /// after changes that affect recoverability, so this call is for
-    /// applications that want an explicit "back up now" affordance or want
-    /// to be sure a backup exists before some user-visible milestone.
-    ///
-    /// # Errors
-    ///
-    /// [`FederationUnreachable`](crate::ErrorCode::FederationUnreachable),
-    /// [`Timeout`](crate::ErrorCode::Timeout),
-    /// [`Recovering`](crate::ErrorCode::Recovering) while this federation's
-    /// recovery is incomplete, which is not the same as still running, since
-    /// a recovery that stopped short leaves the lock in place, and
-    /// [`FederationClosed`](crate::ErrorCode::FederationClosed).
-    pub async fn backup(&self) -> Result<()> {
-        unimplemented!()
-    }
-
     /// Wraps shared federation state in a handle.
     pub(crate) fn new(inner: Arc<FederationInner>) -> Federation {
         Federation { inner }
@@ -531,8 +510,8 @@ impl FederationInner {
     ///
     /// Every facade call holds one of these for its whole duration, which is what makes a close or
     /// an erase wait for work already in flight rather than pulling the client out from under it.
-    /// `fund_touching` marks the calls a recovery-locked federation refuses: sends, receives and
-    /// taking a fresh backup, as opposed to reading a balance or a name.
+    /// `fund_touching` marks the calls a recovery-locked federation refuses: sends and receives,
+    /// as opposed to reading a balance or a name.
     pub(crate) async fn client(&self, fund_touching: bool) -> Result<ClientGuard<'_>> {
         if fund_touching && self.status() == FederationStatus::Recovering {
             return Err(crate::Error::new(

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -621,15 +621,19 @@ impl FederationInner {
         Fut: Future<Output = Result<ClientHandleArc>>,
     {
         let mut guard = self.client.write().await;
-        if let Some(old) = guard.take()
-            && let Err(err) = shutdown_client(old).await
-        {
-            tracing::warn!(
-                target: "fedimint_sdk",
-                federation = %self.id,
-                error = %err,
-                "could not cleanly shut down the client being replaced",
-            );
+        if let Some(old) = guard.take() {
+            // Told to stop before the consuming shutdown is attempted, as `quiesce` does: a
+            // stray handle to the old client (a watcher's clone, say) makes that shutdown fail,
+            // and without this the old client would keep running until the stray handle went.
+            old.task_group().shutdown();
+            if let Err(err) = shutdown_client(old).await {
+                tracing::warn!(
+                    target: "fedimint_sdk",
+                    federation = %self.id,
+                    error = %err,
+                    "could not cleanly shut down the client being replaced",
+                );
+            }
         }
         let fresh = open().await?;
         *guard = Some(fresh);

--- a/rust/fedimint-sdk/src/federation.rs
+++ b/rust/fedimint-sdk/src/federation.rs
@@ -1,5 +1,6 @@
 //! A joined federation, and the capability facades hanging off it.
 
+use std::future::Future;
 use std::sync::{Arc, Weak};
 
 use fedimint_client::{Client, ClientHandleArc};
@@ -10,7 +11,7 @@ use fedimint_core::module::AmountUnit;
 use futures::StreamExt;
 
 use crate::db::{FederationRecord, StoredStatus};
-use crate::operation::{Driver, Operation, OperationInner, OperationState};
+use crate::operation::{Driver, Operation, OperationInner, OperationState, kinds};
 use crate::sdk::SdkInner;
 use crate::{
     ActivityPage, Amount, AnyOperation, Cursor, Ecash, FederationId, FederationInfo,
@@ -452,6 +453,9 @@ pub(crate) struct FederationInner {
     /// Flipped once the federation stops running, so a pending subscriber resolves promptly
     /// instead of waiting on a stream that will never yield again.
     closed: tokio::sync::watch::Sender<bool>,
+    /// Bumped whenever a recovery attempt's recorded state changes, so a subscriber to the
+    /// attempt wakes up without polling.
+    recovery_changed: tokio::sync::watch::Sender<u64>,
     /// Serialises the start of a lightning claim retry per federation: the read of the record,
     /// the upstream call that starts the retry and the write that records it happen under this
     /// lock, so two subscribers that see the same rejected claim start exactly one retry.
@@ -491,6 +495,7 @@ impl FederationInner {
             record: std::sync::RwLock::new(record),
             status: std::sync::RwLock::new(status),
             closed: tokio::sync::watch::Sender::new(!running),
+            recovery_changed: tokio::sync::watch::Sender::new(0),
             reclaim_starts: tokio::sync::Mutex::new(()),
         }
     }
@@ -597,6 +602,40 @@ impl FederationInner {
         shutdown_client(client).await
     }
 
+    /// Swaps the live client for a freshly opened one, under the client write lock.
+    ///
+    /// The old client is taken out and shut down before `open` is even called: two clients open
+    /// over the same database at once is exactly what the storage lock exists to prevent, so the
+    /// old one has to be gone before the new one can be asked for. A failure shutting the old one
+    /// down is logged and does not stop the swap, because refusing to open the replacement over a
+    /// client that is already on its way out would help nobody.
+    ///
+    /// `closed` is left untouched throughout: unlike [`quiesce`](Self::quiesce), this is not the
+    /// federation shutting down, and every handle to it stays live for the duration. On `Err`
+    /// from `open`, the lock is released with no client installed, which reads exactly like any
+    /// other reason there is currently no client; the caller decides what status that leaves the
+    /// federation in.
+    pub(crate) async fn replace_client<F, Fut>(&self, open: F) -> Result<()>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<ClientHandleArc>>,
+    {
+        let mut guard = self.client.write().await;
+        if let Some(old) = guard.take()
+            && let Err(err) = shutdown_client(old).await
+        {
+            tracing::warn!(
+                target: "fedimint_sdk",
+                federation = %self.id,
+                error = %err,
+                "could not cleanly shut down the client being replaced",
+            );
+        }
+        let fresh = open().await?;
+        *guard = Some(fresh);
+        Ok(())
+    }
+
     /// The raw read side of the client lock, for tests that need to hold it the way a facade
     /// call does without a live client behind it.
     #[cfg(test)]
@@ -609,6 +648,16 @@ impl FederationInner {
     /// A receiver that fires when this federation stops running.
     pub(crate) fn closed(&self) -> tokio::sync::watch::Receiver<bool> {
         self.closed.subscribe()
+    }
+
+    /// A receiver that fires whenever a recovery attempt's recorded state changes.
+    pub(crate) fn recovery_changed(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.recovery_changed.subscribe()
+    }
+
+    /// Wakes every subscriber to [`FederationInner::recovery_changed`].
+    pub(crate) fn bump_recovery(&self) {
+        self.recovery_changed.send_modify(|n| *n += 1);
     }
 
     /// The lock that serialises starting a lightning claim retry for this federation.
@@ -707,6 +756,34 @@ impl FederationInner {
             }),
             driver,
         ))
+    }
+
+    /// Records a recovery attempt's operation, in the fixed shape every attempt is written in.
+    ///
+    /// Called before the federation's client exists, by whichever of `Sdk::recover`,
+    /// `Sdk::resume_recovery` or the pre-open repair minted this attempt, so it needs no client
+    /// and no [`ensure_open`](Self::ensure_open). An existing record for `attempt` is kept as
+    /// is: `overwrite_placeholder: false` never replaces one, and this attempt's record is never
+    /// the placeholder shape `write_record` would offer up for replacement anyway.
+    ///
+    /// # Errors
+    ///
+    /// [`Storage`](crate::ErrorCode::Storage) if the record cannot be committed.
+    pub(crate) async fn record_recovery_attempt(
+        &self,
+        attempt: fedimint_core::core::OperationId,
+    ) -> crate::Result<()> {
+        let record = crate::db::OperationRecord {
+            schema_version: crate::operation::READABLE_STATE_SCHEMA,
+            kind: kinds::RECOVERY.to_owned(),
+            module: String::new(),
+            created_at: crate::db::now_millis(),
+            details: "{}".to_owned(),
+            phase: None,
+            cancel_requested_at: None,
+            final_state: None,
+        };
+        self.write_record(attempt, record, false).await.map(|_| ())
     }
 
     /// Looks one operation up by id, rebuilding its record from the client's own log if a crash
@@ -1100,6 +1177,17 @@ pub(crate) async fn reconcile_on_open(federation: &Arc<FederationInner>) {
 /// Holding it keeps a close, an erase or a shutdown waiting until the call is done.
 pub(crate) struct ClientGuard<'a>(tokio::sync::RwLockReadGuard<'a, Option<ClientHandleArc>>);
 
+impl ClientGuard<'_> {
+    /// A clone of the client behind this guard, for a task that must outlive the guard itself
+    /// (the recovery watcher, which drops its guard and then blocks on the client alone).
+    pub(crate) fn handle(&self) -> ClientHandleArc {
+        self.0
+            .as_ref()
+            .expect("a client guard is only built while the client is live")
+            .clone()
+    }
+}
+
 impl core::ops::Deref for ClientGuard<'_> {
     type Target = Client;
 
@@ -1175,10 +1263,10 @@ mod tests {
     use fedimint_core::util::SafeUrl;
 
     use crate::db::{
-        FederationRecord, OperationRecordKey, StoredCapabilities, StoredNetwork, StoredStatus,
-        federation_namespace, in_memory_root,
+        FederationRecord, OperationRecord, OperationRecordKey, StoredCapabilities, StoredNetwork,
+        StoredStatus, federation_namespace, in_memory_root,
     };
-    use crate::operation::kinds;
+    use crate::operation::{READABLE_STATE_SCHEMA, kinds};
     use crate::{ErrorCode, FederationStatus};
 
     use super::*;
@@ -1882,5 +1970,77 @@ mod tests {
             dbtx.get_value(&OperationRecordKey(id)).await.as_ref(),
             Some(&created)
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recording_an_attempt_writes_a_running_record_once() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db.clone(), true);
+        let attempt = UpstreamOperationId([6u8; 32]);
+
+        federation
+            .record_recovery_attempt(attempt)
+            .await
+            .expect("record");
+
+        let mut dbtx = db.begin_transaction_nc().await;
+        let record = dbtx
+            .get_value(&OperationRecordKey(attempt))
+            .await
+            .expect("the attempt's record was written");
+        assert_eq!(record.kind, kinds::RECOVERY);
+        assert_eq!(record.module, "");
+        assert_eq!(record.details, "{}");
+        assert_eq!(record.schema_version, READABLE_STATE_SCHEMA);
+        assert_eq!(record.final_state, None);
+        let indexed: Vec<_> = dbtx
+            .find_by_prefix_sorted_descending(&crate::db::OperationIndexKeyPrefix)
+            .await
+            .map(|(key, ())| (key.created_at, key.id))
+            .collect()
+            .await;
+        assert_eq!(indexed, vec![(record.created_at, attempt)]);
+        drop(dbtx);
+
+        // A driver observed the rescan finish and recorded it, which a second call must not
+        // undo: `record_recovery_attempt` only ever gets the attempt started, never rewrites it.
+        let mut dbtx = db.begin_transaction().await;
+        let finished = OperationRecord {
+            final_state: Some("\"Done\"".to_owned()),
+            ..record.clone()
+        };
+        dbtx.insert_entry(&OperationRecordKey(attempt), &finished)
+            .await;
+        dbtx.commit_tx().await;
+
+        federation
+            .record_recovery_attempt(attempt)
+            .await
+            .expect("record again");
+
+        let mut dbtx = db.begin_transaction_nc().await;
+        assert_eq!(
+            dbtx.get_value(&OperationRecordKey(attempt)).await,
+            Some(finished)
+        );
+        let indexed_after: Vec<_> = dbtx
+            .find_by_prefix_sorted_descending(&crate::db::OperationIndexKeyPrefix)
+            .await
+            .map(|(key, ())| (key.created_at, key.id))
+            .collect()
+            .await;
+        assert_eq!(indexed_after, vec![(record.created_at, attempt)]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bumping_recovery_wakes_a_subscriber() {
+        let db = federation_namespace(&in_memory_root(), [1u8; 32]);
+        let federation = FederationInner::detached(db, true);
+        let mut updates = federation.recovery_changed();
+
+        federation.bump_recovery();
+
+        updates.changed().await.expect("the sender is still alive");
+        assert_eq!(*updates.borrow(), 1);
     }
 }

--- a/rust/fedimint-sdk/src/operation.rs
+++ b/rust/fedimint-sdk/src/operation.rs
@@ -763,13 +763,14 @@ impl AnyOperation {
     /// reading the state will succeed.
     // "`Observable` means supported: the matching `as_*` accessor will hand back a typed handle"
     // is accurate once every kind in `kinds` has a driver arm in `driver_for` below, filled in by
-    // T7, T9 and T12 (T8 filled in the two lightning arms). Until then, `support_of` still answers
-    // `Observable` for every kind whose arm is `None`: the record's kind and schema version are
-    // all it looks at, and neither says whether a driver has been written yet. That is four kinds
-    // in a test build, where `ECASH_SEND` has its own probe arm, and five in any other build,
-    // where that arm is `None` too. This is not a bug in the accessor, which is honest about what
-    // it can do, but a temporary gap between what `support` promises and what a build this
-    // incomplete can deliver; it closes as each task above lands its arm.
+    // T7 and T9 (T8 filled in the two lightning arms, T12 filled in the recovery arm). Until
+    // then, `support_of` still answers `Observable` for every kind whose arm is `None`: the
+    // record's kind and schema version are all it looks at, and neither says whether a driver has
+    // been written yet. That is three kinds in a test build, where `ECASH_SEND` has its own probe
+    // arm, and four in any other build, where that arm is `None` too. This is not a bug in the
+    // accessor, which is honest about what it can do, but a temporary gap between what `support`
+    // promises and what a build this incomplete can deliver; it closes as each task above lands
+    // its arm.
     pub fn support(&self) -> OperationSupport {
         self.inner.support
     }
@@ -1418,9 +1419,9 @@ pub(crate) enum ErasedDriver {
 pub(crate) fn driver_for(kind: &str) -> Option<ErasedDriver> {
     match kind {
         // One arm per tag in `kinds`, filled in by the task that writes the facade owning that
-        // kind: ecash in T7, on-chain in T9, recovery in T12. Until an arm is filled in this
-        // build cannot observe that kind, which is a real answer rather than a gap: the record
-        // is still found, still listed, and still says what it is.
+        // kind: ecash in T7, on-chain in T9; recovery is filled in below. Until an arm is filled
+        // in this build cannot observe that kind, which is a real answer rather than a gap: the
+        // record is still found, still listed, and still says what it is.
         //
         // The probe stands in for the ecash-send driver so that the type-erased accessors are
         // exercised end to end before any facade exists; T7 replaces the pair of arms below with
@@ -1438,7 +1439,9 @@ pub(crate) fn driver_for(kind: &str) -> Option<ErasedDriver> {
         ))),
         kinds::ONCHAIN_SEND => None,
         kinds::ONCHAIN_RECEIVE => None,
-        kinds::RECOVERY => None,
+        kinds::RECOVERY => Some(ErasedDriver::Recovery(Arc::new(
+            crate::recovery::RecoveryDriver,
+        ))),
         // A tag this build does not know, which `kind_of_tag` already reads as
         // `OperationKind::Unknown`.
         _ => None,
@@ -2481,8 +2484,9 @@ mod tests {
     #[test]
     fn this_build_observes_the_kinds_it_has_a_driver_for_and_no_others() {
         // The probe fixture stands in for the ecash-send driver T7 writes; the two lightning
-        // arms are real. Every other kind is a record this build can find, list and label but
-        // not observe, which the accessors report as `None` rather than as a failure.
+        // arms and the recovery arm are real. `ONCHAIN_SEND` (and `ONCHAIN_RECEIVE`, not
+        // asserted here) is a record this build can find, list and label but not observe, which
+        // the accessors report as `None` rather than as a failure.
         assert!(matches!(
             driver_for(kinds::ECASH_SEND),
             Some(ErasedDriver::EcashSend(_))
@@ -2496,7 +2500,10 @@ mod tests {
             Some(ErasedDriver::LnReceive(_))
         ));
         assert!(driver_for(kinds::ONCHAIN_SEND).is_none());
-        assert!(driver_for(kinds::RECOVERY).is_none());
+        assert!(matches!(
+            driver_for(kinds::RECOVERY),
+            Some(ErasedDriver::Recovery(_))
+        ));
         // A tag this build does not know is not a lookup failure either.
         assert!(driver_for("something_else").is_none());
         // Backfillers are a list rather than a lookup: one is asked about an upstream module

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -276,7 +276,12 @@ impl Sdk {
                 // `Joining` with its recovery record, is reported `Quarantined` with this error
                 // as its diagnostic, and the next open redoes the recovery under the same
                 // attempt id.
-                let committed = !crate::db::is_empty(&namespace).await.unwrap_or(true);
+                // An inconclusive read counts as committed: erasing is the destructive answer, and
+                // it is only right when the namespace is known to be empty.
+                let committed = crate::db::is_empty(&namespace)
+                    .await
+                    .map(|empty| !empty)
+                    .unwrap_or(true);
                 if !committed {
                     let _ = self.inner().finish_erase(&id).await;
                     self.inner().remove(&id);

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -307,6 +307,9 @@ impl Sdk {
         joined.status = StoredStatus::Open;
         crate::db::write_federation(&self.inner().db, &id, &joined).await?;
 
+        // Locked from the first moment it can be found: facade calls do not take the lifecycle
+        // mutex, so a federation published as `Running` with its rescan still going would accept
+        // a send or a receive until `after_open` below corrected it.
         let federation = Arc::new(FederationInner::new(
             id,
             Arc::downgrade(self.inner()),
@@ -314,13 +317,33 @@ impl Sdk {
                 .db
                 .with_prefix(crate::db::federation_prefix(&id).to_vec()),
             joined,
-            FederationStatus::Running,
+            FederationStatus::Recovering,
             Some(client.clone()),
         ));
+        // Written before the federation is published, so a failure here has nothing live to
+        // leave behind: the client is stopped and the federation surfaces as `Quarantined`,
+        // the outcome the docs describe for an error after the join has committed. The root
+        // record already names the attempt, so the reopen that brings it back writes this
+        // record under the same id and resumes the rescan.
+        if let Err(err) = federation.record_recovery_attempt(attempt).await {
+            drop(client);
+            if let Err(stop) = federation.stop().await {
+                tracing::warn!(
+                    target: "fedimint_sdk",
+                    federation = %federation.id,
+                    error = %stop,
+                    "could not cleanly shut down the client of a recovery that failed to start",
+                );
+            }
+            federation.set_status(FederationStatus::Quarantined {
+                diagnostic: err.clone().into(),
+            });
+            self.inner().insert(federation.clone());
+            self.inner().announce(&federation);
+            return Err(err);
+        }
         self.inner().insert(federation.clone());
-        federation.record_recovery_attempt(attempt).await?;
-        let status = engine::after_open(self.inner(), &federation, &client, Some(attempt)).await;
-        federation.set_status(status);
+        engine::after_open(self.inner(), &federation, client, Some(attempt)).await;
         crate::federation::reconcile_on_open(&federation).await;
         self.inner().announce(&federation);
         Ok(Recovery {
@@ -425,13 +448,15 @@ impl Sdk {
             // record's word: a current attempt whose rescan is not actually live is completed
             // here, exactly as the watcher would, rather than trusted and handed back to watch.
             engine::AttemptOnFile::None | engine::AttemptOnFile::Running => {
-                let client = federation.client(false).await?.handle();
                 // Idempotent: repairs the crash window where the record is missing, and is a
                 // harmless rewrite of the same record otherwise. Done before either branch so
                 // that a completion finds a record to mark done.
                 federation.record_recovery_attempt(record.attempt).await?;
-                if !client.has_pending_recoveries() {
-                    engine::complete(self.inner(), &federation, record.attempt).await;
+                // The guard is a temporary, gone before the completion below: its swap needs
+                // the last handle to the client it retires.
+                let pending = federation.client(false).await?.has_pending_recoveries();
+                if !pending {
+                    engine::finish(self.inner(), &federation, record.attempt).await;
                 }
                 record.attempt
             }
@@ -461,14 +486,8 @@ impl Sdk {
                     }
                     Ok(()) => {
                         let client = federation.client(false).await?.handle();
-                        let status = engine::after_open(
-                            self.inner(),
-                            &federation,
-                            &client,
-                            Some(new_attempt),
-                        )
-                        .await;
-                        federation.set_status(status);
+                        engine::after_open(self.inner(), &federation, client, Some(new_attempt))
+                            .await;
                         self.inner().announce(&federation);
                     }
                 }

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -170,6 +170,7 @@
 use crate::{Federation, FederationId, InviteCode, Operation, OperationState, Result, Sdk};
 
 mod driver;
+pub(crate) mod engine;
 mod wire;
 
 pub(crate) use driver::RecoveryDriver;

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -169,6 +169,8 @@
 
 use crate::{Federation, FederationId, InviteCode, Operation, OperationState, Result, Sdk};
 
+mod wire;
+
 impl Sdk {
     /// Joins a federation and restores this seed's wallet in it from the
     /// federation's backup plus a rescan.

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -188,6 +188,7 @@ impl Sdk {
     /// # A failed call may still have joined
     ///
     /// An `Err` from this call does not certify that nothing happened: a
+    /// [`FederationUnreachable`](crate::ErrorCode::FederationUnreachable),
     /// [`Timeout`](crate::ErrorCode::Timeout) or [`Storage`](crate::ErrorCode::Storage) can
     /// arrive after the federation is already joined and already committed to recovering.
     ///
@@ -379,11 +380,10 @@ impl Sdk {
     /// closed federation back, recovery record and all, and this call then works on it:
     /// re-joining is neither needed nor accepted.
     ///
-    /// [`FederationUnreachable`](crate::ErrorCode::FederationUnreachable) and
-    /// [`Timeout`](crate::ErrorCode::Timeout) when the guardians cannot be reached to fetch
-    /// the backup a new attempt starts from, and [`Storage`](crate::ErrorCode::Storage) if
-    /// the attempt cannot be recorded durably. None of these releases the lock or unwinds the
-    /// recovery record. An error raised while retrying a *stopped* attempt on an open
+    /// [`Storage`](crate::ErrorCode::Storage) if the attempt cannot be recorded durably or the
+    /// client cannot be reopened over the federation's local state, which is all a new attempt
+    /// needs: no guardian is contacted to start one. This does not release the lock or unwind
+    /// the recovery record. An error raised while retrying a *stopped* attempt on an open
     /// federation can leave the federation with no live handle, in which case it transitions
     /// to [`Quarantined`](crate::FederationStatus::Quarantined) carrying the error as its
     /// diagnostic, this call reports
@@ -427,11 +427,11 @@ impl Sdk {
             // here, exactly as the watcher would, rather than trusted and handed back to watch.
             engine::AttemptOnFile::None | engine::AttemptOnFile::Running => {
                 let client = federation.client(false).await?.handle();
-                if client.has_pending_recoveries() {
-                    // Idempotent: repairs the crash window where the record is missing, and is
-                    // a harmless rewrite of the same record otherwise.
-                    federation.record_recovery_attempt(record.attempt).await?;
-                } else {
+                // Idempotent: repairs the crash window where the record is missing, and is a
+                // harmless rewrite of the same record otherwise. Done before either branch so
+                // that a completion finds a record to mark done.
+                federation.record_recovery_attempt(record.attempt).await?;
+                if !client.has_pending_recoveries() {
                     engine::complete(self.inner(), &federation, record.attempt).await;
                 }
                 record.attempt

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -264,11 +264,36 @@ impl Sdk {
         let client = match self.inner().recover_client(&id, &record).await {
             Ok(client) => client,
             Err(err) => {
-                // A recovery that returned an error must leave nothing behind. Only a crash
-                // leaves the `Joining` row and its recovery record, and only a crash is what it
-                // is for. `finish_erase` drops both.
-                let _ = self.inner().finish_erase(&id).await;
-                self.inner().remove(&id);
+                let namespace = self
+                    .inner()
+                    .db
+                    .with_prefix(crate::db::federation_prefix(&id).to_vec());
+                // Whether the underlying client got as far as writing into the federation's
+                // namespace is what decides between the two outcomes the docs describe. Nothing
+                // written means nothing joined: the row and its recovery record are dropped, as
+                // a failed `Sdk::join` drops its own. Anything written means the join may have
+                // committed, and the docs promise that such a federation is not lost: it stays
+                // `Joining` with its recovery record, is reported `Quarantined` with this error
+                // as its diagnostic, and the next open redoes the recovery under the same
+                // attempt id.
+                let committed = !crate::db::is_empty(&namespace).await.unwrap_or(true);
+                if !committed {
+                    let _ = self.inner().finish_erase(&id).await;
+                    self.inner().remove(&id);
+                    return Err(err);
+                }
+                let federation = Arc::new(FederationInner::new(
+                    id,
+                    Arc::downgrade(self.inner()),
+                    namespace,
+                    record,
+                    FederationStatus::Quarantined {
+                        diagnostic: err.clone().into(),
+                    },
+                    None,
+                ));
+                self.inner().insert(federation.clone());
+                self.inner().announce(&federation);
                 return Err(err);
             }
         };

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -1,7 +1,7 @@
 //! Seed-based wallet recovery.
 //!
-//! Recovery restores a wallet from the seed alone: a federation's backup plus a rescan of the
-//! history it references. Its failure mode is silent fund loss if handled wrong, so this
+//! Recovery restores a wallet from the seed alone, by rescanning the federation's history for
+//! what that seed owns. Its failure mode is silent fund loss if handled wrong, so this
 //! module's contract is written to rule that out: a recovery either completes and the wallet
 //! is restored, or it has not completed and the wallet is not spendable. There is no state in
 //! between that is safe to spend from.
@@ -10,8 +10,7 @@
 //!
 //! A federation whose recovery is **incomplete** is locked. Every ecash, lightning and
 //! on-chain send and receive against it fails with
-//! [`Recovering`](crate::ErrorCode::Recovering), as does
-//! [`Federation::backup`](crate::Federation::backup). Wherever else this crate says an action
+//! [`Recovering`](crate::ErrorCode::Recovering). Wherever else this crate says an action
 //! is refused "while a recovery is in progress", this is the lock meant, and this section is
 //! its authoritative definition.
 //!
@@ -167,8 +166,8 @@ mod wire;
 pub(crate) use driver::RecoveryDriver;
 
 impl Sdk {
-    /// Joins a federation and restores this seed's wallet in it from the
-    /// federation's backup plus a rescan.
+    /// Joins a federation and restores this seed's wallet in it by rescanning
+    /// the federation's history.
     ///
     /// Use this instead of [`Sdk::join`] when the instance was built from a mnemonic the user
     /// restored and the federation may already hold funds belonging to that seed. A plain
@@ -368,9 +367,9 @@ impl Sdk {
     /// federation but has no recovery for it, because it was joined with [`Sdk::join`] rather
     /// than [`Sdk::recover`]. Resuming a recovery is a different request from starting the
     /// first one, and this call deliberately does not do the second: turning a plainly
-    /// joined federation into a recovering one would re-derive its client state from a backup
-    /// while local state derived from that same seed already exists, a double-application
-    /// hazard no rescan can be trusted to survive. A wallet that should have been recovered
+    /// joined federation into a recovering one would re-derive its client state from the
+    /// federation's history while local state derived from that same seed already exists, a
+    /// double-application hazard no rescan can be trusted to survive. A wallet that should have been recovered
     /// and was joined plainly instead has to take the erase path in the module documentation.
     ///
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed) when the id names no open
@@ -661,7 +660,7 @@ pub enum RecoveryState {
     /// This is the only state that releases the lock, and the only one for
     /// which [`is_complete`](Self::is_complete) is true. It says the wallet
     /// is restored: everything the seed owned in this federation that a
-    /// backup and a rescan can find has been found.
+    /// rescan can find has been found.
     Done,
     /// Final for this attempt, and the wallet is **not** recovered.
     ///

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -169,7 +169,10 @@
 
 use crate::{Federation, FederationId, InviteCode, Operation, OperationState, Result, Sdk};
 
+mod driver;
 mod wire;
+
+pub(crate) use driver::RecoveryDriver;
 
 impl Sdk {
     /// Joins a federation and restores this seed's wallet in it from the

--- a/rust/fedimint-sdk/src/recovery.rs
+++ b/rust/fedimint-sdk/src/recovery.rs
@@ -147,27 +147,18 @@
 //! - **Value the local state alone could have reclaimed is forfeited.** Out-of-band notes
 //!   this instance handed out and could still have reclaimed are recorded only locally, so
 //!   erasing that record gives up the reclaim.
-// Implementation notes (delete once implemented):
-// - Crash-at-every-checkpoint idempotency is a hard requirement: kill the process at each
-//   persisted checkpoint of a recovery, restart, and assert the recovered wallet is identical
-//   to one recovered without interruption.
-// - The underlying client does not persist a stopped recovery as failed: its own progress
-//   rests at the last durable checkpoint, and opening the federation again resumes the rescan
-//   from there automatically, whether via `reopen_federation` or via `SdkBuilder::build`
-//   bringing up federations at startup. The SDK cannot veto that restart, so on such a reopen
-//   it must mint the new attempt itself (a new `OperationId`, exactly as `resume_recovery`
-//   would) and persist that record *before* the underlying open is invoked, not merely
-//   before this call returns: the underlying open spawns recovery tasks while it runs, so a
-//   rescan can be advancing, or finished, before the open call returns. A crash in that
-//   window must not leave an unlogged attempt running with the SDK's own record still naming
-//   the old one, or the next boot would mint a third attempt.
-// - A guard that refuses to erase a federation which still reports a balance must not count
-//   the provisional balance of a recovery-locked federation: that balance is unspendable
-//   because of the lock, so counting it would close the erase path, the only way to end a
-//   recovery that cannot be retried into completion. There is deliberately no call to cancel
-//   a running recovery; erase is the only mechanism that can end one.
 
-use crate::{Federation, FederationId, InviteCode, Operation, OperationState, Result, Sdk};
+use std::sync::Arc;
+
+use fedimint_core::core::OperationId as UpstreamOperationId;
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+
+use crate::db::{FederationRecord, OperationRecordKey, RecoveryRecord, StoredStatus};
+use crate::federation::FederationInner;
+use crate::operation::OperationInner;
+use crate::{
+    Federation, FederationId, FederationStatus, InviteCode, Operation, OperationState, Result, Sdk,
+};
 
 mod driver;
 pub(crate) mod engine;
@@ -228,18 +219,84 @@ impl Sdk {
     /// [`FederationClosed`](crate::ErrorCode::FederationClosed), each with the
     /// may-already-have-joined caveat above.
     pub async fn recover(&self, invite: &InviteCode) -> Result<Recovery> {
-        // Implementation notes (delete once implemented):
-        // - The underlying client commits the join durably (configuration, secret hash,
-        //   pending-recovery marker) before any step that can still fail after it. Order the
-        //   SDK's own writes first: persist the recovery intent and the operation id this
-        //   call would return before the upstream join is asked to mutate anything, so that
-        //   if the join committed, the SDK's recovery record exists too.
-        // - An intent written for a join that never committed is inert: only the underlying
-        //   client's own durable recovery marker, not the SDK's intent alone, makes a
-        //   federation count as recovering. The next `recover` for the same federation
-        //   supersedes a leftover intent, and a plain `Sdk::join` discards it in the same
-        //   transaction that joins.
-        unimplemented!()
+        let _lifecycle = self.inner().lifecycle.lock().await;
+        self.inner().alive()?;
+        let id = invite.inner().federation_id();
+
+        // An id already here is `AlreadyJoined`, closed and quarantined included, because
+        // `reopen_federation` is the call that wants making. A committed erase is the exception:
+        // it is finished first and then this is a first-time recovery of the same federation.
+        if let Some(existing) = self.inner().federation_inner(&id) {
+            if existing.status() == FederationStatus::Forgetting {
+                self.inner().finish_erase(&id).await?;
+                self.inner().remove(&id);
+            } else {
+                return Err(crate::Error::new(
+                    crate::ErrorCode::AlreadyJoined,
+                    "this instance already holds that federation",
+                ));
+            }
+        }
+
+        let config = self.inner().download_config(invite).await?;
+        let preview = crate::modules::preview_of(&self.inner().module_inits, &config)?;
+        let record = FederationRecord {
+            invite: invite.inner().clone(),
+            network: preview.network.into(),
+            status: StoredStatus::Joining,
+            capabilities: crate::modules::capabilities_of(&preview.modules).into(),
+            generation: crate::modules::check_generation(&preview.modules)?,
+            name: preview.name.clone(),
+        };
+
+        let attempt = UpstreamOperationId::new_random();
+        // The intent is durable, together with the row it belongs to, before the client writes
+        // a byte: a process killed anywhere after this comes back with the federation
+        // recovering, and `SdkInner::start` redoes the recover under this same attempt id.
+        crate::db::write_joining_with_recovery(
+            &self.inner().db,
+            &id,
+            &record,
+            &RecoveryRecord { attempt },
+        )
+        .await?;
+
+        let client = match self.inner().recover_client(&id, &record).await {
+            Ok(client) => client,
+            Err(err) => {
+                // A recovery that returned an error must leave nothing behind. Only a crash
+                // leaves the `Joining` row and its recovery record, and only a crash is what it
+                // is for. `finish_erase` drops both.
+                let _ = self.inner().finish_erase(&id).await;
+                self.inner().remove(&id);
+                return Err(err);
+            }
+        };
+
+        let mut joined = record;
+        joined.status = StoredStatus::Open;
+        crate::db::write_federation(&self.inner().db, &id, &joined).await?;
+
+        let federation = Arc::new(FederationInner::new(
+            id,
+            Arc::downgrade(self.inner()),
+            self.inner()
+                .db
+                .with_prefix(crate::db::federation_prefix(&id).to_vec()),
+            joined,
+            FederationStatus::Running,
+            Some(client.clone()),
+        ));
+        self.inner().insert(federation.clone());
+        federation.record_recovery_attempt(attempt).await?;
+        let status = engine::after_open(self.inner(), &federation, &client, Some(attempt)).await;
+        federation.set_status(status);
+        crate::federation::reconcile_on_open(&federation).await;
+        self.inner().announce(&federation);
+        Ok(Recovery {
+            federation: Federation::new(federation.clone()),
+            progress: progress_handle(&federation, attempt).await?,
+        })
     }
 
     /// Resumes, or retries, the recovery of a federation this instance
@@ -306,24 +363,94 @@ impl Sdk {
     /// raised before that point leaves the running client untouched, and the call can simply
     /// be made again.
     pub async fn resume_recovery(&self, id: &FederationId) -> Result<Recovery> {
-        // Implementation notes (delete once implemented):
-        // - Presence of a *corroborated* recovery record is what this call keys on: an
-        //   intent whose upstream join never committed is not a record (see `Sdk::recover`'s
-        //   notes), so a plainly joined federation cannot ride in on a leftover intent.
-        // - "Running" must be verified against the underlying client, not taken from the
-        //   record's word: a current-attempt record whose rescan is not actually live should
-        //   be completed here, the restart finished then observed, rather than trusted and
-        //   watched.
-        // - The underlying client only derives and spawns recoveries when it is built, so
-        //   retrying a *stopped* attempt on an open federation means shutting the live client
-        //   down and rebuilding it, and the shutdown must run before the step that can still
-        //   fail, so an error from the rebuild leaves the federation with no live handle.
-        //   Persist the new attempt's id durably before attempting the rebuild, so it
-        //   survives as the current attempt for a later reopen to resume rather than mint
-        //   another.
-        // - `InvalidInput` here matches `Federation::activity`'s use of it for a cursor the
-        //   federation did not issue: a well-formed id this call does not apply to.
-        unimplemented!()
+        let _lifecycle = self.inner().lifecycle.lock().await;
+        self.inner().alive()?;
+        let upstream = id.inner();
+        let federation = self
+            .inner()
+            .federation_inner(&upstream)
+            .filter(|federation| federation.is_open())
+            .ok_or_else(|| {
+                crate::Error::new(
+                    crate::ErrorCode::FederationClosed,
+                    "this instance holds no open federation with that id",
+                )
+            })?;
+
+        let Some((record, on_file)) = engine::attempt_on_file(self.inner(), &federation).await?
+        else {
+            return Err(crate::Error::new(
+                crate::ErrorCode::InvalidInput,
+                "this federation was joined, not recovered; there is no recovery to resume",
+            ));
+        };
+
+        let attempt = match on_file {
+            engine::AttemptOnFile::Done => {
+                return Ok(Recovery {
+                    federation: Federation::new(federation.clone()),
+                    progress: progress_handle(&federation, record.attempt).await?,
+                });
+            }
+            // "Running" is verified against the underlying client rather than taken on the
+            // record's word: a current attempt whose rescan is not actually live is completed
+            // here, exactly as the watcher would, rather than trusted and handed back to watch.
+            engine::AttemptOnFile::None | engine::AttemptOnFile::Running => {
+                let client = federation.client(false).await?.handle();
+                if client.has_pending_recoveries() {
+                    // Idempotent: repairs the crash window where the record is missing, and is
+                    // a harmless rewrite of the same record otherwise.
+                    federation.record_recovery_attempt(record.attempt).await?;
+                } else {
+                    engine::complete(self.inner(), &federation, record.attempt).await;
+                }
+                record.attempt
+            }
+            // The underlying client only derives and spawns recoveries when it is built, so
+            // retrying a stopped attempt means rebuilding the client. The new attempt is made
+            // durable before the rebuild, so it survives as the current attempt for a later
+            // reopen to resume rather than minting another.
+            engine::AttemptOnFile::Failed { .. } => {
+                let new_attempt = engine::new_attempt(self.inner(), &federation).await?;
+                match federation
+                    .replace_client(|| async { self.inner().open_client(&upstream).await })
+                    .await
+                {
+                    // The federation was closed, quarantined or erased while this call was
+                    // minting the new attempt: whatever did that owns the status now, and this
+                    // call must not quarantine a federation that is no longer this call's to
+                    // decide about.
+                    Err(err) if err.code == crate::ErrorCode::FederationClosed => {
+                        return Err(err);
+                    }
+                    Err(err) => {
+                        federation.set_status(FederationStatus::Quarantined {
+                            diagnostic: err.clone().into(),
+                        });
+                        self.inner().announce(&federation);
+                        return Err(err);
+                    }
+                    Ok(()) => {
+                        let client = federation.client(false).await?.handle();
+                        let status = engine::after_open(
+                            self.inner(),
+                            &federation,
+                            &client,
+                            Some(new_attempt),
+                        )
+                        .await;
+                        federation.set_status(status);
+                        self.inner().announce(&federation);
+                    }
+                }
+                new_attempt
+            }
+        };
+
+        Ok(Recovery {
+            federation: Federation::new(federation.clone()),
+            progress: progress_handle(&federation, attempt).await?,
+        })
     }
 
     /// Where this federation's recovery stands, or `None` if it never had
@@ -363,8 +490,62 @@ impl Sdk {
     /// federation that has no recovery is `Ok(None)`, never an error, that
     /// is the whole point of the `Option`.
     pub async fn recovery_status(&self, id: &FederationId) -> Result<Option<RecoveryState>> {
-        unimplemented!()
+        self.inner().alive()?;
+        let upstream = id.inner();
+        let federation = self
+            .inner()
+            .federation_inner(&upstream)
+            .filter(|federation| federation.is_open())
+            .ok_or_else(|| {
+                crate::Error::new(
+                    crate::ErrorCode::FederationClosed,
+                    "this instance holds no open federation with that id",
+                )
+            })?;
+
+        let Some((_, on_file)) = engine::attempt_on_file(self.inner(), &federation).await? else {
+            return Ok(None);
+        };
+        Ok(Some(match on_file {
+            engine::AttemptOnFile::None | engine::AttemptOnFile::Running => RecoveryState::Running,
+            engine::AttemptOnFile::Done => RecoveryState::Done,
+            engine::AttemptOnFile::Failed { reason } => RecoveryState::Failed { reason },
+        }))
     }
+}
+
+/// The typed handle over an attempt just written, built from the record as it reads right now.
+///
+/// Shared by [`Sdk::recover`] and [`Sdk::resume_recovery`], the two calls that hand a fresh or
+/// resumed attempt back to the caller.
+///
+/// # Errors
+///
+/// [`Internal`](crate::ErrorCode::Internal) if `attempt` has no operation record: every caller
+/// writes or verifies one first, so this is a bug in this crate rather than a condition an
+/// application can be in.
+async fn progress_handle(
+    federation: &Arc<FederationInner>,
+    attempt: UpstreamOperationId,
+) -> Result<Operation<RecoveryState>> {
+    let db = federation.db();
+    let mut dbtx = db.begin_transaction_nc().await;
+    let record = dbtx.get_value(&OperationRecordKey(attempt)).await;
+    drop(dbtx);
+    let record = record.ok_or_else(|| {
+        crate::Error::new(
+            crate::ErrorCode::Internal,
+            format!("no record for recovery attempt {}", attempt.fmt_full()),
+        )
+    })?;
+    Ok(Operation::attach(
+        Arc::new(OperationInner {
+            federation: federation.clone(),
+            id: attempt,
+            record,
+        }),
+        Arc::new(RecoveryDriver),
+    ))
 }
 
 /// A federation that is being recovered, plus the operation doing it.
@@ -518,6 +699,9 @@ impl OperationState for RecoveryState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::{OperationRecord, StoredCapabilities, StoredNetwork};
+    use crate::operation::kinds;
+    use crate::{ErrorCode, Storage};
 
     #[test]
     fn recovery_state_running_is_not_final() {
@@ -560,5 +744,186 @@ mod tests {
         };
         assert!(stopped.is_final());
         assert!(!stopped.is_complete());
+    }
+
+    /// A real, in-memory instance: `recovery_status` and `resume_recovery` read and write the
+    /// root store through a genuine `SdkInner`, and there is no cheaper way to get one here than
+    /// the public builder, exactly as `engine`'s own tests do.
+    async fn detached_sdk() -> Sdk {
+        Sdk::builder()
+            .storage(Storage::in_memory())
+            .build()
+            .await
+            .expect("an instance opens")
+    }
+
+    /// Plants an open federation with no live client, so the lifecycle calls that read only
+    /// records can be tested natively. Mirrors `sdk::tests::building::plant_closed_federation`,
+    /// which cannot be reused from here: it is private to that module.
+    async fn plant_open_federation(sdk: &Sdk, id: fedimint_core::config::FederationId) {
+        let record = FederationRecord {
+            invite: fedimint_core::invite_code::InviteCode::new(
+                fedimint_core::util::SafeUrl::parse("wss://guardian.example:5000")
+                    .expect("a valid url"),
+                fedimint_core::PeerId::from(0),
+                id,
+                None,
+            ),
+            network: StoredNetwork::Regtest,
+            status: StoredStatus::Open,
+            capabilities: StoredCapabilities {
+                ecash: true,
+                lightning: false,
+                onchain: false,
+            },
+            generation: Some(1),
+            name: Some("Planted".to_owned()),
+        };
+        crate::db::write_federation(&sdk.inner().db, &id, &record)
+            .await
+            .expect("the row is written");
+        sdk.inner().insert(Arc::new(FederationInner::new(
+            id,
+            Arc::downgrade(sdk.inner()),
+            sdk.inner()
+                .db
+                .with_prefix(crate::db::federation_prefix(&id).to_vec()),
+            record,
+            FederationStatus::Running,
+            None,
+        )));
+    }
+
+    /// Plants an attempt's operation record directly, without going through
+    /// `record_recovery_attempt`, so a test can set up any final state it wants.
+    async fn plant_attempt_record(
+        federation: &FederationInner,
+        id: UpstreamOperationId,
+        final_state: Option<String>,
+    ) {
+        let db = federation.db();
+        let mut dbtx = db.begin_transaction().await;
+        dbtx.insert_entry(
+            &OperationRecordKey(id),
+            &OperationRecord {
+                schema_version: crate::operation::READABLE_STATE_SCHEMA,
+                kind: kinds::RECOVERY.to_owned(),
+                module: String::new(),
+                created_at: 0,
+                details: "{}".to_owned(),
+                phase: None,
+                cancel_requested_at: None,
+                final_state,
+            },
+        )
+        .await;
+        dbtx.commit_tx().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recovery_status_of_an_unknown_id_is_federation_closed() {
+        let sdk = detached_sdk().await;
+        let id = FederationId::from_upstream(fedimint_core::config::FederationId::dummy());
+
+        let err = sdk
+            .recovery_status(&id)
+            .await
+            .expect_err("this instance holds no such federation");
+        assert_eq!(err.code, ErrorCode::FederationClosed);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recovery_status_of_a_plainly_joined_federation_is_none() {
+        let sdk = detached_sdk().await;
+        let upstream = fedimint_core::config::FederationId::dummy();
+        plant_open_federation(&sdk, upstream).await;
+
+        let status = sdk
+            .recovery_status(&FederationId::from_upstream(upstream))
+            .await
+            .expect("a plainly joined federation is readable");
+        assert_eq!(status, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn recovery_status_reads_the_attempt_on_file() {
+        let sdk = detached_sdk().await;
+        let upstream = fedimint_core::config::FederationId::dummy();
+        plant_open_federation(&sdk, upstream).await;
+        let federation = sdk
+            .inner()
+            .federation_inner(&upstream)
+            .expect("just planted");
+
+        let attempt = UpstreamOperationId([9u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &upstream, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+        plant_attempt_record(
+            &federation,
+            attempt,
+            Some(
+                wire::encode_state(&RecoveryState::Failed {
+                    reason: "guardian gone".to_owned(),
+                })
+                .expect("encode"),
+            ),
+        )
+        .await;
+
+        let status = sdk
+            .recovery_status(&FederationId::from_upstream(upstream))
+            .await
+            .expect("the attempt's record reads back");
+        assert_eq!(
+            status,
+            Some(RecoveryState::Failed {
+                reason: "guardian gone".to_owned(),
+            })
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resume_recovery_refuses_a_plainly_joined_federation() {
+        let sdk = detached_sdk().await;
+        let upstream = fedimint_core::config::FederationId::dummy();
+        plant_open_federation(&sdk, upstream).await;
+
+        let err = sdk
+            .resume_recovery(&FederationId::from_upstream(upstream))
+            .await
+            .expect_err("this federation was joined, not recovered");
+        assert_eq!(err.code, ErrorCode::InvalidInput);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resume_recovery_of_a_completed_attempt_hands_back_done() {
+        let sdk = detached_sdk().await;
+        let upstream = fedimint_core::config::FederationId::dummy();
+        plant_open_federation(&sdk, upstream).await;
+        let federation = sdk
+            .inner()
+            .federation_inner(&upstream)
+            .expect("just planted");
+
+        let attempt = UpstreamOperationId([11u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &upstream, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+        plant_attempt_record(
+            &federation,
+            attempt,
+            Some(wire::encode_state(&RecoveryState::Done).expect("encode")),
+        )
+        .await;
+
+        let recovery = sdk
+            .resume_recovery(&FederationId::from_upstream(upstream))
+            .await
+            .expect("a completed recovery is handed back rather than restarted");
+        assert_eq!(
+            recovery.progress.state().await.expect("state"),
+            RecoveryState::Done
+        );
     }
 }

--- a/rust/fedimint-sdk/src/recovery/driver.rs
+++ b/rust/fedimint-sdk/src/recovery/driver.rs
@@ -38,9 +38,17 @@ impl Driver<RecoveryState> for RecoveryDriver {
         record: &'a OperationRecord,
     ) -> BoxFuture<'a, Result<BoxStream<'static, Result<RecoveryState>>>> {
         Box::pin(async move {
-            let current = current_state(record)?;
+            // Subscribed to the watch before the record is read, and the record read fresh
+            // rather than taken from the caller: a receiver only ever wakes for bumps made after
+            // it was created, so an ending recorded and bumped between the caller's read of
+            // `record` and this subscription would otherwise never be seen, and the stream
+            // would wait for a second bump that never comes.
             let changed = federation.recovery_changed();
             let db = federation.db();
+            let current = match reload_final_state(&db, id).await? {
+                Some(state) => state,
+                None => current_state(record)?,
+            };
             // Every other driver's `subscribe` replays an upstream state machine and has to
             // reason about whether resubscribing after a lagged notifier could skip a
             // transition it already produced. This one cannot lose anything that way, because
@@ -259,6 +267,43 @@ mod tests {
         assert_eq!(
             stream.next().await.expect("second item").expect("ok"),
             ending
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_ending_recorded_between_the_read_and_the_subscription_is_not_missed() {
+        let federation = detached_federation();
+        let id = OperationId([9u8; 32]);
+        federation
+            .record_recovery_attempt(id)
+            .await
+            .expect("record the attempt");
+        // The caller's snapshot says the attempt is running.
+        let stale = record_of(&federation, id).await;
+
+        // The ending lands, and is bumped, before the subscription exists.
+        let inner = Arc::new(OperationInner {
+            federation: federation.clone(),
+            id,
+            record: stale.clone(),
+        });
+        let encoded = RecoveryDriver
+            .encode_state(&RecoveryState::Done)
+            .expect("encode");
+        inner
+            .record_final_state(encoded)
+            .await
+            .expect("record final state");
+        federation.bump_recovery();
+
+        let mut stream = RecoveryDriver
+            .subscribe(&federation, id, &stale)
+            .await
+            .expect("subscribe");
+        assert_eq!(
+            stream.next().await.expect("first item").expect("ok"),
+            RecoveryState::Done
         );
         assert!(stream.next().await.is_none());
     }

--- a/rust/fedimint-sdk/src/recovery/driver.rs
+++ b/rust/fedimint-sdk/src/recovery/driver.rs
@@ -1,0 +1,339 @@
+//! The recovery driver: reads one attempt's persisted state, and never asks the client.
+
+use std::any::Any;
+
+use fedimint_core::core::OperationId;
+use fedimint_core::db::{Database, IDatabaseTransactionOpsCoreTyped};
+use fedimint_core::util::{BoxFuture, BoxStream};
+
+use super::wire;
+use crate::db::{OperationRecord, OperationRecordKey};
+use crate::federation::FederationInner;
+use crate::operation::Driver;
+use crate::{Error, ErrorCode, OperationState, RecoveryState, Result};
+
+/// Observes a seed recovery attempt from its operation record alone.
+///
+/// Recovery is not a client operation upstream (see the module documentation), so unlike every
+/// other driver in this crate, this one has no module call to make and no upstream state machine
+/// to fold onto: the attempt's operation record, written by
+/// [`FederationInner::record_recovery_attempt`] and completed by the watcher task the recovery
+/// flow starts, is the entire source of truth.
+pub(crate) struct RecoveryDriver;
+
+impl Driver<RecoveryState> for RecoveryDriver {
+    fn current<'a>(
+        &'a self,
+        _federation: &'a FederationInner,
+        _id: OperationId,
+        record: &'a OperationRecord,
+    ) -> BoxFuture<'a, Result<RecoveryState>> {
+        Box::pin(async move { current_state(record) })
+    }
+
+    fn subscribe<'a>(
+        &'a self,
+        federation: &'a FederationInner,
+        id: OperationId,
+        record: &'a OperationRecord,
+    ) -> BoxFuture<'a, Result<BoxStream<'static, Result<RecoveryState>>>> {
+        Box::pin(async move {
+            let current = current_state(record)?;
+            let changed = federation.recovery_changed();
+            let db = federation.db();
+            // Every other driver's `subscribe` replays an upstream state machine and has to
+            // reason about whether resubscribing after a lagged notifier could skip a
+            // transition it already produced. This one cannot lose anything that way, because
+            // there is no history to replay: the only thing a subscription ever reports is the
+            // attempt's record as it reads right now, and every stream this method returns,
+            // the first one or a fresh one opened after an earlier stream ended without a final
+            // state, starts by reading that same record and yielding its current reading first.
+            // A resubscribe is therefore never a second chance to catch something already
+            // missed, it is simply asking the same question again.
+            Ok(Box::pin(futures::stream::unfold(
+                (changed, db, id, Next::Current(current)),
+                |(mut changed, db, id, next)| async move {
+                    match next {
+                        Next::Current(state) => {
+                            let after = if state.is_final() {
+                                Next::Ended
+                            } else {
+                                Next::Watching
+                            };
+                            Some((Ok(state), (changed, db, id, after)))
+                        }
+                        Next::Watching => loop {
+                            if changed.changed().await.is_err() {
+                                // The sender lives on `FederationInner`; it going away means the
+                                // federation itself did, and there is nothing left to watch.
+                                return None;
+                            }
+                            match reload_final_state(&db, id).await {
+                                Ok(Some(state)) => {
+                                    return Some((Ok(state), (changed, db, id, Next::Ended)));
+                                }
+                                // Recorded change was not this attempt reaching an ending; keep
+                                // waiting for the one that is.
+                                Ok(None) => continue,
+                                Err(err) => {
+                                    return Some((Err(err), (changed, db, id, Next::Ended)));
+                                }
+                            }
+                        },
+                        Next::Ended => None,
+                    }
+                },
+            )) as BoxStream<'static, Result<RecoveryState>>)
+        })
+    }
+
+    fn same_state(&self, previous: &RecoveryState, next: &RecoveryState) -> bool {
+        previous == next
+    }
+
+    fn encode_state(&self, state: &RecoveryState) -> Result<String> {
+        wire::encode_state(state)
+    }
+
+    fn decode_state(&self, encoded: &str) -> Result<RecoveryState> {
+        wire::decode_state(encoded)
+    }
+
+    fn decode_details(&self, _json: &str) -> Result<Box<dyn Any + Send + Sync>> {
+        Err(Error::new(
+            ErrorCode::Internal,
+            "a recovery has no details record",
+        ))
+    }
+}
+
+/// Where a `subscribe` stream stands, threaded through `futures::stream::unfold`.
+enum Next {
+    /// The state read from the record when the subscription was opened, not yet handed out.
+    Current(RecoveryState),
+    /// The current state was not final: wait for the attempt's record to change.
+    Watching,
+    /// A final state has already been handed out; nothing more will ever come.
+    Ended,
+}
+
+/// The state an attempt's record reads as right now.
+///
+/// A missing final state is `Running`, never an error: an attempt with no ending recorded yet is
+/// simply still going.
+fn current_state(record: &OperationRecord) -> Result<RecoveryState> {
+    match &record.final_state {
+        Some(encoded) => wire::decode_state(encoded),
+        None => Ok(RecoveryState::Running),
+    }
+}
+
+/// The decoded final state on `id`'s record, or `None` if it has not recorded one yet.
+async fn reload_final_state(db: &Database, id: OperationId) -> Result<Option<RecoveryState>> {
+    let mut dbtx = db.begin_transaction_nc().await;
+    let record = dbtx.get_value(&OperationRecordKey(id)).await;
+    drop(dbtx);
+    let Some(record) = record else {
+        return Err(Error::new(
+            ErrorCode::Internal,
+            format!("no record for operation {}", id.fmt_full()),
+        ));
+    };
+    match record.final_state {
+        Some(encoded) => wire::decode_state(&encoded).map(Some),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::operation::OperationInner;
+
+    /// A detached federation over a fresh in-memory namespace, the way this driver's tests
+    /// exercise it: no client, so the driver's promise to never touch one is load-bearing.
+    fn detached_federation() -> Arc<FederationInner> {
+        FederationInner::detached(
+            crate::db::federation_namespace(&crate::db::in_memory_root(), [1u8; 32]),
+            true,
+        )
+    }
+
+    /// Reads back the record an attempt was written under, the way a driver reloads it.
+    async fn record_of(federation: &FederationInner, id: OperationId) -> OperationRecord {
+        let db = federation.db();
+        let mut dbtx = db.begin_transaction_nc().await;
+        dbtx.get_value(&OperationRecordKey(id))
+            .await
+            .expect("the attempt was recorded")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_fresh_attempt_reads_running() {
+        let federation = detached_federation();
+        let id = OperationId([1u8; 32]);
+        federation
+            .record_recovery_attempt(id)
+            .await
+            .expect("record the attempt");
+        let record = record_of(&federation, id).await;
+        let state = RecoveryDriver
+            .current(&federation, id, &record)
+            .await
+            .expect("current");
+        assert_eq!(state, RecoveryState::Running);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_recorded_ending_reads_back() {
+        for ending in [
+            RecoveryState::Done,
+            RecoveryState::Failed {
+                reason: "guardian went away".to_owned(),
+            },
+        ] {
+            let federation = detached_federation();
+            let id = OperationId([2u8; 32]);
+            federation
+                .record_recovery_attempt(id)
+                .await
+                .expect("record the attempt");
+            let record = record_of(&federation, id).await;
+            let inner = Arc::new(OperationInner {
+                federation: federation.clone(),
+                id,
+                record,
+            });
+            let encoded = RecoveryDriver.encode_state(&ending).expect("encode");
+            inner
+                .record_final_state(encoded)
+                .await
+                .expect("record final state");
+            let record = record_of(&federation, id).await;
+            let state = RecoveryDriver
+                .current(&federation, id, &record)
+                .await
+                .expect("current");
+            assert_eq!(state, ending);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_subscription_yields_running_then_the_ending_when_it_is_recorded() {
+        let federation = detached_federation();
+        let id = OperationId([3u8; 32]);
+        federation
+            .record_recovery_attempt(id)
+            .await
+            .expect("record the attempt");
+        let record = record_of(&federation, id).await;
+        let mut stream = RecoveryDriver
+            .subscribe(&federation, id, &record)
+            .await
+            .expect("subscribe");
+        assert_eq!(
+            stream.next().await.expect("first item").expect("ok"),
+            RecoveryState::Running
+        );
+
+        let ending = RecoveryState::Failed {
+            reason: "guardian went away".to_owned(),
+        };
+        let inner = Arc::new(OperationInner {
+            federation: federation.clone(),
+            id,
+            record: record_of(&federation, id).await,
+        });
+        let encoded = RecoveryDriver.encode_state(&ending).expect("encode");
+        inner
+            .record_final_state(encoded)
+            .await
+            .expect("record final state");
+        federation.bump_recovery();
+
+        assert_eq!(
+            stream.next().await.expect("second item").expect("ok"),
+            ending
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_subscription_to_a_finished_attempt_yields_only_the_ending() {
+        let federation = detached_federation();
+        let id = OperationId([4u8; 32]);
+        federation
+            .record_recovery_attempt(id)
+            .await
+            .expect("record the attempt");
+        let record = record_of(&federation, id).await;
+        let inner = Arc::new(OperationInner {
+            federation: federation.clone(),
+            id,
+            record,
+        });
+        let encoded = RecoveryDriver
+            .encode_state(&RecoveryState::Done)
+            .expect("encode");
+        inner
+            .record_final_state(encoded)
+            .await
+            .expect("record final state");
+
+        let record = record_of(&federation, id).await;
+        let mut stream = RecoveryDriver
+            .subscribe(&federation, id, &record)
+            .await
+            .expect("subscribe");
+        assert_eq!(
+            stream.next().await.expect("first item").expect("ok"),
+            RecoveryState::Done
+        );
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_bump_with_nothing_recorded_yields_nothing() {
+        let federation = detached_federation();
+        let id = OperationId([5u8; 32]);
+        federation
+            .record_recovery_attempt(id)
+            .await
+            .expect("record the attempt");
+        let record = record_of(&federation, id).await;
+        let mut stream = RecoveryDriver
+            .subscribe(&federation, id, &record)
+            .await
+            .expect("subscribe");
+        assert_eq!(
+            stream.next().await.expect("first item").expect("ok"),
+            RecoveryState::Running
+        );
+
+        federation.bump_recovery();
+        let pending = tokio::time::timeout(Duration::from_millis(50), stream.next()).await;
+        assert!(pending.is_err(), "the stream must still be waiting");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn as_recovery_hands_back_a_typed_handle() {
+        let federation = detached_federation();
+        let id = OperationId([6u8; 32]);
+        federation
+            .record_recovery_attempt(id)
+            .await
+            .expect("record the attempt");
+        let any = federation
+            .operation(id)
+            .await
+            .expect("lookup")
+            .expect("the attempt was recorded");
+        let typed = any.as_recovery().expect("this build reads recovery");
+        assert_eq!(typed.state().await.expect("state"), RecoveryState::Running);
+    }
+}

--- a/rust/fedimint-sdk/src/recovery/engine.rs
+++ b/rust/fedimint-sdk/src/recovery/engine.rs
@@ -203,18 +203,30 @@ pub(crate) fn watch(
     });
 }
 
-/// The watcher's completion: [`finish`] under the lifecycle mutex.
+/// The watcher's completion: [`finish`] under the lifecycle mutex, unless the attempt has
+/// already been concluded by the time the mutex is held.
 ///
 /// Taken because the swap and the status that follows it are a lifecycle transition, and a
 /// `close_federation` or `forget_federation` interleaved between the two would have its
 /// `Closed` overwritten with `Running` on a federation whose client had just been taken away.
 /// The mutex is taken before anything else, as every lifecycle call takes it.
+///
+/// The attempt is re-read once the mutex is held: a `resume_recovery` that held it while the
+/// rescan ended has already seen nothing pending and completed the attempt itself, and a second
+/// swap would retire the usable client it just installed for nothing, with a failed reopen
+/// quarantining a federation that had recovered.
 pub(crate) async fn complete(
     sdk: &Arc<SdkInner>,
     federation: &Arc<FederationInner>,
     attempt: UpstreamOperationId,
 ) {
     let _lifecycle = sdk.lifecycle.lock().await;
+    if read_attempt_record(federation, attempt)
+        .await
+        .is_some_and(|record| record.final_state.is_some())
+    {
+        return;
+    }
     finish(sdk, federation, attempt).await;
 }
 
@@ -545,6 +557,35 @@ mod tests {
                 .expect("decode"),
             RecoveryState::Done
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_concluded_attempt_is_not_completed_a_second_time() {
+        let sdk = detached_sdk().await;
+        let federation = detached_federation(&sdk.inner().db);
+        let attempt = UpstreamOperationId([9u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &federation.id, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+        // What the watcher finds when `resume_recovery` held the lifecycle mutex while the
+        // rescan ended and completed the attempt first.
+        plant_operation_record(
+            &federation,
+            attempt,
+            Some(wire::encode_state(&RecoveryState::Done).expect("encode")),
+        )
+        .await;
+        let observed = federation.recovery_changed();
+
+        complete(sdk.inner(), &federation, attempt).await;
+
+        // A completion writes the ending and wakes the attempt's subscribers; a skipped one
+        // does neither.
+        assert!(
+            !observed.has_changed().expect("the sender is alive"),
+            "a second completion must leave the concluded attempt alone"
+        );
+        assert_eq!(federation.status(), FederationStatus::Running);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/fedimint-sdk/src/recovery/engine.rs
+++ b/rust/fedimint-sdk/src/recovery/engine.rs
@@ -101,20 +101,40 @@ pub(crate) async fn prepare_open(
     }
 }
 
-/// Reconciles the attempt with what the freshly opened client says, sets the status, and starts
-/// the watcher when the rescan is still running. `attempt` is `prepare_open`'s answer.
+/// Reconciles the attempt with what the freshly opened client says, publishes the status that
+/// follows, and starts the watcher when the rescan is still running. `attempt` is
+/// `prepare_open`'s answer.
+///
+/// `client` is the caller's last handle to the client, taken by value so that a swap made here
+/// finds nothing else holding it. The status is set here, and set before the watcher spawns,
+/// because the watcher's own close-watch reads it: a federation still marked closed from its
+/// construction would end the watch before the rescan had started.
+///
+/// Like [`finish`], this runs under the lifecycle mutex, or inside the build before any handle
+/// exists to contend for it.
 pub(crate) async fn after_open(
     sdk: &Arc<SdkInner>,
     federation: &Arc<FederationInner>,
-    client: &ClientHandleArc,
+    client: ClientHandleArc,
     attempt: Option<UpstreamOperationId>,
-) -> FederationStatus {
+) {
     let Some(attempt) = attempt else {
-        return FederationStatus::Running;
+        federation.set_status(FederationStatus::Running);
+        return;
     };
     if client.has_pending_recoveries() {
-        watch(sdk.clone(), federation.clone(), client.clone(), attempt);
-        return FederationStatus::Recovering;
+        federation.set_status(FederationStatus::Recovering);
+        watch(sdk.clone(), federation.clone(), client, attempt);
+        return;
+    }
+    // A rescan that ended between the client's construction and here reports nothing pending,
+    // but a module it held back for the duration (a v1 mint) is still out of the registry
+    // until the next build: the same swap the watcher would have made is made now.
+    let usable = client.all_modules_usable();
+    drop(client);
+    if !usable {
+        finish(sdk, federation, attempt).await;
+        return;
     }
     // The client's own durable state already corroborates completion. If the attempt's record
     // has not caught up yet (the crash window between the client's own commit and this SDK's
@@ -134,7 +154,7 @@ pub(crate) async fn after_open(
             ),
         }
     }
-    FederationStatus::Running
+    federation.set_status(FederationStatus::Running);
 }
 
 /// One task per recovering federation: blocks until the client's rescan ends, then records
@@ -183,8 +203,28 @@ pub(crate) fn watch(
     });
 }
 
-/// The completion rule from the plan's fixed decisions.
+/// The watcher's completion: [`finish`] under the lifecycle mutex.
+///
+/// Taken because the swap and the status that follows it are a lifecycle transition, and a
+/// `close_federation` or `forget_federation` interleaved between the two would have its
+/// `Closed` overwritten with `Running` on a federation whose client had just been taken away.
+/// The mutex is taken before anything else, as every lifecycle call takes it.
 pub(crate) async fn complete(
+    sdk: &Arc<SdkInner>,
+    federation: &Arc<FederationInner>,
+    attempt: UpstreamOperationId,
+) {
+    let _lifecycle = sdk.lifecycle.lock().await;
+    finish(sdk, federation, attempt).await;
+}
+
+/// The completion rule from the plan's fixed decisions: swap in a usable client, record the
+/// attempt done, publish the status.
+///
+/// The caller holds the lifecycle mutex, or is the build, which runs before any handle exists
+/// to take it. Either way nothing can close, erase or reopen the federation between the swap
+/// and the status.
+pub(crate) async fn finish(
     sdk: &Arc<SdkInner>,
     federation: &Arc<FederationInner>,
     attempt: UpstreamOperationId,
@@ -479,6 +519,32 @@ mod tests {
             .expect("prepare")
             .expect("an attempt to open under");
         assert_eq!(prepared, attempt);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn completing_a_closed_federation_records_the_ending_but_leaves_its_status_alone() {
+        let sdk = detached_sdk().await;
+        // Closed, with no client: what the watcher finds when a close won the race against
+        // the rescan's end.
+        let federation =
+            FederationInner::detached(federation_namespace(&sdk.inner().db, [1u8; 32]), false);
+        let attempt = UpstreamOperationId([8u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &federation.id, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+        plant_operation_record(&federation, attempt, None).await;
+
+        complete(sdk.inner(), &federation, attempt).await;
+
+        assert_eq!(federation.status(), FederationStatus::Closed);
+        let record = read_attempt_record(&federation, attempt)
+            .await
+            .expect("the record survives");
+        assert_eq!(
+            wire::decode_state(&record.final_state.expect("the rescan's end is recorded"))
+                .expect("decode"),
+            RecoveryState::Done
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/rust/fedimint-sdk/src/recovery/engine.rs
+++ b/rust/fedimint-sdk/src/recovery/engine.rs
@@ -221,6 +221,19 @@ pub(crate) async fn complete(
     sdk.announce(federation);
 }
 
+/// Mints a brand new attempt: the root record naming it, then its operation record, in that
+/// order, so a crash between the two reads back as `PreOpen::RecordMissing` next time rather
+/// than as an attempt the root record does not name.
+pub(crate) async fn new_attempt(
+    sdk: &SdkInner,
+    federation: &FederationInner,
+) -> Result<UpstreamOperationId> {
+    let attempt = UpstreamOperationId::new_random();
+    crate::db::write_recovery(&sdk.db, &federation.id, &RecoveryRecord { attempt }).await?;
+    federation.record_recovery_attempt(attempt).await?;
+    Ok(attempt)
+}
+
 /// Records that an attempt stopped, for the reason the watcher observed. Status is untouched:
 /// the federation stays `Recovering`, and a later open or `resume_recovery` decides what to do
 /// about the attempt from here.
@@ -249,19 +262,6 @@ async fn record_attempt_failed(
             "could not record a failed recovery attempt",
         ),
     }
-}
-
-/// Mints a brand new attempt: the root record naming it, then its operation record, in that
-/// order, so a crash between the two reads back as `PreOpen::RecordMissing` next time rather
-/// than as an attempt the root record does not name.
-pub(crate) async fn new_attempt(
-    sdk: &SdkInner,
-    federation: &FederationInner,
-) -> Result<UpstreamOperationId> {
-    let attempt = UpstreamOperationId::new_random();
-    crate::db::write_recovery(&sdk.db, &federation.id, &RecoveryRecord { attempt }).await?;
-    federation.record_recovery_attempt(attempt).await?;
-    Ok(attempt)
 }
 
 /// The attempt's own operation record, straight from the federation's namespace.

--- a/rust/fedimint-sdk/src/recovery/engine.rs
+++ b/rust/fedimint-sdk/src/recovery/engine.rs
@@ -184,7 +184,7 @@ pub(crate) fn watch(
 }
 
 /// The completion rule from the plan's fixed decisions.
-async fn complete(
+pub(crate) async fn complete(
     sdk: &Arc<SdkInner>,
     federation: &Arc<FederationInner>,
     attempt: UpstreamOperationId,
@@ -254,7 +254,10 @@ async fn record_attempt_failed(
 /// Mints a brand new attempt: the root record naming it, then its operation record, in that
 /// order, so a crash between the two reads back as `PreOpen::RecordMissing` next time rather
 /// than as an attempt the root record does not name.
-async fn new_attempt(sdk: &SdkInner, federation: &FederationInner) -> Result<UpstreamOperationId> {
+pub(crate) async fn new_attempt(
+    sdk: &SdkInner,
+    federation: &FederationInner,
+) -> Result<UpstreamOperationId> {
     let attempt = UpstreamOperationId::new_random();
     crate::db::write_recovery(&sdk.db, &federation.id, &RecoveryRecord { attempt }).await?;
     federation.record_recovery_attempt(attempt).await?;

--- a/rust/fedimint-sdk/src/recovery/engine.rs
+++ b/rust/fedimint-sdk/src/recovery/engine.rs
@@ -146,7 +146,20 @@ pub(crate) fn watch(
     attempt: UpstreamOperationId,
 ) {
     fedimint_core::task::spawn("sdk-recovery-watch", async move {
-        let outcome = client.wait_for_all_recoveries().await;
+        // The wait ends either with the rescan's outcome or with the federation closing,
+        // whichever comes first. The second matters because the client's own status channel
+        // need not close when the federation does (a coordinator whose module gave up parks
+        // for ever), and a close has to get this task's clone of the client back promptly:
+        // `shutdown_client` needs the last reference.
+        let mut closed = federation.closed();
+        let outcome = {
+            let wait = std::pin::pin!(client.wait_for_all_recoveries());
+            let close = std::pin::pin!(closed.wait_for(|closed| *closed));
+            match futures::future::select(wait, close).await {
+                futures::future::Either::Left((outcome, _)) => outcome,
+                futures::future::Either::Right(_) => Err(RecoveryError::ClientStopped),
+            }
+        };
         drop(client);
         match outcome {
             Ok(()) => complete(&sdk, &federation, attempt).await,
@@ -198,6 +211,9 @@ async fn complete(
     federation.bump_recovery();
     match opened {
         Ok(()) => federation.set_status(FederationStatus::Running),
+        // The federation was closed, quarantined or erased while the rescan was finishing;
+        // the swap was refused, and whatever closed it owns the status now.
+        Err(err) if err.code == crate::ErrorCode::FederationClosed => return,
         Err(err) => federation.set_status(FederationStatus::Quarantined {
             diagnostic: err.into(),
         }),

--- a/rust/fedimint-sdk/src/recovery/engine.rs
+++ b/rust/fedimint-sdk/src/recovery/engine.rs
@@ -1,0 +1,520 @@
+//! What the SDK does around the underlying client's own recovery: the records it keeps, the
+//! watcher that learns when a rescan ends, and the client swap that makes a recovered wallet
+//! usable.
+
+use std::sync::Arc;
+
+use fedimint_client::ClientHandleArc;
+use fedimint_client::error::RecoveryError;
+use fedimint_core::core::OperationId as UpstreamOperationId;
+use fedimint_core::db::IDatabaseTransactionOpsCoreTyped;
+
+use super::wire;
+use crate::db::{OperationRecord, OperationRecordKey, RecoveryRecord};
+use crate::federation::FederationInner;
+use crate::operation::OperationInner;
+use crate::sdk::SdkInner;
+use crate::{FederationStatus, RecoveryState, Result};
+
+/// What is known about a federation's attempt before its client is opened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AttemptOnFile {
+    /// The root record names an attempt with no operation record: the crash window between the
+    /// underlying client's own commit and this SDK's write of it.
+    None,
+    /// The operation record exists and has not recorded a final state.
+    Running,
+    /// The operation record's final state decodes as done.
+    Done,
+    /// The operation record's final state decodes as failed, or does not decode at all: an
+    /// ending this build cannot interpret is treated the same as a failed one.
+    Failed {
+        /// Why, for the case this build could decode; the decode error's own text otherwise.
+        reason: String,
+    },
+}
+
+/// What to do about the attempt before the underlying open is invoked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreOpen {
+    /// The attempt is already durable and current: nothing to do before the open.
+    Keep,
+    /// The root record names an attempt whose operation record is missing; write it, under the
+    /// same id, before the open runs.
+    RecordMissing,
+    /// The last attempt stopped; mint a fresh one before the open runs.
+    Mint,
+}
+
+/// The pre-open rule from the plan's fixed decisions, as a pure function.
+pub(crate) fn plan_pre_open(on_file: &AttemptOnFile) -> PreOpen {
+    match on_file {
+        AttemptOnFile::None => PreOpen::RecordMissing,
+        AttemptOnFile::Running | AttemptOnFile::Done => PreOpen::Keep,
+        AttemptOnFile::Failed { .. } => PreOpen::Mint,
+    }
+}
+
+/// The attempt's state on file, from the root record and the attempt's operation record.
+pub(crate) async fn attempt_on_file(
+    sdk: &SdkInner,
+    federation: &FederationInner,
+) -> Result<Option<(RecoveryRecord, AttemptOnFile)>> {
+    let Some(record) = crate::db::read_recovery(&sdk.db, &federation.id).await? else {
+        return Ok(None);
+    };
+    let on_file = match read_attempt_record(federation, record.attempt).await {
+        None => AttemptOnFile::None,
+        Some(op_record) => match op_record.final_state {
+            None => AttemptOnFile::Running,
+            Some(encoded) => match wire::decode_state(&encoded) {
+                Ok(RecoveryState::Running) => AttemptOnFile::Running,
+                Ok(RecoveryState::Done) => AttemptOnFile::Done,
+                Ok(RecoveryState::Failed { reason }) => AttemptOnFile::Failed { reason },
+                // A fresh attempt is the safe reading of a record this build cannot interpret:
+                // minting one beats trusting an ending nothing here can understand.
+                Err(err) => AttemptOnFile::Failed {
+                    reason: err.message,
+                },
+            },
+        },
+    };
+    Ok(Some((record, on_file)))
+}
+
+/// Applies the pre-open rule, durably, before the underlying open is invoked. Returns the
+/// attempt id the open runs under, or `None` for a federation with no recovery record.
+pub(crate) async fn prepare_open(
+    sdk: &SdkInner,
+    federation: &FederationInner,
+) -> Result<Option<UpstreamOperationId>> {
+    let Some((record, on_file)) = attempt_on_file(sdk, federation).await? else {
+        return Ok(None);
+    };
+    match plan_pre_open(&on_file) {
+        PreOpen::Keep => Ok(Some(record.attempt)),
+        PreOpen::RecordMissing => {
+            federation.record_recovery_attempt(record.attempt).await?;
+            Ok(Some(record.attempt))
+        }
+        PreOpen::Mint => new_attempt(sdk, federation).await.map(Some),
+    }
+}
+
+/// Reconciles the attempt with what the freshly opened client says, sets the status, and starts
+/// the watcher when the rescan is still running. `attempt` is `prepare_open`'s answer.
+pub(crate) async fn after_open(
+    sdk: &Arc<SdkInner>,
+    federation: &Arc<FederationInner>,
+    client: &ClientHandleArc,
+    attempt: Option<UpstreamOperationId>,
+) -> FederationStatus {
+    let Some(attempt) = attempt else {
+        return FederationStatus::Running;
+    };
+    if client.has_pending_recoveries() {
+        watch(sdk.clone(), federation.clone(), client.clone(), attempt);
+        return FederationStatus::Recovering;
+    }
+    // The client's own durable state already corroborates completion. If the attempt's record
+    // has not caught up yet (the crash window between the client's own commit and this SDK's
+    // write), catch it up now: no watcher starts for an attempt whose client reports nothing
+    // pending, so nothing else ever will.
+    if let Some(record) = read_attempt_record(federation, attempt).await
+        && record.final_state.is_none()
+    {
+        match write_final_state(federation, attempt, record, RecoveryState::Done).await {
+            Ok(()) => federation.bump_recovery(),
+            Err(err) => tracing::warn!(
+                target: "fedimint_sdk",
+                federation = %federation.id,
+                attempt = %attempt.fmt_full(),
+                error = %err,
+                "could not record a finished recovery attempt as done",
+            ),
+        }
+    }
+    FederationStatus::Running
+}
+
+/// One task per recovering federation: blocks until the client's rescan ends, then records
+/// the outcome and, on success, swaps in a usable client.
+pub(crate) fn watch(
+    sdk: Arc<SdkInner>,
+    federation: Arc<FederationInner>,
+    client: ClientHandleArc,
+    attempt: UpstreamOperationId,
+) {
+    fedimint_core::task::spawn("sdk-recovery-watch", async move {
+        let outcome = client.wait_for_all_recoveries().await;
+        drop(client);
+        match outcome {
+            Ok(()) => complete(&sdk, &federation, attempt).await,
+            Err(RecoveryError::Failed {
+                module_instance_id,
+                error,
+            }) => {
+                record_attempt_failed(
+                    &federation,
+                    attempt,
+                    format!("module {module_instance_id}: {error}"),
+                )
+                .await;
+            }
+            Err(RecoveryError::ClientStopped) => {}
+            // `RecoveryError` is `#[non_exhaustive]`: a variant this build does not recognise
+            // yet is still recorded as a failure, using its own `Display` for the reason,
+            // rather than leaving the attempt `Running` forever.
+            Err(err) => record_attempt_failed(&federation, attempt, err.to_string()).await,
+        }
+    });
+}
+
+/// The completion rule from the plan's fixed decisions.
+async fn complete(
+    sdk: &Arc<SdkInner>,
+    federation: &Arc<FederationInner>,
+    attempt: UpstreamOperationId,
+) {
+    let id = federation.id;
+    // The swap is what makes the recovered wallet usable: a v1 mint recovers as
+    // `RecoveryMode::Unusable` and only enters the module registry on the client's next build
+    // (`fedimint-mint-client/src/lib.rs:839-841`, `fedimint-client/src/client/builder.rs:951`),
+    // so every generation is swapped even though only some of them need it.
+    let opened = federation
+        .replace_client(|| async { sdk.open_client(&id).await })
+        .await;
+    if let Some(record) = read_attempt_record(federation, attempt).await
+        && let Err(err) = write_final_state(federation, attempt, record, RecoveryState::Done).await
+    {
+        tracing::warn!(
+            target: "fedimint_sdk",
+            federation = %federation.id,
+            attempt = %attempt.fmt_full(),
+            error = %err,
+            "could not record a finished recovery attempt as done",
+        );
+    }
+    federation.bump_recovery();
+    match opened {
+        Ok(()) => federation.set_status(FederationStatus::Running),
+        Err(err) => federation.set_status(FederationStatus::Quarantined {
+            diagnostic: err.into(),
+        }),
+    }
+    sdk.announce(federation);
+}
+
+/// Records that an attempt stopped, for the reason the watcher observed. Status is untouched:
+/// the federation stays `Recovering`, and a later open or `resume_recovery` decides what to do
+/// about the attempt from here.
+async fn record_attempt_failed(
+    federation: &Arc<FederationInner>,
+    attempt: UpstreamOperationId,
+    reason: String,
+) {
+    let Some(record) = read_attempt_record(federation, attempt).await else {
+        return;
+    };
+    match write_final_state(
+        federation,
+        attempt,
+        record,
+        RecoveryState::Failed { reason },
+    )
+    .await
+    {
+        Ok(()) => federation.bump_recovery(),
+        Err(err) => tracing::warn!(
+            target: "fedimint_sdk",
+            federation = %federation.id,
+            attempt = %attempt.fmt_full(),
+            error = %err,
+            "could not record a failed recovery attempt",
+        ),
+    }
+}
+
+/// Mints a brand new attempt: the root record naming it, then its operation record, in that
+/// order, so a crash between the two reads back as `PreOpen::RecordMissing` next time rather
+/// than as an attempt the root record does not name.
+async fn new_attempt(sdk: &SdkInner, federation: &FederationInner) -> Result<UpstreamOperationId> {
+    let attempt = UpstreamOperationId::new_random();
+    crate::db::write_recovery(&sdk.db, &federation.id, &RecoveryRecord { attempt }).await?;
+    federation.record_recovery_attempt(attempt).await?;
+    Ok(attempt)
+}
+
+/// The attempt's own operation record, straight from the federation's namespace.
+async fn read_attempt_record(
+    federation: &FederationInner,
+    attempt: UpstreamOperationId,
+) -> Option<OperationRecord> {
+    let db = federation.db();
+    let mut dbtx = db.begin_transaction_nc().await;
+    dbtx.get_value(&OperationRecordKey(attempt)).await
+}
+
+/// Encodes `state` and records it as the attempt's final state, through an [`OperationInner`]
+/// built from `record`.
+async fn write_final_state(
+    federation: &Arc<FederationInner>,
+    attempt: UpstreamOperationId,
+    record: OperationRecord,
+    state: RecoveryState,
+) -> Result<()> {
+    let encoded = wire::encode_state(&state)?;
+    OperationInner {
+        federation: federation.clone(),
+        id: attempt,
+        record,
+    }
+    .record_final_state(encoded)
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use fedimint_core::db::Database;
+
+    use super::*;
+    use crate::db::federation_namespace;
+    use crate::operation::kinds;
+    use crate::{Sdk, Storage};
+
+    /// A real, minimal instance backed by in-memory storage. `attempt_on_file` and
+    /// `prepare_open` read and write the root store through a genuine `SdkInner`, and
+    /// `SdkInner`'s own fields are private outside `crate::sdk`, so there is no cheaper way to
+    /// get one here than the public builder.
+    async fn detached_sdk() -> Sdk {
+        Sdk::builder()
+            .storage(Storage::in_memory())
+            .build()
+            .await
+            .expect("an instance opens")
+    }
+
+    /// A federation with no client, whose own namespace sits inside `root`: the same
+    /// relationship an `SdkInner`'s root database and a federation's own database have in a
+    /// real instance.
+    fn detached_federation(root: &Database) -> Arc<FederationInner> {
+        FederationInner::detached(federation_namespace(root, [1u8; 32]), true)
+    }
+
+    /// Plants an attempt's operation record directly, without going through
+    /// `record_recovery_attempt` or `record_final_state`, so a test can set up any final state
+    /// it wants, decodable or not.
+    async fn plant_operation_record(
+        federation: &FederationInner,
+        id: UpstreamOperationId,
+        final_state: Option<String>,
+    ) {
+        let db = federation.db();
+        let mut dbtx = db.begin_transaction().await;
+        dbtx.insert_entry(
+            &OperationRecordKey(id),
+            &OperationRecord {
+                schema_version: crate::operation::READABLE_STATE_SCHEMA,
+                kind: kinds::RECOVERY.to_owned(),
+                module: String::new(),
+                created_at: 0,
+                details: "{}".to_owned(),
+                phase: None,
+                cancel_requested_at: None,
+                final_state,
+            },
+        )
+        .await;
+        dbtx.commit_tx().await;
+    }
+
+    #[test]
+    fn plan_pre_open_answers_the_three_fixed_cases() {
+        assert_eq!(plan_pre_open(&AttemptOnFile::None), PreOpen::RecordMissing);
+        assert_eq!(plan_pre_open(&AttemptOnFile::Running), PreOpen::Keep);
+        assert_eq!(plan_pre_open(&AttemptOnFile::Done), PreOpen::Keep);
+        assert_eq!(
+            plan_pre_open(&AttemptOnFile::Failed {
+                reason: "guardian gone".to_owned(),
+            }),
+            PreOpen::Mint
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn attempt_on_file_needs_a_root_record_before_it_reads_anything_else() {
+        let sdk = detached_sdk().await;
+        let federation = detached_federation(&sdk.inner().db);
+
+        // No recovery record at all: this federation was never recovered.
+        assert_eq!(
+            attempt_on_file(sdk.inner(), &federation)
+                .await
+                .expect("read"),
+            None
+        );
+
+        // A root record naming an attempt that crashed before its own operation record was
+        // written.
+        let attempt = UpstreamOperationId([1u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &federation.id, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+        let (record, on_file) = attempt_on_file(sdk.inner(), &federation)
+            .await
+            .expect("read")
+            .expect("a root record now exists");
+        assert_eq!(record.attempt, attempt);
+        assert_eq!(on_file, AttemptOnFile::None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn attempt_on_file_reads_the_operation_records_final_state() {
+        let sdk = detached_sdk().await;
+        let federation = detached_federation(&sdk.inner().db);
+        let broken = r#"{"Paused":{}}"#.to_owned();
+        let undecodable_reason = wire::decode_state(&broken)
+            .expect_err("this build has no Paused variant")
+            .message;
+
+        let cases = [
+            (1u8, None, AttemptOnFile::Running),
+            (
+                2u8,
+                Some(wire::encode_state(&RecoveryState::Done).expect("encode")),
+                AttemptOnFile::Done,
+            ),
+            (
+                3u8,
+                Some(
+                    wire::encode_state(&RecoveryState::Failed {
+                        reason: "guardian gone".to_owned(),
+                    })
+                    .expect("encode"),
+                ),
+                AttemptOnFile::Failed {
+                    reason: "guardian gone".to_owned(),
+                },
+            ),
+            (
+                4u8,
+                Some(broken),
+                AttemptOnFile::Failed {
+                    reason: undecodable_reason,
+                },
+            ),
+        ];
+        for (byte, final_state, expected) in cases {
+            let attempt = UpstreamOperationId([byte; 32]);
+            crate::db::write_recovery(&sdk.inner().db, &federation.id, &RecoveryRecord { attempt })
+                .await
+                .expect("write the root record");
+            plant_operation_record(&federation, attempt, final_state).await;
+
+            let (_, on_file) = attempt_on_file(sdk.inner(), &federation)
+                .await
+                .expect("read")
+                .expect("a root record exists");
+            assert_eq!(on_file, expected);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_open_records_a_missing_attempt_under_the_same_id() {
+        let sdk = detached_sdk().await;
+        let federation = detached_federation(&sdk.inner().db);
+        let attempt = UpstreamOperationId([5u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &federation.id, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+
+        let prepared = prepare_open(sdk.inner(), &federation)
+            .await
+            .expect("prepare")
+            .expect("an attempt to open under");
+        assert_eq!(prepared, attempt);
+
+        let (record, on_file) = attempt_on_file(sdk.inner(), &federation)
+            .await
+            .expect("read")
+            .expect("a root record");
+        assert_eq!(record.attempt, attempt);
+        assert_eq!(on_file, AttemptOnFile::Running);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_open_keeps_a_running_attempt() {
+        let sdk = detached_sdk().await;
+        let federation = detached_federation(&sdk.inner().db);
+        let attempt = UpstreamOperationId([6u8; 32]);
+        crate::db::write_recovery(&sdk.inner().db, &federation.id, &RecoveryRecord { attempt })
+            .await
+            .expect("write the root record");
+        federation
+            .record_recovery_attempt(attempt)
+            .await
+            .expect("record the attempt");
+
+        let prepared = prepare_open(sdk.inner(), &federation)
+            .await
+            .expect("prepare")
+            .expect("an attempt to open under");
+        assert_eq!(prepared, attempt);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn prepare_open_mints_a_new_attempt_after_a_failed_one() {
+        let sdk = detached_sdk().await;
+        let federation = detached_federation(&sdk.inner().db);
+        let old_attempt = UpstreamOperationId([7u8; 32]);
+        crate::db::write_recovery(
+            &sdk.inner().db,
+            &federation.id,
+            &RecoveryRecord {
+                attempt: old_attempt,
+            },
+        )
+        .await
+        .expect("write the root record");
+        plant_operation_record(
+            &federation,
+            old_attempt,
+            Some(
+                wire::encode_state(&RecoveryState::Failed {
+                    reason: "guardian gone".to_owned(),
+                })
+                .expect("encode"),
+            ),
+        )
+        .await;
+
+        let new_attempt = prepare_open(sdk.inner(), &federation)
+            .await
+            .expect("prepare")
+            .expect("a fresh attempt");
+        assert_ne!(new_attempt, old_attempt);
+
+        let root_record = crate::db::read_recovery(&sdk.inner().db, &federation.id)
+            .await
+            .expect("read")
+            .expect("the root record now exists");
+        assert_eq!(root_record.attempt, new_attempt);
+
+        let (_, new_on_file) = attempt_on_file(sdk.inner(), &federation)
+            .await
+            .expect("read")
+            .expect("a root record");
+        assert_eq!(new_on_file, AttemptOnFile::Running);
+
+        // The old attempt's own record is untouched: it still reads failed.
+        let old_record = read_attempt_record(&federation, old_attempt)
+            .await
+            .expect("the old record survives");
+        assert_eq!(
+            wire::decode_state(&old_record.final_state.expect("a final state")).expect("decode"),
+            RecoveryState::Failed {
+                reason: "guardian gone".to_owned(),
+            }
+        );
+    }
+}

--- a/rust/fedimint-sdk/src/recovery/wire.rs
+++ b/rust/fedimint-sdk/src/recovery/wire.rs
@@ -1,0 +1,89 @@
+//! The persisted form of a recovery attempt's state.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, ErrorCode, RecoveryState, Result};
+
+/// [`RecoveryState`] as stored on `OperationRecord::final_state`.
+#[derive(Debug, Serialize, Deserialize)]
+enum RecoveryStateWire {
+    Running,
+    Done,
+    Failed { reason: String },
+}
+
+pub(super) fn encode_state(state: &RecoveryState) -> Result<String> {
+    let wire = match state {
+        RecoveryState::Running => RecoveryStateWire::Running,
+        RecoveryState::Done => RecoveryStateWire::Done,
+        RecoveryState::Failed { reason } => RecoveryStateWire::Failed {
+            reason: reason.clone(),
+        },
+    };
+    serde_json::to_string(&wire).map_err(encode_error)
+}
+
+pub(super) fn decode_state(encoded: &str) -> Result<RecoveryState> {
+    let wire: RecoveryStateWire = serde_json::from_str(encoded).map_err(decode_error)?;
+    Ok(match wire {
+        RecoveryStateWire::Running => RecoveryState::Running,
+        RecoveryStateWire::Done => RecoveryState::Done,
+        RecoveryStateWire::Failed { reason } => RecoveryState::Failed { reason },
+    })
+}
+
+fn encode_error(err: serde_json::Error) -> Error {
+    Error::new(
+        ErrorCode::Internal,
+        format!("could not encode a recovery record: {err}"),
+    )
+}
+
+fn decode_error(err: serde_json::Error) -> Error {
+    Error::new(
+        ErrorCode::Internal,
+        format!("could not decode a recovery record: {err}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_state_round_trips() {
+        for state in [
+            RecoveryState::Running,
+            RecoveryState::Done,
+            RecoveryState::Failed {
+                reason: "gone".to_owned(),
+            },
+        ] {
+            let encoded = encode_state(&state).expect("encode");
+            assert_eq!(decode_state(&encoded).expect("decode"), state);
+        }
+    }
+
+    #[test]
+    fn a_state_this_build_does_not_know_is_refused() {
+        assert_eq!(
+            decode_state(r#"{"Paused":{}}"#).expect_err("refused").code,
+            ErrorCode::Internal
+        );
+    }
+
+    #[test]
+    fn the_wire_is_the_documented_shape() {
+        assert_eq!(
+            encode_state(&RecoveryState::Running).expect("encode"),
+            "\"Running\""
+        );
+        assert_eq!(
+            encode_state(&RecoveryState::Failed {
+                reason: "x".to_owned(),
+            })
+            .expect("encode"),
+            r#"{"Failed":{"reason":"x"}}"#
+        );
+    }
+}

--- a/rust/fedimint-sdk/src/sdk.rs
+++ b/rust/fedimint-sdk/src/sdk.rs
@@ -667,6 +667,20 @@ impl Sdk {
         }
 
         let record = existing.record();
+        // Read from records alone, before `start` invokes the underlying open: a `Failed`
+        // attempt is replaced and a missing operation record is repaired here, so the open
+        // below always runs under a durable, current attempt. Its own failure quarantines
+        // exactly as a failed `start` does.
+        let attempt = match crate::recovery::engine::prepare_open(&self.inner, &existing).await {
+            Ok(attempt) => attempt,
+            Err(err) => {
+                existing.set_status(FederationStatus::Quarantined {
+                    diagnostic: err.clone().into(),
+                });
+                self.inner.announce(&existing);
+                return Err(err);
+            }
+        };
         let (client, revalidated) = match self.inner.start(&upstream, &record).await {
             Ok(started) => started,
             Err(err) => {
@@ -684,7 +698,6 @@ impl Sdk {
         // refreshed the capabilities, network or generation against the client's live
         // configuration, and only flipping `status` here keeps that refresh rather than
         // overwriting it with the stale values `record` still holds.
-        let recovering = client.has_pending_recoveries();
         let mut opened = revalidated;
         opened.status = StoredStatus::Open;
         crate::db::write_federation(&self.inner.db, &upstream, &opened).await?;
@@ -695,6 +708,9 @@ impl Sdk {
         // point at would quietly make them work again. `existing` is already closed — its
         // `closed` watch flipped when it was stopped — and stays that way for as long as anyone
         // holds it.
+        //
+        // Built with a provisional `Running` status: `after_open` below, run once this value
+        // exists for its watcher to hold a clone of, decides the real one.
         let federation = Arc::new(FederationInner::new(
             upstream,
             Arc::downgrade(&self.inner),
@@ -702,14 +718,13 @@ impl Sdk {
                 .db
                 .with_prefix(crate::db::federation_prefix(&upstream).to_vec()),
             opened,
-            if recovering {
-                FederationStatus::Recovering
-            } else {
-                FederationStatus::Running
-            },
-            Some(client),
+            FederationStatus::Running,
+            Some(client.clone()),
         ));
         self.inner.insert(federation.clone());
+        let status =
+            crate::recovery::engine::after_open(&self.inner, &federation, &client, attempt).await;
+        federation.set_status(status);
         crate::federation::reconcile_on_open(&federation).await;
         self.inner.announce(&federation);
         Ok(Federation::new(federation))
@@ -1814,12 +1829,63 @@ impl SdkInner {
         Ok(Arc::new(handle))
     }
 
-    /// Carries out a committed erase: wipe the namespace, then drop the registry row.
+    /// Joins a federation whose intent is already recorded, restoring this seed's wallet in it
+    /// from the federation's own recovery log rather than starting a fresh client.
+    ///
+    /// A copy of [`join_client`](Self::join_client) whose last step recovers instead of joins.
+    /// Used by `Sdk::recover` and by `start`'s `Joining` branch when the interrupted join it is
+    /// redoing was itself a recovery.
+    pub(crate) async fn recover_client(
+        &self,
+        id: &config::FederationId,
+        record: &FederationRecord,
+    ) -> Result<ClientHandleArc> {
+        let mut builder = Client::builder().await;
+        builder.with_module_inits(self.module_inits.clone());
+        let preview = fedimint_core::runtime::timeout(
+            CONTACT_TIMEOUT,
+            builder.preview(self.connectors.clone(), &record.invite),
+        )
+        .await
+        .map_err(|_| {
+            crate::Error::new(
+                crate::ErrorCode::Timeout,
+                "the federation's guardians did not answer in time",
+            )
+        })?
+        .map_err(|err| {
+            crate::Error::new(
+                crate::ErrorCode::FederationUnreachable,
+                format!("no guardian answered: {err}"),
+            )
+        })?;
+        let db = self
+            .db
+            .with_prefix(crate::db::federation_prefix(id).to_vec());
+        // No backups: upstream deprecates every backup method for removal in v0.13 ("Recovery
+        // is now efficient enough that backups are no longer necessary"), and at this pin the
+        // mint modules recover from the federation's own recovery log without a snapshot.
+        let handle = preview
+            .recover(db, self.root_secret.clone(), None)
+            .await
+            .map_err(|err| {
+                crate::Error::new(
+                    crate::ErrorCode::Storage,
+                    format!("the federation could not be recovered: {err}"),
+                )
+            })?;
+        Ok(Arc::new(handle))
+    }
+
+    /// Carries out a committed erase: wipe the namespace, drop the recovery record, then drop
+    /// the registry row.
     ///
     /// In that order, so a failure half way leaves the federation `Forgetting` and owed rather
-    /// than forgotten with state behind it.
+    /// than forgotten with state behind it. The recovery record goes with the namespace it
+    /// names an attempt in, before the row that owns both of them.
     pub(crate) async fn finish_erase(&self, id: &config::FederationId) -> Result<()> {
         crate::db::wipe_federation(&self.db, id).await?;
+        crate::db::remove_recovery(&self.db, id).await?;
         crate::db::remove_federation(&self.db, id).await
     }
 
@@ -1873,25 +1939,24 @@ impl SdkInner {
             None,
         ));
         self.insert(federation.clone());
-        let status = match self.start(id, &record).await {
-            Ok((client, revalidated)) => {
-                // Set before `install`/`announce`, so a refresh `start` made against the client's
-                // live configuration is what `network()`/`capabilities()` and the announced
-                // `FederationInfo` report from here on, not the pre-revalidation snapshot in
-                // `record`.
-                federation.set_record(revalidated);
-                let recovering = client.has_pending_recoveries();
-                federation.install(client).await;
-                if recovering {
-                    FederationStatus::Recovering
-                } else {
-                    FederationStatus::Running
-                }
-            }
-            Err(err) => FederationStatus::Quarantined {
-                diagnostic: err.into(),
-            },
-        };
+        // A recovery record's pre-open repair runs against records alone, before `start` invokes
+        // the underlying open, and its own failure quarantines exactly as a failed `start` does:
+        // both are folded into the one `?`-chain below.
+        let outcome: Result<FederationStatus> = async {
+            let attempt = crate::recovery::engine::prepare_open(self, &federation).await?;
+            let (client, revalidated) = self.start(id, &record).await?;
+            // Set before `install`/`announce`, so a refresh `start` made against the client's
+            // live configuration is what `network()`/`capabilities()` and the announced
+            // `FederationInfo` report from here on, not the pre-revalidation snapshot in
+            // `record`.
+            federation.set_record(revalidated);
+            federation.install(client.clone()).await;
+            Ok(crate::recovery::engine::after_open(self, &federation, &client, attempt).await)
+        }
+        .await;
+        let status = outcome.unwrap_or_else(|err| FederationStatus::Quarantined {
+            diagnostic: err.into(),
+        });
         federation.set_status(status);
         crate::federation::reconcile_on_open(&federation).await;
         self.announce(&federation);
@@ -1906,7 +1971,8 @@ impl SdkInner {
     /// written. No value can exist in that namespace, because the caller never received a handle
     /// to receive with, so the namespace is wiped and the join is redone from the stored invite.
     /// That is deterministic, where trying to tell a half-written client database from a complete
-    /// one is not.
+    /// one is not. A federation that also has a `RecoveryRecord` redoes a *recover* instead of a
+    /// join, from the same invite, keeping the attempt id the record already names.
     ///
     /// The returned record is whatever `revalidate` actually persisted, which is not necessarily
     /// `record` itself: a caller that goes on to write its own status change onto `record` instead
@@ -1918,7 +1984,10 @@ impl SdkInner {
     ) -> Result<(ClientHandleArc, FederationRecord)> {
         let (client, opened) = if record.status == StoredStatus::Joining {
             crate::db::wipe_federation(&self.db, id).await?;
-            let client = self.join_client(id, record).await?;
+            let client = match crate::db::read_recovery(&self.db, id).await? {
+                Some(_) => self.recover_client(id, record).await?,
+                None => self.join_client(id, record).await?,
+            };
             let mut opened = record.clone();
             opened.status = StoredStatus::Open;
             crate::db::write_federation(&self.db, id, &opened).await?;
@@ -2684,6 +2753,38 @@ mod tests {
                 .expect("the instance reopens");
             assert_eq!(reopened.federation_status(&public), None);
             assert!(reopened.stored_federations().is_empty());
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn finish_erase_removes_the_recovery_record() {
+            let sdk = Sdk::builder()
+                .storage(Storage::in_memory())
+                .build()
+                .await
+                .expect("an instance opens");
+            let id = fedimint_core::config::FederationId::dummy();
+            plant_closed_federation(&sdk, id).await;
+            crate::db::write_recovery(
+                &sdk.inner().db,
+                &id,
+                &crate::db::RecoveryRecord {
+                    attempt: fedimint_core::core::OperationId([1u8; 32]),
+                },
+            )
+            .await
+            .expect("the recovery record is written");
+
+            sdk.inner()
+                .finish_erase(&id)
+                .await
+                .expect("the erase finishes");
+
+            assert_eq!(
+                crate::db::read_recovery(&sdk.inner().db, &id)
+                    .await
+                    .expect("read"),
+                None
+            );
         }
 
         #[tokio::test(flavor = "multi_thread")]

--- a/rust/fedimint-sdk/src/sdk.rs
+++ b/rust/fedimint-sdk/src/sdk.rs
@@ -438,9 +438,8 @@ impl Sdk {
     /// any other federation, and its balance and activity are reported and
     /// kept up to date, provisionally, as the wallet is reconstructed. What
     /// it refuses is the work that needs a complete wallet: every send and
-    /// receive, and taking a fresh backup, fail with
-    /// [`Recovering`](crate::ErrorCode::Recovering) until the
-    /// reconstruction completes.
+    /// receive fails with [`Recovering`](crate::ErrorCode::Recovering)
+    /// until the reconstruction completes.
     ///
     /// This is *not* the list to render a wallet screen from. Use
     /// [`Sdk::stored_federations`] for that: it is a superset of this list

--- a/rust/fedimint-sdk/src/sdk.rs
+++ b/rust/fedimint-sdk/src/sdk.rs
@@ -344,14 +344,6 @@ impl Sdk {
     /// persisted or a committed erase for the same id cannot be finished
     /// first.
     pub async fn join(&self, invite: &InviteCode) -> Result<Federation> {
-        // Implementation note (delete once `Sdk::recover` persists a recovery intent):
-        // - `Sdk::recover` persists its intent to recover, and the operation id of the first
-        //   attempt, before asking the client to join, so a failure between those writes can
-        //   leave a recovery intent for a federation that never actually joined. This call
-        //   must discard such a leftover intent in the same transaction that records the plain
-        //   join, unless the client's own durable state corroborates that a recovery was
-        //   committed. This matters because the erase path bypasses the balance guard for
-        //   recovery-locked federations.
         let _lifecycle = self.inner.lifecycle.lock().await;
         self.inner.alive()?;
         let id = invite.inner().federation_id();
@@ -1318,12 +1310,12 @@ impl SdkBuilder {
                 Bip39RootSecretStrategy::<12>::to_root_secret(mnemonic.inner()),
             ),
             location,
+            lifecycle: tokio::sync::Mutex::new(()),
             mnemonic,
             federations: std::sync::RwLock::new(BTreeMap::new()),
             status_tx: tokio::sync::broadcast::Sender::new(STATUS_CAPACITY),
             shutdown_tx: tokio::sync::watch::Sender::new(false),
             lock: std::sync::Mutex::new(lock),
-            lifecycle: tokio::sync::Mutex::new(()),
         });
 
         // Steps 3 and 4: finish committed erases, then reopen everything else. They run
@@ -1630,6 +1622,17 @@ pub(crate) struct SdkInner {
     /// Exactly the string the caller gave `Storage::at` or `Storage::in_browser`, for the error
     /// details that name a location.
     pub(crate) location: String,
+    /// Serializes `join`, `recover`, `resume_recovery`, `close_federation`,
+    /// `reopen_federation`, `forget_federation` and `shutdown` against each other,
+    /// instance-wide, for the whole body of each call.
+    ///
+    /// Without it, two concurrent `join`s of the same invite both pass the `AlreadyJoined` check
+    /// before either has written a row, and both end up writing into one federation namespace;
+    /// two concurrent `reopen_federation`s of the same id both open a client over that same
+    /// namespace. Taken first, before any other lock or the client's own `RwLock`, so a lifecycle
+    /// call never waits on this mutex while holding something a concurrent lifecycle call would
+    /// need.
+    pub(crate) lifecycle: tokio::sync::Mutex<()>,
     /// Held for the instance's lifetime so `export_mnemonic` needs no storage read and keeps
     /// working after shutdown.
     mnemonic: Mnemonic,
@@ -1641,16 +1644,6 @@ pub(crate) struct SdkInner {
     shutdown_tx: tokio::sync::watch::Sender<bool>,
     /// The single-opener claim, released by `shutdown` or by dropping the last handle.
     lock: std::sync::Mutex<Option<StorageLock>>,
-    /// Serializes `join`, `close_federation`, `reopen_federation`, `forget_federation` and
-    /// `shutdown` against each other, instance-wide, for the whole body of each call.
-    ///
-    /// Without it, two concurrent `join`s of the same invite both pass the `AlreadyJoined` check
-    /// before either has written a row, and both end up writing into one federation namespace;
-    /// two concurrent `reopen_federation`s of the same id both open a client over that same
-    /// namespace. Taken first, before any other lock or the client's own `RwLock`, so a lifecycle
-    /// call never waits on this mutex while holding something a concurrent lifecycle call would
-    /// need.
-    lifecycle: tokio::sync::Mutex<()>,
 }
 
 impl core::fmt::Debug for SdkInner {

--- a/rust/fedimint-sdk/src/sdk.rs
+++ b/rust/fedimint-sdk/src/sdk.rs
@@ -1978,7 +1978,21 @@ impl SdkInner {
         let (client, opened) = if record.status == StoredStatus::Joining {
             crate::db::wipe_federation(&self.db, id).await?;
             let client = match crate::db::read_recovery(&self.db, id).await? {
-                Some(_) => self.recover_client(id, record).await?,
+                Some(recovery) => {
+                    let client = self.recover_client(id, record).await?;
+                    // The wipe above took the attempt's operation record with it, if a reopen
+                    // had written one before calling here; it is written again now, into the
+                    // namespace the client has just committed to, so the attempt the root record
+                    // names stays observable and resumable.
+                    crate::federation::record_recovery_attempt_in(
+                        &self
+                            .db
+                            .with_prefix(crate::db::federation_prefix(id).to_vec()),
+                        recovery.attempt,
+                    )
+                    .await?;
+                    client
+                }
                 None => self.join_client(id, record).await?,
             };
             let mut opened = record.clone();

--- a/rust/fedimint-sdk/src/sdk.rs
+++ b/rust/fedimint-sdk/src/sdk.rs
@@ -700,8 +700,14 @@ impl Sdk {
         // `closed` watch flipped when it was stopped — and stays that way for as long as anyone
         // holds it.
         //
-        // Built with a provisional `Running` status: `after_open` below, run once this value
-        // exists for its watcher to hold a clone of, decides the real one.
+        // Built already locked when it has a recovery to resume: facade calls do not take the
+        // lifecycle mutex, so nothing may find this federation `Running` before `after_open`
+        // below, run once this value exists for its watcher to hold, has decided the status.
+        let provisional = if attempt.is_some() {
+            FederationStatus::Recovering
+        } else {
+            FederationStatus::Running
+        };
         let federation = Arc::new(FederationInner::new(
             upstream,
             Arc::downgrade(&self.inner),
@@ -709,13 +715,11 @@ impl Sdk {
                 .db
                 .with_prefix(crate::db::federation_prefix(&upstream).to_vec()),
             opened,
-            FederationStatus::Running,
+            provisional,
             Some(client.clone()),
         ));
         self.inner.insert(federation.clone());
-        let status =
-            crate::recovery::engine::after_open(&self.inner, &federation, &client, attempt).await;
-        federation.set_status(status);
+        crate::recovery::engine::after_open(&self.inner, &federation, client, attempt).await;
         crate::federation::reconcile_on_open(&federation).await;
         self.inner.announce(&federation);
         Ok(Federation::new(federation))
@@ -1934,7 +1938,7 @@ impl SdkInner {
         // A recovery record's pre-open repair runs against records alone, before `start` invokes
         // the underlying open, and its own failure quarantines exactly as a failed `start` does:
         // both are folded into the one `?`-chain below.
-        let outcome: Result<FederationStatus> = async {
+        let outcome: Result<()> = async {
             let attempt = crate::recovery::engine::prepare_open(self, &federation).await?;
             let (client, revalidated) = self.start(id, &record).await?;
             // Set before `install`/`announce`, so a refresh `start` made against the client's
@@ -1943,13 +1947,18 @@ impl SdkInner {
             // `record`.
             federation.set_record(revalidated);
             federation.install(client.clone()).await;
-            Ok(crate::recovery::engine::after_open(self, &federation, &client, attempt).await)
+            // Sets the status, `Recovering` or `Running`, and does so before its watcher can
+            // run: the federation was built closed, and the watcher's close-watch would
+            // otherwise end it at once.
+            crate::recovery::engine::after_open(self, &federation, client, attempt).await;
+            Ok(())
         }
         .await;
-        let status = outcome.unwrap_or_else(|err| FederationStatus::Quarantined {
-            diagnostic: err.into(),
-        });
-        federation.set_status(status);
+        if let Err(err) = outcome {
+            federation.set_status(FederationStatus::Quarantined {
+                diagnostic: err.into(),
+            });
+        }
         crate::federation::reconcile_on_open(&federation).await;
         self.announce(&federation);
     }

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -387,13 +387,19 @@ async fn fund(lightning: &fedimint_sdk::Lightning, msats: u64) -> fedimint_sdk::
         .net_credit
 }
 
-/// Waits until the federation's balance reads `expected`, through the balance stream, and
+/// Waits until the federation's balance reads `expected`, through a fresh balance stream, and
 /// panics with the last figure seen if it has not within a minute.
 ///
 /// A recovered wallet's notes are re-signed by state machines that resume on the client the
 /// recovery's end swaps in, so the balance can land a moment after the recovery reads `Done`.
 async fn balance_settles_at(federation: &fedimint_sdk::Federation, expected: fedimint_sdk::Amount) {
     let mut updates = federation.balance_updates();
+    settles_at(&mut updates, expected).await;
+}
+
+/// Waits on an existing balance stream until it yields `expected`, and panics with the last
+/// figure seen if it has not within a minute.
+async fn settles_at(updates: &mut fedimint_sdk::BalanceUpdates, expected: fedimint_sdk::Amount) {
     let mut last = None;
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
     loop {
@@ -1039,6 +1045,18 @@ async fn recovery_restores_a_wallet_with_history() {
 
     let recovery = sdk_b.recover(&invite).await.expect("the recovery starts");
     assert_eq!(recovery.federation.id(), id);
+    // Subscribed while the rescan is still running, when the timing allows, and kept for the
+    // rest of the test: the recovery's end retires the client this subscription was opened on,
+    // and the subscription has to follow it to the successor rather than end or go quiet.
+    let mut updates = recovery.federation.balance_updates();
+    let provisional = updates
+        .next()
+        .await
+        .expect("a balance is readable during recovery");
+    assert!(
+        provisional <= funded,
+        "a provisional balance never exceeds the funded one"
+    );
     let last = recovery
         .progress
         .await_final()
@@ -1053,7 +1071,7 @@ async fn recovery_restores_a_wallet_with_history() {
         sdk_b.federation_status(&id),
         Some(FederationStatus::Running)
     );
-    balance_settles_at(&recovery.federation, funded).await;
+    settles_at(&mut updates, funded).await;
 
     // Resuming a completed recovery hands back the same attempt rather than starting a new one.
     let resumed = sdk_b
@@ -1114,6 +1132,16 @@ async fn recovery_restores_a_wallet_with_history() {
             LnSendState::Success { .. }
         ));
     }
+    // The subscription opened during recovery is the one that reports the payment.
+    let paid = tokio::time::timeout(std::time::Duration::from_secs(60), updates.next())
+        .await
+        .expect("the balance moves within a minute of the payment")
+        .expect("the balance stream is still live after the recovery");
+    assert!(
+        paid < funded,
+        "the payment lowered the balance: {paid:?} < {funded:?}"
+    );
+    drop(updates);
     let balance_before_restart = recovery.federation.balance().await.expect("balance");
 
     // Restart B: every handle dropped before rebuilding on the same storage, as in

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -387,6 +387,27 @@ async fn fund(lightning: &fedimint_sdk::Lightning, msats: u64) -> fedimint_sdk::
         .net_credit
 }
 
+/// Waits until the federation's balance reads `expected`, through the balance stream, and
+/// panics with the last figure seen if it has not within a minute.
+///
+/// A recovered wallet's notes are re-signed by state machines that resume on the client the
+/// recovery's end swaps in, so the balance can land a moment after the recovery reads `Done`.
+async fn balance_settles_at(federation: &fedimint_sdk::Federation, expected: fedimint_sdk::Amount) {
+    let mut updates = federation.balance_updates();
+    let mut last = None;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let next = tokio::time::timeout(remaining, updates.next()).await;
+        match next {
+            Ok(Ok(balance)) if balance == expected => return,
+            Ok(Ok(balance)) => last = Some(balance),
+            Ok(Err(err)) => panic!("the balance stream failed: {err:?}"),
+            Err(_) => panic!("the balance did not reach {expected:?}; last seen {last:?}"),
+        }
+    }
+}
+
 /// On the lnv2 shape, leaves the LND gateway as the guardian's only lnv2 gateway, once per test
 /// process.
 ///
@@ -1032,10 +1053,7 @@ async fn recovery_restores_a_wallet_with_history() {
         sdk_b.federation_status(&id),
         Some(FederationStatus::Running)
     );
-    assert_eq!(
-        recovery.federation.balance().await.expect("balance"),
-        funded
-    );
+    balance_settles_at(&recovery.federation, funded).await;
 
     // Resuming a completed recovery hands back the same attempt rather than starting a new one.
     let resumed = sdk_b
@@ -1221,10 +1239,7 @@ async fn recovery_locks_the_federation_while_it_runs() {
         sdk_b.federation_status(&id),
         Some(FederationStatus::Running)
     );
-    assert_eq!(
-        recovery.federation.balance().await.expect("balance"),
-        funded
-    );
+    balance_settles_at(&recovery.federation, funded).await;
 
     sdk_b.shutdown().await.expect("the instance shuts down");
 }

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -1071,7 +1071,11 @@ async fn recovery_restores_a_wallet_with_history() {
         sdk_b.federation_status(&id),
         Some(FederationStatus::Running)
     );
-    settles_at(&mut updates, funded).await;
+    // The stream reports changes only, so a provisional reading that was already the funded
+    // figure (a rescan that ended before the subscription) is not waited for a second time.
+    if provisional != funded {
+        settles_at(&mut updates, funded).await;
+    }
 
     // Resuming a completed recovery hands back the same attempt rather than starting a new one.
     let resumed = sdk_b

--- a/rust/fedimint-sdk/tests/integration.rs
+++ b/rust/fedimint-sdk/tests/integration.rs
@@ -954,3 +954,277 @@ async fn activity_lists_what_the_federation_was_used_for() {
 
     reopened.shutdown().await.expect("shuts down");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recovery_restores_a_wallet_with_history() {
+    use fedimint_sdk::{
+        ActivityStatus, FederationStatus, LnSendState, OperationKind, RecoveryState,
+    };
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    pin_lnv2_gateway_to_lnd(&devimint);
+    let invite: fedimint_sdk::InviteCode = devimint
+        .invite
+        .parse()
+        .expect("devimint's invite code parses");
+
+    // Instance A joins plainly and funds the wallet that the recovery below will restore.
+    let storage_a = tempfile::tempdir().expect("a temporary directory");
+    let path_a = storage_a.path().to_str().expect("a utf-8 path");
+    let sdk_a = Sdk::builder()
+        .storage(Storage::at(path_a).expect("a valid path"))
+        .build()
+        .await
+        .expect("an instance opens on a fresh directory");
+    let federation_a = sdk_a.join(&invite).await.expect("the federation joins");
+    let id = federation_a.id();
+    let lightning_a = federation_a
+        .lightning()
+        .expect("devimint runs a lightning module");
+    let funded = fund(&lightning_a, 200_000).await;
+    let mnemonic = sdk_a.export_mnemonic();
+
+    assert_eq!(
+        sdk_a.recovery_status(&id).await.expect("readable"),
+        None,
+        "a plainly joined federation has no recovery"
+    );
+    let err = sdk_a
+        .resume_recovery(&id)
+        .await
+        .expect_err("this federation was joined, not recovered");
+    assert_eq!(err.code, ErrorCode::InvalidInput);
+
+    sdk_a.shutdown().await.expect("the instance shuts down");
+    // Every handle dropped before the second instance builds, as in
+    // `stored_federation_survives_restart`.
+    drop(lightning_a);
+    drop(federation_a);
+    drop(sdk_a);
+
+    // Instance B holds the same seed, in a fresh directory, and recovers the funded federation.
+    let storage_b = tempfile::tempdir().expect("a temporary directory");
+    let path_b = storage_b.path().to_str().expect("a utf-8 path").to_owned();
+    let sdk_b = Sdk::builder()
+        .storage(Storage::at(&path_b).expect("a valid path"))
+        .mnemonic(mnemonic.clone())
+        .build()
+        .await
+        .expect("an instance opens on a fresh directory");
+
+    let recovery = sdk_b.recover(&invite).await.expect("the recovery starts");
+    assert_eq!(recovery.federation.id(), id);
+    let last = recovery
+        .progress
+        .await_final()
+        .await
+        .expect("the recovery finishes");
+    assert_eq!(last, RecoveryState::Done);
+    assert_eq!(
+        sdk_b.recovery_status(&id).await.expect("readable"),
+        Some(RecoveryState::Done)
+    );
+    assert_eq!(
+        sdk_b.federation_status(&id),
+        Some(FederationStatus::Running)
+    );
+    assert_eq!(
+        recovery.federation.balance().await.expect("balance"),
+        funded
+    );
+
+    // Resuming a completed recovery hands back the same attempt rather than starting a new one.
+    let resumed = sdk_b
+        .resume_recovery(&id)
+        .await
+        .expect("a completed recovery is handed back rather than restarted");
+    assert_eq!(resumed.progress.id(), recovery.progress.id());
+    assert_eq!(
+        resumed.progress.state().await.expect("state"),
+        RecoveryState::Done
+    );
+
+    let err = sdk_b
+        .recover(&invite)
+        .await
+        .expect_err("this instance already holds that federation");
+    assert_eq!(err.code, ErrorCode::AlreadyJoined);
+
+    let history = recovery
+        .federation
+        .activity(None, 10)
+        .await
+        .expect("activity reads");
+    let recovery_row = history
+        .items
+        .iter()
+        .find(|item| item.kind == OperationKind::Recovery)
+        .expect("a recovery row is in the history");
+    assert_eq!(recovery_row.status, ActivityStatus::Success);
+    assert!(recovery_row.is_final);
+    assert_eq!(recovery_row.direction, None);
+    assert_eq!(recovery_row.amount, None);
+    assert_eq!(recovery_row.fee, None);
+
+    // A spend works after recovery: this proves the client swap made the mint usable.
+    let lightning_b = recovery
+        .federation
+        .lightning()
+        .expect("devimint runs a lightning module");
+    let invoice: fedimint_sdk::Bolt11Invoice = faucet("POST", "/invoice", "10000")
+        .expect("the faucet issues an invoice")
+        .trim()
+        .parse()
+        .expect("a bolt11 invoice");
+    let quote = lightning_b.quote(&invoice).await.expect("a quote");
+    let send = lightning_b.send(quote).await.expect("the payment starts");
+    if devimint.shape == "v1" {
+        // fedimint/fedimint#8969: the v1 client strips two characters off the preimage the
+        // gateway returns, so the SDK cannot decode the success state. The payment itself goes
+        // through; only its observation fails, as in
+        // `lightning_send_pays_an_invoice_from_outside_the_federation`.
+        let err = send.await_final().await.expect_err("fedimint#8969");
+        assert_eq!(err.code, ErrorCode::Internal);
+        assert!(err.message.contains("preimage"), "{}", err.message);
+    } else {
+        assert!(matches!(
+            send.await_final().await.expect("settles"),
+            LnSendState::Success { .. }
+        ));
+    }
+    let balance_before_restart = recovery.federation.balance().await.expect("balance");
+
+    // Restart B: every handle dropped before rebuilding on the same storage, as in
+    // `lightning_receive_is_paid_by_the_faucet_and_survives_a_restart`.
+    sdk_b.shutdown().await.expect("the instance shuts down");
+    drop(send);
+    drop(lightning_b);
+    drop(resumed);
+    drop(recovery);
+    drop(sdk_b);
+    let reopened = Sdk::builder()
+        .storage(Storage::at(&path_b).expect("a valid path"))
+        .mnemonic(mnemonic)
+        .build()
+        .await
+        .expect("the instance reopens");
+    assert_eq!(
+        reopened.federation_status(&id),
+        Some(FederationStatus::Running)
+    );
+    assert_eq!(
+        reopened.recovery_status(&id).await.expect("readable"),
+        Some(RecoveryState::Done)
+    );
+    let federation = reopened.federation(&id).expect("still there");
+    assert_eq!(
+        federation.balance().await.expect("balance"),
+        balance_before_restart
+    );
+
+    reopened.shutdown().await.expect("the instance shuts down");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn recovery_locks_the_federation_while_it_runs() {
+    use fedimint_sdk::{Amount, FederationStatus, RecoveryState};
+
+    let devimint = devimint!();
+    if devimint.shape == "mixed" {
+        eprintln!("skipping: the mixed shape is covered by its own test");
+        return;
+    }
+    pin_lnv2_gateway_to_lnd(&devimint);
+    let invite: fedimint_sdk::InviteCode = devimint
+        .invite
+        .parse()
+        .expect("devimint's invite code parses");
+
+    // Instance A joins plainly and funds the wallet that the recovery below will restore,
+    // mirroring `recovery_restores_a_wallet_with_history`.
+    let storage_a = tempfile::tempdir().expect("a temporary directory");
+    let path_a = storage_a.path().to_str().expect("a utf-8 path");
+    let sdk_a = Sdk::builder()
+        .storage(Storage::at(path_a).expect("a valid path"))
+        .build()
+        .await
+        .expect("an instance opens on a fresh directory");
+    let federation_a = sdk_a.join(&invite).await.expect("the federation joins");
+    let id = federation_a.id();
+    let lightning_a = federation_a
+        .lightning()
+        .expect("devimint runs a lightning module");
+    let funded = fund(&lightning_a, 200_000).await;
+    let mnemonic = sdk_a.export_mnemonic();
+    sdk_a.shutdown().await.expect("the instance shuts down");
+    drop(lightning_a);
+    drop(federation_a);
+    drop(sdk_a);
+
+    let storage_b = tempfile::tempdir().expect("a temporary directory");
+    let path_b = storage_b.path().to_str().expect("a utf-8 path");
+    let sdk_b = Sdk::builder()
+        .storage(Storage::at(path_b).expect("a valid path"))
+        .mnemonic(mnemonic)
+        .build()
+        .await
+        .expect("an instance opens on a fresh directory");
+
+    let recovery = sdk_b.recover(&invite).await.expect("the recovery starts");
+    assert_eq!(recovery.federation.id(), id);
+
+    // The rescan on devimint takes only seconds and may already be done by the time `recover`
+    // returns, so the lock is asserted only when it can still be observed here; the end-state
+    // checks below run either way, so this test never passes vacuously on the parts it can
+    // check.
+    if sdk_b.federation_status(&id) == Some(FederationStatus::Recovering) {
+        let lightning = recovery
+            .federation
+            .lightning()
+            .expect("devimint runs a lightning module");
+        let err = lightning
+            .receive(Amount::from_msats(1_000), "locked")
+            .await
+            .expect_err("a recovering federation refuses fund-touching calls");
+        assert_eq!(err.code, ErrorCode::Recovering);
+        recovery
+            .federation
+            .balance()
+            .await
+            .expect("reading a balance is not fund-touching");
+        assert!(
+            sdk_b
+                .federations()
+                .iter()
+                .any(|federation| federation.id() == id),
+            "a recovering federation is still listed as open"
+        );
+    } else {
+        eprintln!("skipping the lock assertion: the rescan finished before recover returned");
+    }
+
+    let last = recovery
+        .progress
+        .await_final()
+        .await
+        .expect("the recovery finishes");
+    assert_eq!(last, RecoveryState::Done);
+    assert_eq!(
+        sdk_b.recovery_status(&id).await.expect("readable"),
+        Some(RecoveryState::Done)
+    );
+    assert_eq!(
+        sdk_b.federation_status(&id),
+        Some(FederationStatus::Running)
+    );
+    assert_eq!(
+        recovery.federation.balance().await.expect("balance"),
+        funded
+    );
+
+    sdk_b.shutdown().await.expect("the instance shuts down");
+}


### PR DESCRIPTION
## Description

- ref fedimint-sdk-implementation-plan T12
- `Sdk::recover` joins a federation and restores this seed's wallet in it; `Sdk::resume_recovery` reattaches to the running attempt, starts a fresh one after a stopped one, or hands back the completed one; `Sdk::recovery_status` reads where a recovery stands without touching the federation. A federation joined with `recover` keeps a record of its current attempt for life, which is how a plainly joined federation (`None`) and a recovered one (`Some(Done)`) stay distinguishable
- the lock is the persisted state, not a flag: a federation is `Recovering` while its rescan has not completed, sends and receives are refused with `Recovering`, a stopped attempt keeps the lock, and a reopen after a stopped attempt mints a new attempt before the client is opened, since the client resumes its rescan by itself the moment it is opened
- the underlying client reports a stopped rescan only to a caller blocked in its wait, and never durably, so one task per recovering federation waits on it: on success it swaps a freshly opened client in under the federation's lock (a v1 mint stays out of the client until the next open after its rescan) and flips the status to `Running`; on failure it records `Failed` with the module's reason. The wait also ends when the federation closes, so a close never finds the client shared
- follows upstream on backups: fedimint has deprecated client backups for removal in 0.13, the mint modules recover from the federation's own recovery log without a snapshot, so `recover` passes none, the docs describe recovery as a rescan, and `Federation::backup` is removed before it was ever implemented
- a `Federation::balance` read during a v1 rescan reports zero, the provisional figure the docs promise, since the mint is absent from the client until the swap; the balance stream wakes on the swap

## Testing

- 413 unit tests (29 new): the record, the wire, the driver's subscription including an ending recorded as it opens, the pre-open rule for every attempt state, the public methods' error paths, the swap refusing a closed federation
- devimint 11/11 on both the v1 and v2 shapes: a wallet funded on one instance is recovered from its seed on a fresh one, spends after recovery (proving the swap made the mint usable), lists the recovery in activity, keeps its state across a restart, and refuses a receive while the lock is observable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QEJrgHniYSGG69T2Fcmyj
